### PR TITLE
Twilio: Send message using a Messaging Service SID

### DIFF
--- a/extensions/twilio/CHANGELOG.md
+++ b/extensions/twilio/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Twilio changelog
 
+## v2 2023-06-23
+
+Full description: https://github.com/awell-health/awell-extensions/issues/157
+
+1. "Send SMS" action
+   1. Change label from "Send SMS" to "Send SMS (with from number)"
+   2. Throw error when "From" number in both settings and in fields is not provided
+2. Add new action "Send SMS (with Messaging Service)"
+
 ## v2
 
 Compared to v1 (pre-beta release), the extension only has one custom action "Send SMS" instead of two. The Custom Action allows for:

--- a/extensions/twilio/index.ts
+++ b/extensions/twilio/index.ts
@@ -1,6 +1,6 @@
 import { type Extension } from '@awell-health/extensions-core'
 import { AuthorType, Category } from '@awell-health/extensions-core'
-import { sendSms } from './v2/actions'
+import { sendSms, sendSmsWithMessagingService } from './v2/actions'
 import { settings } from './settings'
 
 export const Twilio: Extension = {
@@ -14,6 +14,7 @@ export const Twilio: Extension = {
   },
   actions: {
     sendSms,
+    sendSmsWithMessagingService,
   },
   settings,
 }

--- a/extensions/twilio/settings.ts
+++ b/extensions/twilio/settings.ts
@@ -1,6 +1,8 @@
-import { type Setting } from '@awell-health/extensions-core'
+import {
+  E164PhoneValidationOptionalSchema,
+  type Setting,
+} from '@awell-health/extensions-core'
 import { z, type ZodTypeAny } from 'zod'
