### PR TITLE
Cloudinary extension

### DIFF
--- a/extensions/cloudinary/CHANGELOG.md
+++ b/extensions/cloudinary/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Cloudinary changelog

--- a/extensions/cloudinary/README.md
+++ b/extensions/cloudinary/README.md
@@ -1,0 +1,19 @@
+# Cloudinary
+
+Cloudinary is a cloud-based image and video management platform that provides a comprehensive set of tools for storing, managing, and delivering digital media assets. It enables users to upload, manipulate, optimize, and deliver media files to any device or website quickly and easily.
+
+The platform offers features such as image and video transformation, automatic image optimization, and responsive image delivery. Cloudinary also provides tools for organizing media assets, including tags, folders, and metadata.
+
+## Custom Actions
+
+### Upload files
+
+This action allows a given stakeholder to upload one or many files (all file types allowed).
+
+**Prerequisites:**
+
+- You have a Cloudinary account
+- You have created an upload preset that allows for unsigned uploads
+
+**Limitations:**
+Currently, the URL(s) of the uploaded file(s) are not sent back to Awell. In order to make sure you can easily retrieve the files a stakeholder uploaded, all uploaded files will have the following context fields: `patientId`, `activityId`, and `pathwayId`. Additionally, you have the ability to add tags to files as well.

--- a/extensions/cloudinary/actions/index.ts
+++ b/extensions/cloudinary/actions/index.ts
@@ -1,0 +1,1 @@
+export { uploadFiles } from './uploadFiles'

