### PR TITLE
Healthie reminderIntervalValueOnce

### DIFF
--- a/extensions/healthie/actions/__tests__/createTask.ts
+++ b/extensions/healthie/actions/__tests__/createTask.ts
@@ -22,6 +22,7 @@ const samplePayload = {
     isReminderEnabled: false,
     reminderIntervalType: undefined,
     reminderIntervalValue: undefined,
+    reminderIntervalValueOnce: undefined,
     reminderTime: undefined,
   },
   settings: {
@@ -217,7 +218,7 @@ describe('createTask action', () => {
       })
     })
 
-    describe('Reminder = once', () => {
+    describe('Reminder = once (legacy - reminderIntervalValue)', () => {
       test('Should call onComplete when reminderIntervalValue is correct date', async () => {
         await createTask.onActivityCreated(
           {
@@ -255,6 +256,55 @@ describe('createTask action', () => {
               reminderIntervalType: 'once',
               isReminderEnabled: true,
               reminderIntervalValue: '',
+              reminderTime: 1,
+            },
+          },
+          onComplete,
+          onError
+        )
+
+        expect(onError).toHaveBeenCalled()
+      })
+    })
+
+    describe('Reminder = once (reminderIntervalValueOnce)', () => {
+      test('Should call onComplete when reminderIntervalValueOnce is correct date', async () => {
+        await createTask.onActivityCreated(
+          {
+            ...samplePayload,
+            fields: {
+              ...samplePayload.fields,
+              reminderIntervalType: 'once',
+              reminderTime: 1,
+              isReminderEnabled: true,
+              reminderIntervalValueOnce: '2023-04-13',
+            },
+          },
+          onComplete,
+          onError
+        )
+
+        expect(onComplete).toHaveBeenCalled()
+        expect(mockGetSdkReturn.createTask).toHaveBeenCalledWith({
+          ...sampleTask,
+          reminder: {
+            is_enabled: true,
+            interval_type: 'once',
+            interval_value: '2023-04-13',
+            reminder_time: 1,
+          },
+        })
+      })
+
+      test('Should call onError when reminderIntervalValueOnce is incorrect date', async () => {
+        await createTask.onActivityCreated(
+          {
+            ...samplePayload,
+            fields: {
+              ...samplePayload.fields,
+              reminderIntervalType: 'once',
+              isReminderEnabled: true,
+              reminderIntervalValueOnce: '',
               reminderTime: 1,
             },
           },

--- a/extensions/healthie/actions/createTask.ts
+++ b/extensions/healthie/actions/createTask.ts
@@ -50,15 +50,24 @@ const fields = {
     id: 'reminderIntervalType',
     label: 'Reminder interval type',
     description:
-      'At what interval would you like to send reminders? The options are "daily", "weekly", "once"',
+      'At what interval would you like to send reminders? The options are "daily", "weekly", "once".',
     type: FieldType.STRING,
   },
   reminderIntervalValue: {
     id: 'reminderIntervalValue',
-    label: 'Reminder interval value',
+    label: 'Reminder interval value (weekly)',
     description:
-      'When interval type is set to "daily", leave this field blank. For "weekly" interval, send in comma separated all lower-case days of the week (e.g wednesday, friday). For "once", send in the date in ISO8601 format (e.g 2020-11-28).',
+      'When interval type is set to "daily" or "once", leave this field blank. For "weekly" interval, send in comma separated all lower-case days of the week (e.g wednesday, friday).',
     type: FieldType.STRING,
+    required: false,
+  },
+  reminderIntervalValueOnce: {
+    id: 'reminderIntervalValueOnce',
+    label: 'Reminder interval value (once)',
+    description:
+      'When the interval type is set to "daily" or "weekly", leave this field blank. For "once" interval, set or select a date.',
+    type: FieldType.DATE,
+    required: false,
   },
   reminderTime: {
     id: 'reminderTime',

--- a/extensions/healthie/validation/createTask.zod.ts
+++ b/extensions/healthie/validation/createTask.zod.ts
@@ -83,6 +83,7 @@ const reminderSchema = z
     }),
   ])
   .superRefine((value, context) => {
+    // if type is `once` and both values are not set
     if (
       value.reminderIntervalType === intervalTypeEnum.enum.once &&
       isNil(value.reminderIntervalValue) &&

--- a/extensions/healthie/validation/createTask.zod.ts
+++ b/extensions/healthie/validation/createTask.zod.ts
@@ -22,17 +22,19 @@ const reminderSchema = z
     z.object({
       reminderIntervalType: z.literal(undefined),
       reminderIntervalValue: z.literal(undefined),
+      reminderIntervalValueOnce: z.literal(undefined),
       isReminderEnabled: z.union([z.literal(false), z.literal(undefined)]),
       reminderTime: z.literal(undefined),
     }),
     /**
      * If `isReminderEnabled` is true,
      * and `reminderIntervalType` is 'daily'
-     * then `reminderIntervalValue` is obsolete
+     * then `reminderIntervalValue` and `reminderIntervalValueOnce` is obsolete
      */
     z.object({
       reminderIntervalType: z.literal(intervalTypeEnum.enum.daily),
       reminderIntervalValue: z.literal(undefined),
+      reminderIntervalValueOnce: z.literal(undefined),
       isReminderEnabled: z.literal(true),
       reminderTime: z.coerce.number(),
     }),
@@ -40,6 +42,7 @@ const reminderSchema = z
      * If `isReminderEnabled` is true,
      * and `reminderIntervalType` is 'weekly'
      * then `reminderIntervalValue` should be a comma-separated string of days of the week
+     * and `reminderIntervalValueOnce` is obsolete
      */
     z.object({
       reminderIntervalType: z.literal(intervalTypeEnum.enum.weekly),
@@ -60,26 +63,45 @@ const reminderSchema = z
             )}`,
           }
         ),
+      reminderIntervalValueOnce: z.literal(undefined),
       isReminderEnabled: z.literal(true),
       reminderTime: z.coerce.number(),
     }),
     /**
      * If `isReminderEnabled` is true,
      * and `reminderIntervalType` is 'once'
-     * then `reminderIntervalValue` should be an ISO8601 date
+     * then `reminderIntervalValueOnce` should be an ISO8601 date
+     * and `reminderIntervalValue` is obsolete (left for compatibility purposes)
      */
     z.object({
       reminderIntervalType: z.literal(intervalTypeEnum.enum.once),
-      reminderIntervalValue: DateOnlySchema,
+      // ! preserve for compatibility reasons (use as a fallback)
+      reminderIntervalValue: DateOnlySchema.optional(),
+      reminderIntervalValueOnce: DateOnlySchema.optional(),
       isReminderEnabled: z.literal(true),
       reminderTime: z.coerce.number(),
     }),
   ])
+  .superRefine((value, context) => {
+    if (
+      value.reminderIntervalType === intervalTypeEnum.enum.once &&
+      isNil(value.reminderIntervalValue) &&
+      isNil(value.reminderIntervalValueOnce)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.invalid_date,
+        fatal: true,
+        path: ['reminderIntervalValueOnce'],
+        message: 'Value is not a valid ISO8601 date',
+      })
+    }
+  })
   .transform(
     ({
       isReminderEnabled,
       reminderIntervalType,
       reminderIntervalValue,
+      reminderIntervalValueOnce,
       reminderTime,
     }) => ({
       reminder:
@@ -88,7 +110,9 @@ const reminderSchema = z
           : {
               is_enabled: true,
               interval_type: reminderIntervalType,
-              interval_value: reminderIntervalValue,
+              interval_value:
+                // ! `reminderIntervalValue` left for compatibility
+                reminderIntervalValueOnce ?? reminderIntervalValue,
               reminder_time: reminderTime,
             },
     })


### PR DESCRIPTION
Closes #161 

Add `reminderIntervalValueOnce` date field for `once` type. `reminderIntervalValue` is still working for compatibility reasons.