### PR TITLE
Extension settings: make settings required that need to be required

### DIFF
--- a/extensions/awell/settings.ts
+++ b/extensions/awell/settings.ts
@@ -5,12 +5,14 @@ export const settings = {
     key: 'apiUrl',
     label: 'API url',
     obfuscated: false,
+    required: true,
     description: 'The environment specific API url.',
   },
   apiKey: {
     key: 'apiKey',
     label: 'API key',
     obfuscated: true,
+    required: true,
     description: 'Your orchestration API key.',
   },
 } satisfies Record<string, Setting>

--- a/extensions/healthie/settings.ts
+++ b/extensions/healthie/settings.ts
@@ -5,12 +5,14 @@ export const settings = {
     key: 'apiUrl',
     label: 'API url',
     obfuscated: false,
+    required: true,
     description: 'The environment specific API url.',
   },
   apiKey: {
     key: 'apiKey',
     label: 'API key',
     obfuscated: true,
+    required: true,
     description: 'Your healthie API key.',
   },
 } satisfies Record<string, Setting>


### PR DESCRIPTION
- Healthie extension: API URL & API key should be required
- Awell extension: API URL & API key should be required

I acknowledge that this is a breaking change but given we are still in `alpha` mode this seems acceptable and also better to do it now than later.