--- a/extensions/cloudinary/actions/uploadFiles/config/fields.ts
+++ b/extensions/cloudinary/actions/uploadFiles/config/fields.ts
@@ -1,0 +1,50 @@
+import { isEmpty, isNil } from 'lodash'
+import { z, type ZodTypeAny } from 'zod'
+import { type Field, FieldType } from '../../../../../lib/types'
+
+export const fields = {
+  uploadPreset: {
+    id: 'uploadPreset',
+    label: 'Upload preset',
+    description:
+      'The name of an upload preset defined for your product environment. If left empty, the preset defined in the extension settings will be used.',
+    type: FieldType.STRING,
+    required: true,
+  },
+  folder: {
+    id: 'folder',
+    label: 'Folder',
+    description:
+      'Upload files to the specified folder. If left empty, the folder defined in the extension settings will be used.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  tags: {
+    id: 'tags',
+    label: 'Tags',
+    description:
+      'A comma-separated string of tags to assign to the uploaded assets.',
+    type: FieldType.STRING,
+    required: false,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  uploadPreset: z.optional(z.string()),
+  folder: z.optional(z.string()),
+  tags: z.optional(
+    z
+      .string()
+      // Make sure all white spaces are stripped
+      .transform((chars) => chars.replace(/\s/g, ''))
+      .transform((chars) => chars.split(','))
+      // Make sure there are no undefined or empty characteristics
+      .transform((charsArray) =>
+        charsArray.filter((chars) => {
+          if (isNil(chars) || isEmpty(chars)) return false
+
+          return true
+        })
+      )
+  ),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/cloudinary/actions/uploadFiles/config/fields.ts
+++ b/extensions/cloudinary/actions/uploadFiles/config/fields.ts
@@ -9,7 +9,7 @@ export const fields = {
     description:
       'The name of an upload preset defined for your product environment. If left empty, the preset defined in the extension settings will be used.',
     type: FieldType.STRING,
-    required: true,
+    required: false,
   },
   folder: {
     id: 'folder',

--- a/extensions/cloudinary/actions/uploadFiles/config/index.ts
+++ b/extensions/cloudinary/actions/uploadFiles/config/index.ts
@@ -1,0 +1,1 @@
+export { fields } from './fields'

--- a/extensions/cloudinary/actions/uploadFiles/index.ts
+++ b/extensions/cloudinary/actions/uploadFiles/index.ts
@@ -1,0 +1,1 @@
+export { uploadFiles } from './uploadFiles'

--- a/extensions/cloudinary/actions/uploadFiles/uploadFiles.test.ts
+++ b/extensions/cloudinary/actions/uploadFiles/uploadFiles.test.ts
@@ -1,0 +1,40 @@
+import { uploadFiles } from './uploadFiles'
+
+describe('Upload files action', () => {
+  const onComplete = jest.fn()
+  const onError = jest.fn()
+
+  beforeEach(() => {
+    onComplete.mockClear()
+    onError.mockClear()
+  })
+
+  test('Should not call the onComplete callback', async () => {
+    await uploadFiles.onActivityCreated(
+      {
+        activity: {
+          id: 'activity-id',
+        },
+        patient: { id: 'test-patient' },
+        fields: {
+          uploadPreset: undefined, // If not defined, it will use preset from the extension settings
+          folder: undefined, // If not defined, it will use folder from the extension settings
+          tags: 'tag-1, tag-2, tag-3',
+        },
+        settings: {
+          cloudName: 'cloud-name',
+          uploadPreset: 'upload-preset',
+          folder: 'variant-label',
+        },
+      },
+      onComplete,
+      jest.fn()
+    )
+
+    /**
+     * Because completion is done in Awell Hosted Pages
+     */
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/extensions/cloudinary/actions/uploadFiles/uploadFiles.ts
+++ b/extensions/cloudinary/actions/uploadFiles/uploadFiles.ts
@@ -1,0 +1,70 @@
+import { type Action } from '../../../../lib/types'
+import { Category } from '../../../../lib/types/marketplace'
+import { SettingsValidationSchema, type settings } from '../../settings'
+import { fields } from './config'
+import { fromZodError } from 'zod-validation-error'
+import { z, ZodError } from 'zod'
+import { validate } from '../../../../lib/shared/validation'
+import { FieldsValidationSchema } from './config/fields'
+
+export const uploadFiles: Action<typeof fields, typeof settings> = {
+  key: 'uploadFiles',
+  title: 'Upload files',
+  description: 'Allow a stakeholder to upload one or multiple files.',
+  category: Category.CONTENT_AND_FILES,
+  fields,
+  // Future improvement: ingest uploaded file URLs as data points into the care flow
+  options: {
+    stakeholders: {
+      label: 'Stakeholder',
+      mode: 'single',
+    },
+  },
+  previewable: false, // We don't have Awell Hosted Pages in Preview so cannot be previewed.
+  onActivityCreated: async (payload, onComplete, onError) => {
+    try {
+      validate({
+        schema: z.object({
+          settings: SettingsValidationSchema,
+          fields: FieldsValidationSchema,
+        }),
+        payload,
+      })
+
+      /**
+       * Completion happens in Awell Hosted Pages
+       */
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const error = fromZodError(err)
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: error.name },
+              error: {
+                category: 'WRONG_INPUT',
+                message: `${error.message}`,
+              },
+            },
+          ],
+        })
+        return
+      }
+
+      const error = err as Error
+      await onError({
+        events: [
+          {
+            date: new Date().toISOString(),
+            text: { en: 'Something went wrong while orchestration the action' },
+            error: {
+              category: 'SERVER_ERROR',
+              message: error.message,
+            },
+          },
+        ],
+      })
+    }
+  },
+}

--- a/extensions/cloudinary/index.ts
+++ b/extensions/cloudinary/index.ts
@@ -1,0 +1,21 @@
+import { type Extension } from '../../lib/types'
+import { AuthorType, Category } from '../../lib/types/marketplace'
+import { uploadFiles } from './actions'
+import { settings } from './settings'
+
+export const Cloudinary: Extension = {
+  key: 'cloudinary',
+  title: 'Cloudinary',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1681407040/Awell%20Extensions/cloudinary_logo.png',
+  description:
+    'Cloudinary is a cloud-based image and video management platform for storing, managing, and delivering digital media assets.',
+  category: Category.CONTENT_AND_FILES,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  actions: {
+    uploadFiles,
+  },
+  settings,
+}

--- a/extensions/cloudinary/settings.ts
+++ b/extensions/cloudinary/settings.ts
@@ -1,0 +1,35 @@
+import { type Setting } from '../../lib/types'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {
+  cloudName: {
+    key: 'cloudName',
+    label: 'Cloud name',
+    description:
+      'Your Cloudinary product environment cloud name. This can be found in the Cloudinary console.',
+    obfuscated: true,
+    required: true,
+  },
+  uploadPreset: {
+    key: 'uploadPreset',
+    label: 'Upload preset',
+    description:
+      'The name of an upload preset defined for your product environment. You can always overwrite the preset on the action level.',
+    obfuscated: false,
+    required: true,
+  },
+  folder: {
+    key: 'folder',
+    label: 'Folder',
+    description:
+      'Upload files to the specified folder. You can always overwrite the folder on the action level.',
+    obfuscated: false,
+    required: false,
+  },
+} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({
+  cloudName: z.string(),
+  uploadPreset: z.string(),
+  folder: z.optional(z.string()),
+} satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -11,10 +11,12 @@ import { Mailgun } from './mailgun'
 import { Formsort } from './formsort'
 // import { AvaAi } from './avaAi'
 import { Mailchimp } from './mailchimp'
+import { Cloudinary } from './cloudinary'
 
 export const extensions = [
   // AvaAi, Best to disable this until we cleared out data privacy & HIPAA with OpenAI
   Awell,
+  Cloudinary,
   HelloWorld,
   Healthie,
   Twilio,


### PR DESCRIPTION
I want to validate the "upload file" use case with a Cloudinary extension. The extension code itself doesn't really do anything besides validating the settings & action fields. Awell Hosted Pages will do the heavy lifting:
- Use the Cloudinary React Upload widget so a stakeholder can upload files from within Awell Hosted Pages
- When the upload is complete, complete the activity and move on

Given I don't have a local setup of the awell back-end, the easiest way forward for me to continue the experiment is to have this already merged so I can connect my local hosted-pages setup to the development environment.