### PR TITLE
Mailchimp: fix icon URL

### DIFF
--- a/extensions/mailchimp/index.ts
+++ b/extensions/mailchimp/index.ts
@@ -6,7 +6,8 @@ import { settings } from './settings'
 export const Mailchimp: Extension = {
   key: 'mailchimp',
   title: 'Mailchimp',
-  icon_url: 'https://assets.stickpng.com/images/62a2148e443b787d5837123e.png',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1681285075/Awell%20Extensions/Mailchimp-Logo.png',
   description:
     'Mailchimp is an all-in-one marketing platform that helps businesses to design, send, and manage email campaigns.',
   category: Category.COMMUNICATION,


### PR DESCRIPTION
The current icon URL didn't work properly so uploaded the icon to our Cloudinary to make sure it's always available.

<img width="922" alt="Screenshot 2023-04-12 at 09 40 08" src="https://user-images.githubusercontent.com/5594064/231386928-7279d75e-da5a-463b-8084-da6f52b62185.png">