### PR TITLE
feat(cal.com): expose first attendee name and timezone

### DIFF
--- a/extensions/calDotCom/CHANGELOG.md
+++ b/extensions/calDotCom/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## September 15, 2023
 
 - add createBooking action
+- add first attendee name and timezone to getBooking data points
 
 ## September 4, 2023
 

--- a/extensions/calDotCom/README.md
+++ b/extensions/calDotCom/README.md
@@ -51,6 +51,11 @@ This action allows you to fetch the details of a booking based on the provided `
 6. Status
 7. Cancel URL
 8. Reschedule URL
+9. Video call URL (if available)
+10. First Attendee's name
+12. First Attendee's timezone
+12. First Attendee's email
+13. Organizer's email
 
 ### Update booking
 

--- a/extensions/calDotCom/actions/getBooking/config/dataPoints.ts
+++ b/extensions/calDotCom/actions/getBooking/config/dataPoints.ts
@@ -37,6 +37,14 @@ export const dataPoints = {
     key: 'firstAttendeeEmail',
     valueType: 'string',
   },
+  firstAttendeeTimezone: {
+    key: 'firstAttendeeTimezone',
+    valueType: 'string',
+  },
+  firstAttendeeName: {
+    key: 'firstAttendeeName',
+    valueType: 'string',
+  },
   userEmail: {
     key: 'userEmail',
     valueType: 'string',

--- a/extensions/calDotCom/actions/getBooking/getBooking.test.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.test.ts
@@ -167,6 +167,8 @@ describe('Cal.com GetBooking action', () => {
           rescheduleUrl: `https://app.cal.com/reschedule/${uid}`,
           videoCallUrl: metadata.videoCallUrl,
           firstAttendeeEmail: attendees[0].email,
+          firstAttendeeTimezone: attendees[0].timeZone,
+          firstAttendeeName: attendees[0].name,
           userEmail: user.email,
         },
       })

--- a/extensions/calDotCom/actions/getBooking/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.ts
@@ -41,6 +41,8 @@ export const getBooking: Action<typeof fields, typeof settings> = {
           rescheduleUrl: `https://app.cal.com/reschedule/${booking.uid}`,
           videoCallUrl: booking.metadata.videoCallUrl ?? '',
           firstAttendeeEmail: booking.attendees[0].email,
+          firstAttendeeTimezone: booking.attendees[0].timeZone,
+          firstAttendeeName: booking.attendees[0].name,
           userEmail: booking.user.email,
         },
       })


### PR DESCRIPTION
Changes:
- add firstAttendeeName and firstAttendeeTimezone as data points for cal.com getBooking action
- update docs and tests accordingly 