### PR TITLE
DropboxSign: fix labels & descriptions

### DIFF
--- a/extensions/dropboxSign/v1/actions/cancelSignatureRequest/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/cancelSignatureRequest/config/fields.ts
@@ -3,7 +3,8 @@ import { type Field, FieldType } from '../../../../../../lib/types'
 export const fields = {
   signatureRequestId: {
     id: 'signatureRequestId',
-    label: 'The id of the incomplete SignatureRequest to cancel.',
+    label: 'Signature request ID',
+    description: 'The id of the incomplete SignatureRequest to cancel.',
     type: FieldType.STRING,
     required: true,
   },

--- a/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/config/fields.ts
@@ -3,50 +3,60 @@ import { type Field, FieldType } from '../../../../../../lib/types'
 export const fields = {
   signerRole: {
     id: 'signerRole',
-    label:
+    label: 'Signer role',
+    description:
       "Must match an existing role in chosen template. It's case-sensitive.",
     type: FieldType.STRING,
     required: true,
   },
   signerName: {
     id: 'signerName',
-    label: 'The name of the signer.',
+    label: 'Signer name',
+    description: 'The name of the signer.',
     type: FieldType.STRING,
     required: true,
   },
   signerEmailAddress: {
     id: 'signerEmailAddress',
-    label: 'The email address of the signer.',
+    label: 'Signer email address',
+    description: 'The email address of the signer.',
     type: FieldType.STRING,
     required: true,
   },
   templateId: {
     id: 'templateId',
-    label: 'Use the template id to create a SignatureRequest from a template.',
+    label: 'Template ID',
+    description:
+      'Use the template id to create a SignatureRequest from a template.',
     type: FieldType.STRING,
     required: true,
   },
   title: {
     id: 'title',
-    label: 'The title you want to assign to the SignatureRequest.',
+    label: 'Title',
+    description: 'The title you want to assign to the SignatureRequest.',
     type: FieldType.STRING,
     required: false,
   },
   subject: {
     id: 'subject',
-    label: 'The subject in the email that will be sent to the signer.',
+    label: 'Subject',
+    description: 'The subject in the email that will be sent to the signer.',
     type: FieldType.STRING,
     required: false,
   },
   message: {
     id: 'message',
-    label: 'The custom message in the email that will be sent to the signer.',
+    label: 'Message',
+    description:
+      'The custom message in the email that will be sent to the signer.',
     type: FieldType.STRING,
     required: false,
   },
   customFields: {
     id: 'customFields',
-    label:
+    label: 'Custom fields',
+    description:
       'An array defining values and options for custom fields. Required when a custom field exists in the template.',
     type: FieldType.JSON,
     required: false,

--- a/extensions/dropboxSign/v1/actions/getSignatureRequest/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/getSignatureRequest/config/fields.ts
@@ -3,7 +3,8 @@ import { type Field, FieldType } from '../../../../../../lib/types'
 export const fields = {
   signatureRequestId: {
     id: 'signatureRequestId',
-    label: 'The id of the incomplete SignatureRequest to cancel.',
+    label: 'Signature request ID',
+    description: 'The id of the incomplete SignatureRequest to cancel.',
     type: FieldType.STRING,
     required: true,
   },

--- a/extensions/dropboxSign/v1/actions/sendRequestReminder/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/sendRequestReminder/config/fields.ts
@@ -3,13 +3,15 @@ import { type Field, FieldType } from '../../../../../../lib/types'
 export const fields = {
   signatureRequestId: {
     id: 'signatureRequestId',
-    label: 'The id of the SignatureRequest to send a reminder for.',
+    label: 'Signature request ID',
+    description: 'The id of the SignatureRequest to send a reminder for.',
     type: FieldType.STRING,
     required: true,
   },
   signerEmailAddress: {
     id: 'signerEmailAddress',
-    label: 'The email address of the signer to send a reminder to.',
+    label: 'Signer email address',
+    description: 'The email address of the signer to send a reminder to.',
     type: FieldType.STRING,
     required: true,
   },

--- a/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/config/fields.ts
@@ -3,57 +3,68 @@ import { type Field, FieldType } from '../../../../../../lib/types'
 export const fields = {
   signerRole: {
     id: 'signerRole',
-    label:
+    label: 'Signer role',
+    description:
       "Must match an existing role in chosen template. It's case-sensitive.",
     type: FieldType.STRING,
     required: true,
   },
   signerName: {
     id: 'signerName',
-    label: 'The name of the signer.',
+    label: 'Signer name',
+    description: 'The name of the signer.',
     type: FieldType.STRING,
     required: true,
   },
   signerEmailAddress: {
     id: 'signerEmailAddress',
-    label: 'The email address of the signer.',
+    label: 'Signer email address',
+    description: 'The email address of the signer.',
     type: FieldType.STRING,
     required: true,
   },
   templateId: {
     id: 'templateId',
-    label: 'Use the template id to create a SignatureRequest from a template.',
+    label: 'Template ID',
+    description:
+      'Use the template id to create a SignatureRequest from a template.',
     type: FieldType.STRING,
     required: true,
   },
   title: {
     id: 'title',
-    label: 'The title you want to assign to the SignatureRequest.',
+    label: 'Title',
+    description: 'The title you want to assign to the SignatureRequest.',
     type: FieldType.STRING,
     required: false,
   },
   subject: {
     id: 'subject',
-    label: 'The subject in the email that will be sent to the signer.',
+    label: 'Subject',
+    description: 'The subject in the email that will be sent to the signer.',
     type: FieldType.STRING,
     required: false,
   },
   message: {
     id: 'message',
-    label: 'The custom message in the email that will be sent to the signer.',
+    label: 'Message',
+    description:
+      'The custom message in the email that will be sent to the signer.',
     type: FieldType.STRING,
     required: false,
   },
   signingRedirectUrl: {
     id: 'signingRedirectUrl',
-    label:
+    label: 'Signer redirect URL',
+    description:
       'The URL you want signer redirected to after they successfully sign.',
     type: FieldType.STRING,
     required: false,
   },
   customFields: {
     id: 'customFields',
-    label:
+    label: 'Custom fields',
+    description:
       'An array defining values and options for custom fields. Required when a custom field exists in the template.',
     type: FieldType.JSON,
     required: false,


### PR DESCRIPTION
In the original MR, I switched up labels & descriptions for action fields so this MR makes sure action fields have proper labels & descriptions.