### PR TITLE
added test so field id value matches the field's key

### DIFF
--- a/src/__tests__/extensions.test.ts
+++ b/src/__tests__/extensions.test.ts
@@ -1,6 +1,10 @@
+import type { Action, Fields, Settings } from '@awell-health/extensions-core'
 import { isEmpty } from 'lodash'
 import { extensions } from '../../extensions'
-import { getExtensionDocumentation, getExtensionChangelog } from '../documentation'
+import {
+  getExtensionDocumentation,
+  getExtensionChangelog,
+} from '../documentation'
 
 describe('Extensions', () => {
   describe('All extensions should have documentation (i.e. a README file in their root dir)', () => {
@@ -15,5 +19,25 @@ describe('Extensions', () => {
       const documentation = getExtensionChangelog(ext.key)
       expect(isEmpty(documentation)).toBe(false)
     })
+  })
+  describe('all extension actions have fields labeled correctly', () => {
+    extensions.forEach(
+      // "Check $key extension's actions use fields whose id match the key",
+      (ext) => {
+        Object.entries(ext.actions).forEach(
+          ([actionKey, action]: [string, Action<Fields, Settings>]) => {
+            if (Object.values(action.fields).length === 0) {
+              return
+            }
+            test.each(Object.entries(action.fields))(
+              `Checking fields in  ${ext.key}.${actionKey}, field id $id does not match`,
+              (fieldKey, field) => {
+                expect(field.id).toBe(fieldKey)
+              }
+            )
+          }
+        )
+      }
+    )
   })
 })


### PR DESCRIPTION
There have been a few cases of this issue:
```ts
const fields = { apiKey: { id: 'api_key' } }
```

While a key of `apiKey` and an id value of `api_key` doesn't throw a type error (i found it difficult to solve using TS's type system without additional boilerplate), the difference between the field key and the field's `{ id }` value causes an error in our system and the field disappears.

I've included a set of tests to make sure the id value matches the key.

The good news: No errors caught.