### PR TITLE
[Elation] Rename webhook to patientCreatedOrUpdated and filter non saved actions

### DIFF
--- a/extensions/elation/CHANGELOG.md
+++ b/extensions/elation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Elation Changelog
 
-## 2023-08-21
+## September 4, 2023
+
+- rename `onCreatePatient` webhook to `patientCreatedOrUpdated`
+- filter non `saved` actions for this webhook
+
+## August 21, 2023
 
 - make non-visit note text a large input (`StringType.TEXT`)

--- a/extensions/elation/webhooks/index.ts
+++ b/extensions/elation/webhooks/index.ts
@@ -1,4 +1,4 @@
-import { onCreatePatient } from './onCreatePatient'
-export type { OnCreatePatient } from './onCreatePatient'
+import { patientCreatedOrUpdated } from './patientCreatedOrUpdated'
+export type { OnCreatePatient } from './patientCreatedOrUpdated'
 
-export const webhooks = [onCreatePatient]
+export const webhooks = [patientCreatedOrUpdated]

--- a/extensions/elation/webhooks/patientCreatedOrUpdated.ts
+++ b/extensions/elation/webhooks/patientCreatedOrUpdated.ts
@@ -18,7 +18,13 @@ export const patientCreatedOrUpdated: Webhook<
   key: 'patientCreatedOrUpdated',
   dataPoints,
   onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
-    const { data, resource } = payload
+    const { data, resource, action } = payload
+
+    // skip non 'saved' actions for that webhook
+    if (action !== 'saved') {
+      return
+    }
+
     if (resource !== 'patients') {
       await onError({
         response: {

--- a/extensions/elation/webhooks/patientCreatedOrUpdated.ts
+++ b/extensions/elation/webhooks/patientCreatedOrUpdated.ts
@@ -11,11 +11,11 @@ const dataPoints = {
   },
 } satisfies Record<string, DataPointDefinition>
 
-export const onCreatePatient: Webhook<
+export const patientCreatedOrUpdated: Webhook<
   keyof typeof dataPoints,
   SubscriptionEvent
 > = {
-  key: 'onCreatePatient',
+  key: 'patientCreatedOrUpdated',
   dataPoints,
   onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
     const { data, resource } = payload
@@ -34,4 +34,4 @@ export const onCreatePatient: Webhook<
   },
 }
 
-export type OnCreatePatient = typeof onCreatePatient
+export type OnCreatePatient = typeof patientCreatedOrUpdated


### PR DESCRIPTION
Closes #222 

- rename `onCreatePatient` webhook to `patientCreatedOrUpdated`
- filter non `saved` actions for this webhook