### PR TITLE
feat(collectData): add collectData extension and remoteSingleSelect action

### DIFF
--- a/extensions/collectData/CHANGELOG.md
+++ b/extensions/collectData/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Collect Data changelog

--- a/extensions/collectData/README.md
+++ b/extensions/collectData/README.md
@@ -1,0 +1,18 @@
+---
+title: Collect Data
+description: Collect data from your users using a variety of input types and data sources
+---
+
+# Collect Data
+
+The Collect Data extension allows you to collect data from your users using a variety of input types and data sources.
+
+## Extension settings
+
+In order to set up this extension, no settings are required.
+
+## Custom Actions
+
+### Remote Single Select
+
+The Remote Single Select action allows you to create a single select input that is populated with data from a remote data source. The data source must be a REST API.

--- a/extensions/collectData/index.ts
+++ b/extensions/collectData/index.ts
@@ -1,0 +1,23 @@
+import { type Extension } from '@awell-health/extensions-core'
+import { AuthorType, Category } from '@awell-health/extensions-core'
+import {
+  remoteSingleSelect
+} from './v1/actions'
+import { settings } from './settings'
+
+export const CollectData: Extension = {
+  key: 'collectData',
+  title: 'Collect Data',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1678870116/Awell%20Extensions/Awell_Logo.png',
+  description:
+    'Collect data from users to ingest into care flows',
+  category: Category.FORMS,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  actions: {
+    remoteSingleSelect
+  },
+  settings,
+}

--- a/extensions/collectData/settings.ts
+++ b/extensions/collectData/settings.ts
@@ -1,0 +1,14 @@
+import { type Setting } from '@awell-health/extensions-core'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({} satisfies Record<keyof typeof settings, ZodTypeAny>)
+
+export const validateSettings = (
+  settings: unknown
+): z.infer<typeof SettingsValidationSchema> => {
+  const parsedData = SettingsValidationSchema.parse(settings)
+
+  return parsedData
+}

