### PR TITLE
DropboxSign: revert email action fields to regular string action fields

### DIFF
--- a/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/config/fields.ts
@@ -1,4 +1,4 @@
-import { type Field, FieldType, StringType } from '../../../../../../lib/types'
+import { type Field, FieldType } from '../../../../../../lib/types'
 
 export const fields = {
   signerRole: {
@@ -21,7 +21,6 @@ export const fields = {
     label: 'Signer email address',
     description: 'The email address of the signer.',
     type: FieldType.STRING,
-    stringType: StringType.EMAIL,
     required: true,
   },
   templateId: {

--- a/extensions/dropboxSign/v1/actions/sendRequestReminder/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/sendRequestReminder/config/fields.ts
@@ -1,4 +1,4 @@
-import { type Field, FieldType, StringType } from '../../../../../../lib/types'
+import { type Field, FieldType } from '../../../../../../lib/types'
 
 export const fields = {
   signatureRequestId: {
@@ -13,7 +13,6 @@ export const fields = {
     label: 'Signer email address',
     description: 'The email address of the signer to send a reminder to.',
     type: FieldType.STRING,
-    stringType: StringType.EMAIL,
     required: true,
   },
 } satisfies Record<string, Field>

--- a/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/config/fields.ts
+++ b/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/config/fields.ts
@@ -1,4 +1,4 @@
-import { type Field, FieldType, StringType } from '../../../../../../lib/types'
+import { type Field, FieldType } from '../../../../../../lib/types'
 
 export const fields = {
   signerRole: {
@@ -21,7 +21,6 @@ export const fields = {
     label: 'Signer email address',
     description: 'The email address of the signer.',
     type: FieldType.STRING,
-    stringType: StringType.EMAIL,
     required: true,
   },
   templateId: {


### PR DESCRIPTION
**Given that:**
1. The `email` stringType for an action field only renders an input box for Stef to enter an email address manually
2. And that the most common use case will be to send a signature request to an email address stored in a data point (eg: patient email, email collected in a form)
3. And that regular `string` action field still allows Stef to enter an email address manually

I decided to change the email-related action fields to regular `string` action fields instead of `string` with stringType `email`.

## Screenshot 👁️ 

The `email` stringType for an action field only renders an input box for Stef to enter an email address manually and doesn't allow selecting an email data point (because we don't have the concept of an email data point yet).

<img width="405" alt="Screenshot 2023-04-05 at 20 27 47" src="https://user-images.githubusercontent.com/5594064/230171373-59f55ebb-2cc6-44ee-8ca5-de1905e18faf.png">

## The future 🚀 

**We will have to implement something similar to what we needed for phone data points:**
- Introduce an `email` valueType for data points
- Add `email` question component in the form builder
- Make sure everywhere in the system a user can insert an email data point, the input is validated
- ...

**For reference:**
- https://awellhealth.atlassian.net/browse/AST-4885
- https://awellhealth.atlassian.net/wiki/spaces/AWELL/pages/3433005063/Send+SMS+with+Twilio#Add-%E2%80%9Cphone%E2%80%9D-question-type-to-our-form-builder

## Tracking 🛤️ 

Tracking this potential improvement in Awell Horizons.

https://awellhealth.atlassian.net/jira/polaris/projects/AH/ideas/view/548618?selectedIssue=AH-176&issueViewLayout=sidebar&issueViewSection=capture#