### PR TITLE
EXT-4 [Sendbird] Create user action: make `nickname` optional and set a sensible default

### DIFF
--- a/extensions/sendbird/v1/actions/createUser/config/fields.ts
+++ b/extensions/sendbird/v1/actions/createUser/config/fields.ts
@@ -20,8 +20,9 @@ export const fields = {
     id: 'nickname',
     label: 'Nickname',
     type: FieldType.STRING,
-    description: "The user's nickname. Maximum length is 80 characters.",
-    required: true,
+    description:
+      "The user's nickname. Maximum length is 80 characters. If left empty, we will use the patient's first and last name.",
+    required: false,
   },
   issueAccessToken: {
     id: 'issueAccessToken',

--- a/extensions/sendbird/v1/actions/createUser/config/fields.ts
+++ b/extensions/sendbird/v1/actions/createUser/config/fields.ts
@@ -51,7 +51,7 @@ export const fields = {
 
 export const FieldsValidationSchema = z.object({
   userId: z.string().max(80).nonempty(),
-  nickname: z.string().max(80).nonempty(),
+  nickname: z.string().max(80).optional(),
   issueAccessToken: z.boolean().optional(),
   profileUrl: makeStringOptional(z.string().url()),
   metadata: z.optional(MetadataValidationSchema),

--- a/extensions/sendbird/v1/actions/createUser/createUser.test.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.test.ts
@@ -92,4 +92,30 @@ describe('Create user', () => {
     expect(onComplete).not.toHaveBeenCalled()
     expect(onError).toBeCalledTimes(1)
   })
+
+  test('Should call the onError when firstName is available but lastName and nickname is missing', async () => {
+    basePayload.fields.nickname = ''
+    basePayload.patient = {
+      ...basePayload.patient,
+      profile: { first_name: 'test', last_name: undefined },
+    }
+
+    await createUser.onActivityCreated(basePayload, onComplete, onError)
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toBeCalledTimes(1)
+  })
+
+  test('Should call the onError when lastName is available but firstName and nickname is missing', async () => {
+    basePayload.fields.nickname = ''
+    basePayload.patient = {
+      ...basePayload.patient,
+      profile: { first_name: undefined, last_name: 'test' },
+    }
+
+    await createUser.onActivityCreated(basePayload, onComplete, onError)
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toBeCalledTimes(1)
+  })
 })

--- a/extensions/sendbird/v1/actions/createUser/createUser.test.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.test.ts
@@ -80,7 +80,7 @@ describe('Create user', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  test('Should call the onError when nickname and first and last name in patient are blank', async () => {
+  test('Should call the onError when nickname and first and last name in patient are missing', async () => {
     basePayload.fields.nickname = ''
     basePayload.patient = {
       ...basePayload.patient,
@@ -93,7 +93,7 @@ describe('Create user', () => {
     expect(onError).toBeCalledTimes(1)
   })
 
-  test('Should call the onError when firstName is available but lastName and nickname is missing', async () => {
+  test('Should call the onComplete callback when firstName is available but lastName and nickname is missing', async () => {
     basePayload.fields.nickname = ''
     basePayload.patient = {
       ...basePayload.patient,
@@ -102,11 +102,13 @@ describe('Create user', () => {
 
     await createUser.onActivityCreated(basePayload, onComplete, onError)
 
-    expect(onComplete).not.toHaveBeenCalled()
-    expect(onError).toBeCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: { userId: basePayload.fields.userId },
+    })
+    expect(onError).not.toHaveBeenCalled()
   })
 
-  test('Should call the onError when lastName is available but firstName and nickname is missing', async () => {
+  test('Should call the onComplete callback when lastName is available but firstName and nickname is missing', async () => {
     basePayload.fields.nickname = ''
     basePayload.patient = {
       ...basePayload.patient,
@@ -115,7 +117,9 @@ describe('Create user', () => {
 
     await createUser.onActivityCreated(basePayload, onComplete, onError)
 
-    expect(onComplete).not.toHaveBeenCalled()
-    expect(onError).toBeCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: { userId: basePayload.fields.userId },
+    })
+    expect(onError).not.toHaveBeenCalled()
   })
 })

--- a/extensions/sendbird/v1/actions/createUser/createUser.test.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.test.ts
@@ -19,7 +19,10 @@ describe('Create user', () => {
     activity: {
       id: 'activity-id',
     },
-    patient: { id: 'test-patient' },
+    patient: {
+      id: 'test-patient',
+      profile: { first_name: 'first-name', last_name: 'last-name' },
+    },
     fields: {
       userId: mockedUserData.user_id,
       nickname: mockedUserData.nickname,
@@ -54,5 +57,39 @@ describe('Create user', () => {
       data_points: { userId: basePayload.fields.userId },
     })
     expect(onError).not.toHaveBeenCalled()
+  })
+
+  test('Should call the onComplete callback with nickname as first and last name', async () => {
+    basePayload.fields.nickname = ''
+    await createUser.onActivityCreated(basePayload, onComplete, onError)
+
+    expect(
+      SendbirdClientMockImplementation.chatApi.createUser
+    ).toHaveBeenCalledWith({
+      user_id: basePayload.fields.userId,
+      nickname: `${basePayload.patient.profile?.first_name as string} ${
+        basePayload.patient.profile?.last_name as string
+      }`,
+      issue_access_token: basePayload.fields.issueAccessToken,
+      metadata: JSON.parse(basePayload.fields.metadata),
+      profile_url: mockedUserData.profile_url,
+    })
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: { userId: basePayload.fields.userId },
+    })
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  test('Should call the onError when nickname and first and last name in patient are blank', async () => {
+    basePayload.fields.nickname = ''
+    basePayload.patient = {
+      ...basePayload.patient,
+      profile: { first_name: undefined, last_name: undefined },
+    }
+
+    await createUser.onActivityCreated(basePayload, onComplete, onError)
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toBeCalledTimes(1)
   })
 })

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -93,9 +93,9 @@ const parseNickname = (payload: any): string => {
   const firstName = payload.patient.profile?.first_name
   const lastName = payload.patient.profile?.last_name
 
-  if (isEmpty(nickname) && isEmpty(firstName) && isEmpty(lastName)) {
+  if (isEmpty(nickname) && (isEmpty(firstName) || isEmpty(lastName))) {
     throw new Error(
-      'Nickname is not specified, and both first name and last name are unknown.'
+      'Nickname is not specified, and either the first name or last name is unknown'
     )
   }
 

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -90,14 +90,13 @@ const parseNickname = (payload: any): string => {
   const nickname: string = payload.fields.nickname
   if (!isEmpty(nickname)) return nickname
 
-  const firstName = payload.patient.profile?.first_name
-  const lastName = payload.patient.profile?.last_name
+  const firstName = payload.patient.profile?.first_name ?? ''
+  const lastName = payload.patient.profile?.last_name ?? ''
 
-  if (isEmpty(nickname) && (isEmpty(firstName) || isEmpty(lastName))) {
+  if (isEmpty(firstName) && isEmpty(lastName))
     throw new Error(
       'Nickname is not specified, and either the first name or last name is unknown'
     )
-  }
 
-  return `${firstName as string} ${lastName as string}`
+  return `${firstName as string} ${lastName as string}`.trim()
 }

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -23,11 +23,9 @@ export const createUser: Action<typeof fields, typeof settings> = {
   previewable: false,
   onActivityCreated: async (payload, onComplete, onError) => {
     try {
-      payload.fields.nickname = parseNickname(payload)
-
       const {
         settings: { applicationId, chatApiToken, deskApiToken },
-        fields: { userId, metadata, nickname, issueAccessToken, profileUrl },
+        fields: { userId, metadata, issueAccessToken, profileUrl },
       } = validate({
         schema: z.object({
           settings: SettingsValidationSchema,
@@ -44,7 +42,7 @@ export const createUser: Action<typeof fields, typeof settings> = {
 
       const res = await client.chatApi.createUser({
         user_id: userId,
-        nickname,
+        nickname: parseNickname(payload),
         metadata,
         issue_access_token: issueAccessToken,
         profile_url: profileUrl ?? DEFAULT_PROFILE_URL,

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -95,7 +95,7 @@ const parseNickname = (payload: any): string => {
 
   if (isEmpty(firstName) && isEmpty(lastName))
     throw new Error(
-      'Nickname is not specified, and either the first name or last name is unknown'
+      'The required nickname has not been specified, and neither the first name nor last name of the patient has been set in their profile'
     )
 
   return `${firstName as string} ${lastName as string}`.trim()

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -11,6 +11,7 @@ import {
   sendbirdChatErrorToActivityEvent,
 } from '../../client'
 import { DEFAULT_PROFILE_URL } from '../../constants'
+import { isEmpty } from 'lodash'
 
 export const createUser: Action<typeof fields, typeof settings> = {
   key: 'createUser',
@@ -22,6 +23,8 @@ export const createUser: Action<typeof fields, typeof settings> = {
   previewable: false,
   onActivityCreated: async (payload, onComplete, onError) => {
     try {
+      payload.fields.nickname = parseNickname(payload)
+
       const {
         settings: { applicationId, chatApiToken, deskApiToken },
         fields: { userId, metadata, nickname, issueAccessToken, profileUrl },
@@ -83,4 +86,20 @@ export const createUser: Action<typeof fields, typeof settings> = {
       }
     }
   },
+}
+
+const parseNickname = (payload: any): string => {
+  const nickname: string = payload.fields.nickname
+  if (!isEmpty(nickname)) return nickname
+
+  const firstName = payload.patient.profile?.first_name
+  const lastName = payload.patient.profile?.last_name
+
+  if (isEmpty(nickname) && isEmpty(firstName) && isEmpty(lastName)) {
+    throw new Error(
+      'Nickname is not specified, and both first name and last name are unknown.'
+    )
+  }
+
+  return `${firstName as string} ${lastName as string}`
 }

--- a/extensions/sendbird/v1/client/__mocks__/client.ts
+++ b/extensions/sendbird/v1/client/__mocks__/client.ts
@@ -47,3 +47,5 @@ export const SendbirdClientMockImplementation = {
 const SendbirdClientMock = jest.fn(() => SendbirdClientMockImplementation)
 
 export const SendbirdClient = SendbirdClientMock
+
+export const isSendbirdChatError = jest.fn()


### PR DESCRIPTION
This pull request aims to improve the Create user action by making the nickname field optional and introducing a sensible default behavior.