--- a/extensions/collectData/v1/actions/index.ts
+++ b/extensions/collectData/v1/actions/index.ts
@@ -1,0 +1,1 @@
+export { remoteSingleSelect } from './remoteSingleSelect'

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoints.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoints.ts
@@ -1,12 +1,12 @@
 import { type DataPointDefinition } from '@awell-health/extensions-core'
 
 export const dataPoints = {
-  valueSelected: {
-    key: 'valueSelected',
+  value: {
+    key: 'value',
     valueType: 'string',
   },
-  labelSelected: {
-    key: 'labelSelected',
+  label: {
+    key: 'label',
     valueType: 'string',
   },
 } satisfies Record<string, DataPointDefinition>

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoints.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  valueSelected: {
+    key: 'valueSelected',
+    valueType: 'string',
+  },
+  labelSelected: {
+    key: 'labelSelected',
+    valueType: 'string',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
@@ -1,0 +1,59 @@
+import { z, type ZodTypeAny } from 'zod'
+import { type Field, FieldType } from '@awell-health/extensions-core'
+
+export const fields = {
+  questionLabel: {
+    id: 'questionLabel',
+    label: 'Label text',
+    description:
+      'Enter the label text that will be displayed before the selector.',
+    type: FieldType.STRING,
+    required: true,
+  },
+  optionsSourceUrl: {
+    id: 'optionsSourceUrl',
+    label: 'Options endpoint URL',
+    description:
+      'Enter the URL containing the options to display in the selector. The endpoint must return an array of objects with the following properties: `id`, `label` and `value`.',
+    type: FieldType.STRING,
+    required: true,
+  },
+  optionsSourceHeaders: {
+    id: 'optionsSourceHeaders',
+    label: 'Options endpoint headers',
+    description:
+      'Enter the headers to send to the options source URL. The headers must be in JSON format.',
+    type: FieldType.JSON,
+    required: false,
+  },
+  optionsSourceSearchQueryParams: {
+    id: 'optionsSourceSearchQueryParams',
+    label: 'Options endpoint search query param key',
+    description:
+      'Enter the key of the search query param to send to the options source URL e.g. `search` for `https://example.com/options?search=foo`.',
+    type: FieldType.STRING,
+    required: true,
+  },
+  mandatory: {
+    id: 'mandatory',
+    label: 'Is response required?',
+    description: 'The user must select an option before continuing.',
+    type: FieldType.BOOLEAN,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  questionLabel: z.string().nonempty(),
+  optionsSourceUrl: z.string().url(),
+  optionsSourceHeaders: z.record(z.string()),
+  optionsSourceQueryParams: z.string().nonempty(),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)
+
+export const validateActionFields = (
+  fields: unknown
+): z.infer<typeof FieldsValidationSchema> => {
+  const parsedData = FieldsValidationSchema.parse(fields)
+
+  return parsedData
+}

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
@@ -2,37 +2,37 @@ import { z, type ZodTypeAny } from 'zod'
 import { type Field, FieldType } from '@awell-health/extensions-core'
 
 export const fields = {
-  questionLabel: {
-    id: 'questionLabel',
+  label: {
+    id: 'label',
     label: 'Label text',
     description:
       'Enter the label text that will be displayed before the selector.',
     type: FieldType.STRING,
     required: true,
   },
-  optionsSourceUrl: {
-    id: 'optionsSourceUrl',
+  url: {
+    id: 'url',
     label: 'Options endpoint URL',
     description:
-      'Enter the URL containing the options to display in the selector. The endpoint must return an array of objects with the following properties: `id`, `label` and `value`.',
+      'Enter the URL where the options to display in the selector can be fetched. The endpoint must return an array of objects with the following properties: `label` and `value`.',
     type: FieldType.STRING,
     required: true,
   },
-  optionsSourceHeaders: {
-    id: 'optionsSourceHeaders',
+  headers: {
+    id: 'headers',
     label: 'Options endpoint headers',
     description:
       'Enter the headers to send to the options source URL. The headers must be in JSON format.',
     type: FieldType.JSON,
     required: false,
   },
-  optionsSourceSearchQueryParams: {
-    id: 'optionsSourceSearchQueryParams',
+  queryParam: {
+    id: 'queryParam',
     label: 'Options endpoint search query param key',
     description:
-      'Enter the key of the search query param to send to the options source URL e.g. `search` for `https://example.com/options?search=foo`.',
+      'Enter the key of the free text search query param if the endpoint supports this e.g. `search` for `https://example.com/options?search=foo`.',
     type: FieldType.STRING,
-    required: true,
+    required: false,
   },
   mandatory: {
     id: 'mandatory',
@@ -44,10 +44,11 @@ export const fields = {
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
-  questionLabel: z.string().nonempty(),
-  optionsSourceUrl: z.string().url(),
-  optionsSourceHeaders: z.record(z.string()),
-  optionsSourceQueryParams: z.string().nonempty(),
+  label: z.string().nonempty(),
+  url: z.string().url(),
+  headers: z.record(z.string()),
+  queryParam: z.string().optional(),
+  mandatory: z.boolean(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)
 
 export const validateActionFields = (

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/index.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/index.ts
@@ -1,0 +1,2 @@
+export { fields } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/collectData/v1/actions/remoteSingleSelect/index.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/index.ts
@@ -1,0 +1,1 @@
+export * from './remoteSingleSelect'

--- a/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.test.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.test.ts
@@ -1,0 +1,31 @@
+import { generateTestPayload } from '../../../../../src/tests'
+import { remoteSingleSelect } from './remoteSingleSelect'
+
+describe('Complete flow action', () => {
+  const onComplete = jest.fn()
+
+  beforeEach(() => {
+    onComplete.mockClear()
+  })
+
+  test('Should not call the onComplete callback', async () => {
+    await remoteSingleSelect.onActivityCreated(
+      generateTestPayload({
+        fields: {
+          optionsSourceHeaders: '{"Content-Type": "application/json"}',
+          optionsSourceQueryParams: 'search',
+          optionsSourceUrl: 'https://example.com',
+          questionLabel: 'label',
+        },
+        settings: {},
+      }),
+      onComplete,
+      jest.fn()
+    )
+
+    /**
+     * Because completion is done in Awell Hosted Pages
+     */
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+})

--- a/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.ts
@@ -1,0 +1,60 @@
+import { type Action } from '@awell-health/extensions-core'
+import { dataPoints, fields } from './config'
+import { Category } from '@awell-health/extensions-core'
+import { type settings } from '../../../settings'
+import { validateActionFields } from './config/fields'
+import { fromZodError } from 'zod-validation-error'
+import { ZodError } from 'zod'
+
+export const remoteSingleSelect: Action<typeof fields, typeof settings> = {
+  key: 'remoteSingleSelect',
+  title: 'Remote Single Select',
+  description:
+    'Allow a stakeholder to select a single option from a set fetched from an API endpoint',
+  category: Category.FORMS,
+  fields,
+  dataPoints,
+  options: {
+    stakeholders: {
+      label: 'Stakeholder',
+      mode: 'single',
+    },
+  },
+  previewable: false, // We don't have Awell Hosted Pages in Preview so cannot be previewed.
+  onActivityCreated: async (payload, onComplete, onError) => {
+    try {
+      validateActionFields(payload.fields)
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const error = fromZodError(err)
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: error.name },
+              error: {
+                category: 'WRONG_INPUT',
+                message: `${error.message}`,
+              },
+            },
+          ],
+        })
+        return
+      }
+
+      const error = err as Error
+      await onError({
+        events: [
+          {
+            date: new Date().toISOString(),
+            text: { en: 'Something went wrong while orchestrating the action' },
+            error: {
+              category: 'SERVER_ERROR',
+              message: error.message,
+            },
+          },
+        ],
+      })
+    }
+  },
+}


### PR DESCRIPTION
Changes:
- new extension for collecting data to ingest into care flows
- new action to collect single select value from user using remotely fetched set of options 

relates to V1C-363