### PR TITLE
[Cal.com] Create user datapoints from Get Booking action

### DIFF
--- a/extensions/calDotCom/actions/__tests__/getBooking.ts
+++ b/extensions/calDotCom/actions/__tests__/getBooking.ts
@@ -2,6 +2,7 @@ import { getBooking } from '../getBooking'
 import { faker } from '@faker-js/faker'
 import CalComApi from '../../calComApi'
 import { generateTestPayload } from '../../../../src/tests'
+import { type User } from '../../schema'
 
 describe('Cal.com GetBooking action', () => {
   const onComplete = jest.fn()
@@ -90,6 +91,8 @@ describe('Cal.com GetBooking action', () => {
     let endTime: string
     let status: string
     let uid: string
+    let user: User
+    let attendees: User[]
 
     beforeEach(() => {
       eventTypeId = faker.number.int()
@@ -99,6 +102,20 @@ describe('Cal.com GetBooking action', () => {
       endTime = faker.date.anytime().toISOString()
       status = faker.string.sample()
       uid = faker.string.uuid()
+      user = {
+        email: faker.internet.email(),
+        name: faker.word.sample(),
+        timeZone: faker.word.sample(),
+        locale: faker.word.sample(),
+      }
+      attendees = [
+        {
+          email: faker.internet.email(),
+          name: faker.word.sample(),
+          timeZone: faker.word.sample(),
+        },
+      ]
+
       mockCalComApi = jest
         .spyOn(CalComApi.prototype, 'getBooking')
         .mockResolvedValue({
@@ -109,6 +126,8 @@ describe('Cal.com GetBooking action', () => {
           endTime,
           status,
           uid,
+          user,
+          attendees,
         })
     })
 
@@ -138,6 +157,8 @@ describe('Cal.com GetBooking action', () => {
           status,
           cancelUrl: `https://app.cal.com/booking/${uid}?cancel=true`,
           rescheduleUrl: `https://app.cal.com/reschedule/${uid}`,
+          firstAttendeeEmail: attendees[0].email,
+          userEmail: user.email,
         },
       })
     })

--- a/extensions/calDotCom/actions/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking.ts
@@ -54,6 +54,14 @@ const dataPoints = {
     key: 'rescheduleUrl',
     valueType: 'string',
   },
+  firstAttendeeEmail: {
+    key: 'firstAttendeeEmail',
+    valueType: 'string',
+  },
+  userEmail: {
+    key: 'userEmail',
+    valueType: 'string',
+  },
 } satisfies Record<string, DataPointDefinition>
 
 export const getBooking: Action<typeof fields, typeof settings> = {
@@ -86,6 +94,8 @@ export const getBooking: Action<typeof fields, typeof settings> = {
           status: booking.status,
           cancelUrl: `https://app.cal.com/booking/${booking.uid}?cancel=true`,
           rescheduleUrl: `https://app.cal.com/reschedule/${booking.uid}`,
+          firstAttendeeEmail: booking.attendees[0].email,
+          userEmail: booking.user.email,
         },
       })
     } catch (error) {

--- a/extensions/calDotCom/schema.ts
+++ b/extensions/calDotCom/schema.ts
@@ -12,18 +12,15 @@ export const GetBookingPayloadSchema = z.object({
   fields: GetBookingFieldsSchema,
   settings: SettingsSchema,
 })
-//
 
-// Leaving this and part of booking schema commented out, just in case we want to use it
-// it is a part of api response but we don't use it right now
-// const UserSchema = z.object({
-//   email: z.string(),
-//   name: z.string(),
-//   timeZone: z.string(),
-//   locale: z.string().optional().nullable(),
-// })
+const UserSchema = z.object({
+  email: z.string(),
+  name: z.string(),
+  timeZone: z.string(),
+  locale: z.string().optional().nullable(),
+})
 
-// export type User = z.infer<typeof UserSchema>
+export type User = z.infer<typeof UserSchema>
 
 export const BookingSchema = z.object({
   eventTypeId: z.number(),
@@ -35,8 +32,8 @@ export const BookingSchema = z.object({
   uid: z.string(),
   //   id: z.number(),
   //   userId: z.number(),
-  //   user: UserSchema,
-  //   attendees: z.array(UserSchema),
+  user: UserSchema,
+  attendees: z.array(UserSchema),
   //   metadata: z.record(z.unknown()),
 })
 


### PR DESCRIPTION
This pull request adds two new data points to the existing functionality. The first data point, 'firstAttendeeEmail', involves extracting the email from the first object in the provided array. Additionally, this PR includes the addition of the 'userEmail' data point. Lastly, the associated test has been modified to accommodate these changes. 
