### PR TITLE
AST:5171: date related data points should be of value type `date` instead of `string`

### DIFF
--- a/extensions/calDotCom/CHANGELOG.md
+++ b/extensions/calDotCom/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Cal.com changelog
+
+## April 27, 2023
+
+- Get booking action: `startTime` and `endTime` data points are now of value type `date` instead of `string`.

--- a/extensions/calDotCom/actions/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking.ts
@@ -32,11 +32,11 @@ const dataPoints = {
   },
   startTime: {
     key: 'startTime',
-    valueType: 'string',
+    valueType: 'date',
   },
   endTime: {
     key: 'endTime',
-    valueType: 'string',
+    valueType: 'date',
   },
   status: {
     key: 'status',


### PR DESCRIPTION
The Cal.com API returns `startTime` and `endTime` as ISO8601 strings.

<img width="666" alt="Screenshot 2023-04-27 at 22 37 44" src="https://user-images.githubusercontent.com/5594064/234985137-98e27445-3517-485f-a366-61d3aaeb3913.png">