### PR TITLE
Healthie: send chat message in name of specified provider

### DIFF
--- a/extensions/healthie/actions/sendChatMessage.ts
+++ b/extensions/healthie/actions/sendChatMessage.ts
@@ -96,6 +96,11 @@ export const sendChatMessage: Action<
             input: {
               conversation_id: conversationId,
               content: message,
+              /**
+               * Send the message in name of the specified provider.
+               * If empty or blank, it defaults to the authenticated user.
+               */
+              user_id: provider_id,
             },
           })
         }


### PR DESCRIPTION
Allows sending a chat message into a conversation in the name of the specified provider (id).