### PR TITLE
AST-5083:Jasmine can access the pathway ID & pathway definition ID in `onActivityCreated` function

### DIFF
--- a/extensions/avaAi/v1/actions/generatePatientSummary/generatePatientSummary.test.ts
+++ b/extensions/avaAi/v1/actions/generatePatientSummary/generatePatientSummary.test.ts
@@ -14,6 +14,10 @@ describe('Generate patient summary with Open AI', () => {
   test('Should call the onComplete callback', async () => {
     await generatePatientSummary.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/awell/v1/actions/deletePatient/deletePatient.test.ts
+++ b/extensions/awell/v1/actions/deletePatient/deletePatient.test.ts
@@ -14,6 +14,10 @@ describe('Update patient', () => {
   test('Should call the onComplete callback', async () => {
     await deletePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/awell/v1/actions/startCareFlow/startCareFlow.test.ts
+++ b/extensions/awell/v1/actions/startCareFlow/startCareFlow.test.ts
@@ -14,6 +14,10 @@ describe('Start care flow', () => {
   test('Should call the onComplete callback', async () => {
     await startCareFlow.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/awell/v1/actions/updatePatient/updatePatient.test.ts
+++ b/extensions/awell/v1/actions/updatePatient/updatePatient.test.ts
@@ -14,6 +14,10 @@ describe('Update patient', () => {
   test('Should call the onComplete callback', async () => {
     await updatePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -49,6 +53,10 @@ describe('Update patient', () => {
   test('Should call onError when email is not an actual email address the onComplete callback', async () => {
     await updatePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -94,6 +102,10 @@ describe('Update patient', () => {
   test('Should call onError when phone is not a possible phone number', async () => {
     await updatePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/calDotCom/actions/__tests__/bookAppointment.ts
+++ b/extensions/calDotCom/actions/__tests__/bookAppointment.ts
@@ -10,6 +10,10 @@ describe('Simple book appointment action', () => {
   test('Should not call the onComplete callback', async () => {
     await bookAppointment.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/calDotCom/actions/__tests__/getBooking.ts
+++ b/extensions/calDotCom/actions/__tests__/getBooking.ts
@@ -11,6 +11,10 @@ describe('Simple getBooking action', () => {
   test('Should call the onComplete callback', async () => {
     await getBooking.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/cloudinary/actions/uploadFiles/uploadFiles.test.ts
+++ b/extensions/cloudinary/actions/uploadFiles/uploadFiles.test.ts
@@ -12,6 +12,10 @@ describe('Upload files action', () => {
   test('Should not call the onComplete callback', async () => {
     await uploadFiles.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/cancelSignatureRequest/cancelSignatureRequest.test.ts
+++ b/extensions/dropboxSign/v1/actions/cancelSignatureRequest/cancelSignatureRequest.test.ts
@@ -33,6 +33,10 @@ describe('Cancel signature request action', () => {
   test('Should call the onComplete callback', async () => {
     await cancelSignatureRequest.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/createEmbeddedSignatureRequestWithTemplate.test.ts
+++ b/extensions/dropboxSign/v1/actions/createEmbeddedSignatureRequestWithTemplate/createEmbeddedSignatureRequestWithTemplate.test.ts
@@ -73,6 +73,10 @@ describe('Create embedded signature request with template', () => {
   test('Should call the onComplete callback', async () => {
     await createEmbeddedSignatureRequestWithTemplate.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/embeddedSigning/embeddedSigning.test.ts
+++ b/extensions/dropboxSign/v1/actions/embeddedSigning/embeddedSigning.test.ts
@@ -10,6 +10,10 @@ describe('Complete flow action', () => {
   test('Should not call the onComplete callback', async () => {
     await embeddedSigning.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/getSignatureRequest/getSignatureRequest.test.ts
+++ b/extensions/dropboxSign/v1/actions/getSignatureRequest/getSignatureRequest.test.ts
@@ -40,6 +40,10 @@ describe('Get signature request action', () => {
   test('Should call the onComplete callback', async () => {
     await getSignatureRequest.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/sendRequestReminder/sendRequestReminder.test.ts
+++ b/extensions/dropboxSign/v1/actions/sendRequestReminder/sendRequestReminder.test.ts
@@ -40,6 +40,10 @@ describe('Send request reminder action', () => {
   test('Should call the onComplete callback', async () => {
     await sendRequestReminder.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/sendSignatureRequestWithTemplate.test.ts
+++ b/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/sendSignatureRequestWithTemplate.test.ts
@@ -43,6 +43,10 @@ describe('Cancel signature request action', () => {
   test('Should call the onComplete callback', async () => {
     await sendSignatureRequestWithTemplate.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/formsort/v1/actions/completeFlow/completeFlow.test.ts
+++ b/extensions/formsort/v1/actions/completeFlow/completeFlow.test.ts
@@ -10,6 +10,10 @@ describe('Complete flow action', () => {
   test('Should not call the onComplete callback', async () => {
     await completeFlow.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/applyTagToPatient.ts
+++ b/extensions/healthie/actions/__tests__/applyTagToPatient.ts
@@ -19,6 +19,10 @@ describe('applyTagToPatient action', () => {
   test("Should apply tag to a patient", async () => {
     await applyTagToPatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/archivePatient.ts
+++ b/extensions/healthie/actions/__tests__/archivePatient.ts
@@ -19,6 +19,10 @@ describe('archivePatient action', () => {
   test("Should archive a patient", async () => {
     await archivePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/cancelAppointment.ts
+++ b/extensions/healthie/actions/__tests__/cancelAppointment.ts
@@ -19,6 +19,10 @@ describe('cancelAppointment action', () => {
   test("Should cancel an appointment", async () => {
     await cancelAppointment.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/closeChatConversation.ts
+++ b/extensions/healthie/actions/__tests__/closeChatConversation.ts
@@ -19,6 +19,10 @@ describe('closeChatConversation action', () => {
   test("Should close a conversation", async () => {
     await closeChatConversation.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/completeTask.ts
+++ b/extensions/healthie/actions/__tests__/completeTask.ts
@@ -19,6 +19,10 @@ describe('completeTask action', () => {
   test("Should complete a task", async () => {
     await completeTask.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/createChartingNote.ts
+++ b/extensions/healthie/actions/__tests__/createChartingNote.ts
@@ -19,6 +19,10 @@ describe('createChartingNote action', () => {
   test("Should create a charting note", async () => {
     await createChartingNote.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/createJournalEntry.ts
+++ b/extensions/healthie/actions/__tests__/createJournalEntry.ts
@@ -20,6 +20,10 @@ describe('createJournalEntry action', () => {
   test('Should create a journal entry', async () => {
     await createJournalEntry.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/createLocation.ts
+++ b/extensions/healthie/actions/__tests__/createLocation.ts
@@ -19,6 +19,10 @@ describe('createLocation action', () => {
   test("Should create a location", async () => {
     await createLocation.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/createPatient.ts
+++ b/extensions/healthie/actions/__tests__/createPatient.ts
@@ -20,6 +20,10 @@ describe('createPatient action', () => {
   test('Should create a new patient', async () => {
     await createPatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/createTask.ts
+++ b/extensions/healthie/actions/__tests__/createTask.ts
@@ -6,6 +6,10 @@ jest.mock('../../gql/sdk')
 jest.mock('../../graphqlClient')
 
 const samplePayload = {
+  pathway: {
+    id: 'pathway-id',
+    definition_id: 'pathway-definition-id',
+  },
   activity: {
     id: 'activity-id',
   },

--- a/extensions/healthie/actions/__tests__/deleteAppointment.ts
+++ b/extensions/healthie/actions/__tests__/deleteAppointment.ts
@@ -19,6 +19,10 @@ describe('deleteAppointment action', () => {
   test("Should delete an appointment", async () => {
     await deleteAppointment.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/deleteTask.ts
+++ b/extensions/healthie/actions/__tests__/deleteTask.ts
@@ -19,6 +19,10 @@ describe('deleteTask action', () => {
   test("Should delete a task", async () => {
     await deleteTask.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/removeTagFromPatient.ts
+++ b/extensions/healthie/actions/__tests__/removeTagFromPatient.ts
@@ -19,6 +19,10 @@ describe('removeTagFromPatient action', () => {
   test("Should remove tag from a patient", async () => {
     await removeTagFromPatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/sendChatMessage.ts
+++ b/extensions/healthie/actions/__tests__/sendChatMessage.ts
@@ -19,6 +19,10 @@ describe('sendChatMessage action', () => {
   test("Should create a new message when it doesn't exist", async () => {
     await sendChatMessage.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -63,6 +67,10 @@ describe('sendChatMessage action', () => {
     })
     await sendChatMessage.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/sendFormCompletionRequest.ts
+++ b/extensions/healthie/actions/__tests__/sendFormCompletionRequest.ts
@@ -19,6 +19,10 @@ describe('sendFormCompletionRequest action', () => {
   test("Should send form completion request", async () => {
     await sendFormCompletionRequest.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/healthie/actions/__tests__/updatePatient.ts
+++ b/extensions/healthie/actions/__tests__/updatePatient.ts
@@ -19,6 +19,10 @@ describe('updatePatient action', () => {
   test("Should update patient", async () => {
     await updatePatient.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/hello-world/actions/__tests__/log.ts
+++ b/extensions/hello-world/actions/__tests__/log.ts
@@ -5,6 +5,10 @@ describe('HelloWorld - log', () => {
     const onComplete = jest.fn()
     await log.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: { id: 'test-activity' },
         patient: { id: 'test-patient' },
         fields: {
@@ -23,6 +27,10 @@ describe('HelloWorld - log', () => {
     const onComplete = jest.fn()
     await log.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: { id: 'test-activity' },
         patient: { id: 'test-patient' },
         fields: {
@@ -41,6 +49,10 @@ describe('HelloWorld - log', () => {
     const onComplete = jest.fn()
     await log.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: { id: 'test-activity' },
         patient: { id: 'test-patient' },
         fields: {

--- a/extensions/mailchimp/v1/actions/sendEmail/sendEmail.test.ts
+++ b/extensions/mailchimp/v1/actions/sendEmail/sendEmail.test.ts
@@ -14,6 +14,10 @@ describe('Send email', () => {
   test('Should call the onComplete callback', async () => {
     await sendEmail.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/mailchimp/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.test.ts
+++ b/extensions/mailchimp/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.test.ts
@@ -14,6 +14,10 @@ describe('Send email with template', () => {
   test('Should call the onComplete callback', async () => {
     await sendEmailWithTemplate.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/mailgun/v1/actions/sendEmail/sendEmail.test.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/sendEmail.test.ts
@@ -14,6 +14,10 @@ describe('Send email', () => {
   test('Should call the onComplete callback', async () => {
     await sendEmail.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -43,6 +47,10 @@ describe('Send email', () => {
   test('Should call the onError callback when there is a validation error', async () => {
     await sendEmail.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.test.ts
+++ b/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.test.ts
@@ -14,6 +14,10 @@ describe('Send email with template', () => {
   test('Should call the onComplete callback', async () => {
     await sendEmailWithTemplate.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/math/v1/actions/calculateDateDifference/calculateDateDifference.test.ts
+++ b/extensions/math/v1/actions/calculateDateDifference/calculateDateDifference.test.ts
@@ -12,6 +12,10 @@ describe('Calculate date difference', () => {
   test('Date difference in seconds', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -38,6 +42,10 @@ describe('Calculate date difference', () => {
   test('Date difference in minutes', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -64,6 +72,10 @@ describe('Calculate date difference', () => {
   test('Date difference in hours', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -90,6 +102,10 @@ describe('Calculate date difference', () => {
   test('Date difference in days', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -116,6 +132,10 @@ describe('Calculate date difference', () => {
   test('Date difference in weeks', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -142,6 +162,10 @@ describe('Calculate date difference', () => {
   test('Date difference in months', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -168,6 +192,10 @@ describe('Calculate date difference', () => {
   test('Date difference in years', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -194,6 +222,10 @@ describe('Calculate date difference', () => {
   test('Date difference in non-supported unit should throw an error', async () => {
     await calculateDateDifference.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/math/v1/actions/generateRandomNumber/generateRandomNumber.test.ts
+++ b/extensions/math/v1/actions/generateRandomNumber/generateRandomNumber.test.ts
@@ -10,6 +10,10 @@ describe('Generate random number', () => {
 
   test('Should call onComplete', async () => {
     const mockOnActivityCreateParams = {
+      pathway: {
+        id: 'pathway-id',
+        definition_id: 'pathway-definition-id',
+      },
       activity: { id: 'test-activity' },
       patient: { id: 'test-patient' },
       fields: {
@@ -29,6 +33,10 @@ describe('Generate random number', () => {
   })
   test('Should call onError if fields.min is undefined', async () => {
     const mockOnActivityCreateParams = {
+      pathway: {
+        id: 'pathway-id',
+        definition_id: 'pathway-definition-id',
+      },
       activity: { id: 'test-activity' },
       patient: { id: 'test-patient' },
       fields: {
@@ -48,6 +56,10 @@ describe('Generate random number', () => {
   })
   test('Should call onError if fields.max is undefined', async () => {
     const mockOnActivityCreateParams = {
+      pathway: {
+        id: 'pathway-id',
+        definition_id: 'pathway-definition-id',
+      },
       activity: { id: 'test-activity' },
       patient: { id: 'test-patient' },
       fields: {
@@ -67,6 +79,10 @@ describe('Generate random number', () => {
   })
   test('Check for difference between min and max', async () => {
     const mockOnActivityCreateParams = {
+      pathway: {
+        id: 'pathway-id',
+        definition_id: 'pathway-definition-id',
+      },
       activity: { id: 'test-activity' },
       patient: { id: 'test-patient' },
       fields: {

--- a/extensions/messagebird/v1/actions/sendSms/sendSms.test.ts
+++ b/extensions/messagebird/v1/actions/sendSms/sendSms.test.ts
@@ -14,6 +14,10 @@ describe('Send SMS', () => {
   test('Should call the onComplete callback', async () => {
     await sendSms.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/messagebird/v1/actions/sendVoiceMessage/sendVoiceMessage.test.ts
+++ b/extensions/messagebird/v1/actions/sendVoiceMessage/sendVoiceMessage.test.ts
@@ -14,6 +14,10 @@ describe('Send voice message', () => {
   test('Should call the onComplete callback', async () => {
     await sendVoiceMessage.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/messagebird/v1/actions/sendWhatsAppMessage/sendWhatsAppMessage.test.ts
+++ b/extensions/messagebird/v1/actions/sendWhatsAppMessage/sendWhatsAppMessage.test.ts
@@ -14,6 +14,10 @@ describe('Send WhatsApp message', () => {
   test('Should call the onComplete callback', async () => {
     await sendWhatsAppMessage.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/twilio/v1/actions/__tests__/smsNotification.ts
+++ b/extensions/twilio/v1/actions/__tests__/smsNotification.ts
@@ -12,6 +12,10 @@ describe('Simple sms notification action', () => {
   test('Should call the onComplete callback', async () => {
     await smsNotification.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -36,6 +40,10 @@ describe('Simple sms notification action', () => {
   test('Should call the onError callback', async () => {
     await smsNotification.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/extensions/twilio/v2/actions/sendSms/sendSms.test.ts
+++ b/extensions/twilio/v2/actions/sendSms/sendSms.test.ts
@@ -12,6 +12,10 @@ describe('Send SMS action', () => {
   test('Should call the onComplete callback', async () => {
     await sendSms.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -36,6 +40,10 @@ describe('Send SMS action', () => {
   test('Should call the onError callback when there is no recipient', async () => {
     await sendSms.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },
@@ -60,6 +68,10 @@ describe('Send SMS action', () => {
   test('Should call the onError callback when there is no message', async () => {
     await sendSms.onActivityCreated(
       {
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+        },
         activity: {
           id: 'activity-id',
         },

--- a/lib/types/NewActivityPayload.ts
+++ b/lib/types/NewActivityPayload.ts
@@ -2,6 +2,7 @@ import { type Patient } from './Patient'
 import type { FieldType } from './Field'
 import type { Fields as FieldsType } from './Fields'
 import { type Settings as SettingsType } from './Settings'
+import { type Pathway } from './Pathway'
 
 type TypeValueMap =
   | {
@@ -51,6 +52,7 @@ export interface NewActivityPayload<
     id: string
   }
   patient: Patient
+  pathway: Pathway
   fields: FieldValues<Fields>
   settings: Record<keyof Settings, string | undefined>
 }

--- a/lib/types/Pathway.ts
+++ b/lib/types/Pathway.ts
@@ -1,0 +1,4 @@
+export interface Pathway {
+    id: string
+    definition_id: string
+}


### PR DESCRIPTION
Unlocks additional use cases, especially for our own Awell Extension to create eg “Stop pathway” action.

```ts
export interface NewActivityPayload<
  SettingsKeys extends string | number | symbol = never,
  FieldsKeys extends string | number | symbol = never
> {
  activity: {
    id: string
  }
  pathway: {
    id: string // NEW!
    definition_id: string // NEW!
  },
  patient: {
    // ...
  }
  fields: Record<FieldsKeys, string | undefined>
  settings: Record<SettingsKeys, string | undefined>
}
```
