### PR TITLE
Healthie: "Create appointment" action should use date action field for appointment date

### DIFF
--- a/extensions/healthie/actions/createAppointment.ts
+++ b/extensions/healthie/actions/createAppointment.ts
@@ -43,7 +43,7 @@ const fields = {
     id: 'datetime',
     label: 'Appointment date and time',
     description: 'The date and time of the appointment in ISO8601 format.',
-    type: FieldType.STRING,
+    type: FieldType.DATE,
     required: true,
   },
 } satisfies Record<string, Field>


### PR DESCRIPTION
Was a string previously which resulted in users not being able to select date data points for the appointment date.