### PR TITLE
Signed data point (DocuSign, Dropbox Sign)

### DIFF
--- a/extensions/docuSign/actions/embeddedSigning/config/dataPoints.ts
+++ b/extensions/docuSign/actions/embeddedSigning/config/dataPoints.ts
@@ -1,0 +1,8 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  signed: {
+    key: 'signed',
+    valueType: 'boolean',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/docuSign/actions/embeddedSigning/config/index.ts
+++ b/extensions/docuSign/actions/embeddedSigning/config/index.ts
@@ -1,1 +1,2 @@
 export { fields } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/docuSign/actions/embeddedSigning/embeddedSigning.ts
+++ b/extensions/docuSign/actions/embeddedSigning/embeddedSigning.ts
@@ -1,5 +1,5 @@
 import { type Action } from '@awell-health/extensions-core'
-import { fields } from './config'
+import { dataPoints, fields } from './config'
 import { Category } from '@awell-health/extensions-core'
 import { type settings } from '../../settings'
 import { validateActionFields } from './config/fields'
@@ -13,6 +13,7 @@ export const embeddedSigning: Action<typeof fields, typeof settings> = {
     'Let a stakeholder sign an embedded signature request with Awell Hosted Pages.',
   category: Category.DOCUMENT_MANAGEMENT,
   fields,
+  dataPoints,
   options: {
     stakeholders: {
       label: 'Stakeholder',

--- a/extensions/dropboxSign/v1/actions/embeddedSigning/config/dataPoints.ts
+++ b/extensions/dropboxSign/v1/actions/embeddedSigning/config/dataPoints.ts
@@ -1,0 +1,8 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  signed: {
+    key: 'signed',
+    valueType: 'boolean',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/dropboxSign/v1/actions/embeddedSigning/config/index.ts
+++ b/extensions/dropboxSign/v1/actions/embeddedSigning/config/index.ts
@@ -1,1 +1,2 @@
 export { fields } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/dropboxSign/v1/actions/embeddedSigning/embeddedSigning.ts
+++ b/extensions/dropboxSign/v1/actions/embeddedSigning/embeddedSigning.ts
@@ -1,5 +1,5 @@
 import { type Action } from '@awell-health/extensions-core'
-import { fields } from './config'
+import { dataPoints, fields } from './config'
 import { Category } from '@awell-health/extensions-core'
 import { type settings } from '../../../settings'
 import { validateActionFields } from './config/fields'
@@ -13,6 +13,7 @@ export const embeddedSigning: Action<typeof fields, typeof settings> = {
     'Let a stakeholder sign an embedded signature request with Awell Hosted Pages.',
   category: Category.DOCUMENT_MANAGEMENT,
   fields,
+  dataPoints,
   options: {
     stakeholders: {
       label: 'Stakeholder',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/awell-extensions",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "packageManager": "yarn@3.4.1",
   "main": "dist/src/index.js",
   "repository": {


### PR DESCRIPTION
Adds `signed` data point to both DocuSign and Dropbox Sign as requested [in here](https://github.com/awell-health/hosted-pages/pull/142#discussion_r1276096792)