-import { E164PhoneValidationSchema } from '@awell-health/extensions-core'
 
 export const settings = {
   accountSid: {
@@ -38,6 +40,6 @@ export const settings = {
 export const SettingsValidationSchema = z.object({
   accountSid: z.string().min(1, { message: 'Missing Twilio account SID' }),
   authToken: z.string().min(1, { message: 'Missing Twilio auth token' }),
-  fromNumber: E164PhoneValidationSchema.optional(),
+  fromNumber: E164PhoneValidationOptionalSchema,
   messagingServiceSid: z.string().optional(),
 } satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/twilio/settings.ts
+++ b/extensions/twilio/settings.ts
@@ -21,14 +21,23 @@ export const settings = {
     label: '"From" number',
     key: 'fromNumber',
     obfuscated: false,
-    required: true,
+    required: false,
     description:
-      '"From" specifies the Twilio phone number, short code, or messaging service that will send the text messages. This must be a Twilio phone number that you own.',
+      'A Twilio phone number that you own in E.164 format which will be used to send text messages. If you are using a Messaging Service you can leave this field empty.',
+  },
+  messagingServiceSid: {
+    label: 'Messaging Service SID',
+    key: 'messagingServiceSid',
+    obfuscated: false,
+    required: false,
+    description:
+      'The SID of the Messaging Service you want to associate with the Message. If you are not using a Messaging Service but a "from" number, then you can leave this field empty.',
   },
 } satisfies Record<string, Setting>
 
 export const SettingsValidationSchema = z.object({
   accountSid: z.string().min(1, { message: 'Missing Twilio account SID' }),
   authToken: z.string().min(1, { message: 'Missing Twilio auth token' }),
-  fromNumber: E164PhoneValidationSchema,
+  fromNumber: E164PhoneValidationSchema.optional(),
+  messagingServiceSid: z.string().optional(),
 } satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/twilio/v2/actions/index.ts
+++ b/extensions/twilio/v2/actions/index.ts
@@ -1,1 +1,2 @@
 export { sendSms } from './sendSms'
+export { sendSmsWithMessagingService } from './sendSmsWithMessagingSid'

--- a/extensions/twilio/v2/actions/sendSmsWithMessagingSid/config/fields.ts
+++ b/extensions/twilio/v2/actions/sendSmsWithMessagingSid/config/fields.ts
@@ -1,0 +1,40 @@
+import { z, type ZodTypeAny } from 'zod'
+import { E164PhoneValidationSchema } from '@awell-health/extensions-core'
+import {
+  type Field,
+  FieldType,
+  StringType,
+} from '@awell-health/extensions-core'
+import { MessageValidationSchema } from '../../../../common/validation'
+
+export const fields = {
+  messagingServiceSid: {
+    label: 'Messaging Service SID',
+    id: 'messagingServiceSid',
+    type: FieldType.STRING,
+    required: false,
+    description:
+      'The SID of the Messaging Service you want to associate with the Message. If left blank, the SID specified in the settings will be used.',
+  },
+  recipient: {
+    id: 'recipient',
+    label: '"To" phone number',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    description: 'The phone number you would like to send the text message to.',
+    required: true,
+  },
+  message: {
+    id: 'message',
+    label: 'Message',
+    description: 'The message you would like to send.',
+    type: FieldType.TEXT,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  recipient: E164PhoneValidationSchema,
+  messagingServiceSid: z.string().optional(),
+  message: MessageValidationSchema,
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/twilio/v2/actions/sendSmsWithMessagingSid/config/index.ts
+++ b/extensions/twilio/v2/actions/sendSmsWithMessagingSid/config/index.ts
@@ -1,0 +1,1 @@
+export { FieldsValidationSchema, fields } from './fields'

--- a/extensions/twilio/v2/actions/sendSmsWithMessagingSid/index.ts
+++ b/extensions/twilio/v2/actions/sendSmsWithMessagingSid/index.ts
@@ -1,0 +1,1 @@
+export { sendSmsWithMessagingService } from './sendSmsWithMessagingService'

--- a/extensions/twilio/v2/actions/sendSmsWithMessagingSid/sendSmsWithMessagingService.ts
+++ b/extensions/twilio/v2/actions/sendSmsWithMessagingSid/sendSmsWithMessagingService.ts
@@ -1,0 +1,98 @@
+import { z, ZodError } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+import twilioSdk from '../../../common/sdk/twilio'
+import { type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../../settings'
+import { Category, validate } from '@awell-health/extensions-core'
+import { SettingsValidationSchema } from '../../../settings'
+import { FieldsValidationSchema, fields } from './config'
+import { isNil } from 'lodash'
+
+export const sendSmsWithMessagingService: Action<
+  typeof fields,
+  typeof settings
+> = {
+  key: 'sendSmsWithMessagingService',
+  title: 'Send SMS (with Messaging Service)',
+  description:
+    'Send a text message from a Messaging Service to a recipient of your choice.',
+  category: Category.COMMUNICATION,
+  fields,
+  previewable: false,
+  onActivityCreated: async (payload, onComplete, onError) => {
+    try {
+      const {
+        settings: {
+          accountSid,
+          authToken,
+          messagingServiceSid: defaultMessagingServiceSid,
+        },
+        fields: { recipient, message, messagingServiceSid },
+      } = validate({
+        schema: z
+          .object({
+            settings: SettingsValidationSchema,
+            fields: FieldsValidationSchema,
+          })
+          .superRefine((value, ctx) => {
+            // if both `from` values missing - throw error
+            if (
+              isNil(value.settings.messagingServiceSid) &&
+              isNil(value.fields.messagingServiceSid)
+            ) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                fatal: true,
+                message:
+                  '"Messaging Service SID" is missing in both settings and fields',
+              })
+            }
+          }),
+        payload,
+      })
+
+      const client = twilioSdk(accountSid, authToken, {
+        region: 'IE1',
+        accountSid,
+      })
+
+      await client.messages.create({
+        body: message,
+        messagingServiceSid: messagingServiceSid ?? defaultMessagingServiceSid,
+        to: recipient,
+      })
+
+      await onComplete()
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const error = fromZodError(err)
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: error.message },
+              error: {
+                category: 'BAD_REQUEST',
+                message: error.message,
+              },
+            },
+          ],
+        })
+      } else {
+        const message = (err as Error).message
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: message },
+              error: {
+                category: 'SERVER_ERROR',
+                message,
+              },
+            },
+          ],
+        })
+      }
+    }
+  },
+}


### PR DESCRIPTION
Closes #157 

- Add new action "Send SMS (with Messaging Service)".
- Small changes to current "Send SMS"
  - rename to "Send SMS (with from number)"
  - throw error if `from` number not provided in both settings and fields