### PR TITLE
V1C-380: implement 'Post Letter' action in elation extension

### DIFF
--- a/extensions/elation/CHANGELOG.md
+++ b/extensions/elation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Elation Changelog
 
+## January 30, 2024
+
+- New actions
+  - Post letter: Using patient and practice identifier, post a new letter to either Provider, Patient or associate it with an existing Referral.
+
 ## October 3, 2023
 
 - The README is now more concise with less unneeded detail. A section on the particularities of Elation subscriptions (webhooks) was added.

--- a/extensions/elation/__mocks__/client.ts
+++ b/extensions/elation/__mocks__/client.ts
@@ -6,6 +6,7 @@ import {
   nonVisitNoteResponseExample,
   patientExample,
   physicianResponseExample,
+  postLetterResponseExample,
 } from './constants'
 const { makeAPIClient: makeAPIClientActual } = jest.requireActual('../client')
 
@@ -59,6 +60,9 @@ export const mockClientReturn = {
   }),
   deleteNonVisitNote: jest.fn(() => {
     return {}
+  }),
+  postLetter: jest.fn(() => {
+    return postLetterResponseExample
   }),
 }
 const ElationAPIClientMock = jest.fn((params) => {

--- a/extensions/elation/__mocks__/client.ts
+++ b/extensions/elation/__mocks__/client.ts
@@ -61,7 +61,7 @@ export const mockClientReturn = {
   deleteNonVisitNote: jest.fn(() => {
     return {}
   }),
-  postLetter: jest.fn(() => {
+  postNewLetter: jest.fn(() => {
     return postLetterResponseExample
   }),
 }

--- a/extensions/elation/__mocks__/constants.ts
+++ b/extensions/elation/__mocks__/constants.ts
@@ -1,4 +1,5 @@
 import { type AppointmentInput } from '../types/appointment'
+import { type PostLetterResponse } from '../types/letter'
 import { type NonVisitNoteResponse } from '../types/nonVisitNote'
 import { type PatientInput } from '../types/patient'
 import { type PhysicianResponse } from '../types/physician'
@@ -82,4 +83,17 @@ export const nonVisitNoteResponseExample: NonVisitNoteResponse = {
   chart_date: '2023-01-01T00:00:00Z',
   document_date: '2023-01-01T00:00:00Z',
   tags: [],
+}
+
+export const postLetterResponseExample: PostLetterResponse = {
+  body: 'This my test',
+  id: 142251583930586,
+  letter_type: 'provider',
+  patient: 141986488057857,
+  practice: 141127173275652,
+  referral_order: null,
+  send_to_contact: {
+    id: 141377681883138,
+  },
+  subject: 'My test subject',
 }

--- a/extensions/elation/actions/__tests__/postLetter.ts
+++ b/extensions/elation/actions/__tests__/postLetter.ts
@@ -49,7 +49,7 @@ describe('Post new letter action', () => {
     })
   })
 
-  test('Should reject when subject and referral order are both included', async () => {
+  test('Should reject when both subject and referral order are not included', async () => {
     const onError = jest
       .fn()
       .mockImplementation((obj: { events: ActivityEvent[] }) => {
@@ -60,10 +60,8 @@ describe('Post new letter action', () => {
         fields: {
           patientId: postLetterResponseExample.patient,
           practiceId: postLetterResponseExample.practice,
-          subject: postLetterResponseExample.subject,
           body: postLetterResponseExample.body,
           contactId: postLetterResponseExample.send_to_contact.id,
-          referralOrderId: 123,
         },
         settings,
       } as any,
@@ -72,7 +70,7 @@ describe('Post new letter action', () => {
     )
     expect(onError).toHaveBeenCalled()
     expect(onError).toHaveReturnedWith(
-      "Validation error: Either 'subject' or 'referral order' is required, but not both."
+      "Validation error: One of either 'subject' or 'referral order' is required."
     )
   })
 })

--- a/extensions/elation/actions/__tests__/postLetter.ts
+++ b/extensions/elation/actions/__tests__/postLetter.ts
@@ -1,0 +1,50 @@
+import { postLetterResponseExample } from '../../__mocks__/constants'
+import { makeAPIClientMockFunc } from '../../__mocks__/client'
+import { makeAPIClient } from '../../client'
+import { postLetter } from '../postLetter'
+
+jest.mock('../../client')
+
+describe('Post new letter action', () => {
+  const onComplete = jest.fn()
+  const onError = jest.fn()
+  const settings = {
+    client_id: 'clientId',
+    client_secret: 'clientSecret',
+    username: 'username',
+    password: 'password',
+    auth_url: 'authUrl',
+    base_url: 'baseUrl',
+  }
+
+  beforeAll(() => {
+    const mockAPIClient = makeAPIClient as jest.Mock
+    mockAPIClient.mockImplementation(makeAPIClientMockFunc)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('Should return with correct data_points', async () => {
+    await postLetter.onActivityCreated(
+      {
+        fields: {
+          patientId: postLetterResponseExample.patient,
+          practiceId: postLetterResponseExample.practice,
+          subject: postLetterResponseExample.subject,
+          body: postLetterResponseExample.body,
+          contactId: postLetterResponseExample.send_to_contact.id,
+        },
+        settings,
+      } as any,
+      onComplete,
+      onError
+    )
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        letterId: String(postLetterResponseExample.id),
+      },
+    })
+  })
+})

--- a/extensions/elation/actions/__tests__/postLetter.ts
+++ b/extensions/elation/actions/__tests__/postLetter.ts
@@ -2,6 +2,7 @@ import { postLetterResponseExample } from '../../__mocks__/constants'
 import { makeAPIClientMockFunc } from '../../__mocks__/client'
 import { makeAPIClient } from '../../client'
 import { postLetter } from '../postLetter'
+import { type ActivityEvent } from '@awell-health/extensions-core'
 
 jest.mock('../../client')
 
@@ -46,5 +47,32 @@ describe('Post new letter action', () => {
         letterId: String(postLetterResponseExample.id),
       },
     })
+  })
+
+  test('Should reject when subject and referral order are both included', async () => {
+    const onError = jest
+      .fn()
+      .mockImplementation((obj: { events: ActivityEvent[] }) => {
+        return obj.events[0].error?.message
+      })
+    await postLetter.onActivityCreated(
+      {
+        fields: {
+          patientId: postLetterResponseExample.patient,
+          practiceId: postLetterResponseExample.practice,
+          subject: postLetterResponseExample.subject,
+          body: postLetterResponseExample.body,
+          contactId: postLetterResponseExample.send_to_contact.id,
+          referralOrderId: 123,
+        },
+        settings,
+      } as any,
+      onComplete,
+      onError
+    )
+    expect(onError).toHaveBeenCalled()
+    expect(onError).toHaveReturnedWith(
+      "Validation error: Either 'subject' or 'referral order' is required, but not both."
+    )
   })
 })

--- a/extensions/elation/actions/index.ts
+++ b/extensions/elation/actions/index.ts
@@ -9,6 +9,7 @@ import { createNonVisitNote } from './createNonVisitNote'
 import { getNonVisitNote } from './getNonVisitNote'
 import { deleteNonVisitNote } from './deleteNonVisitNote'
 import { getPhysician } from './getPhysician'
+import { postLetter } from './postLetter'
 
 export const actions = {
   getPatient,
@@ -22,4 +23,5 @@ export const actions = {
   // updateNonVisitNote, // Disable for now, don't immediately see a use case for this action.
   getNonVisitNote,
   deleteNonVisitNote,
+  postLetter,
 }

--- a/extensions/elation/actions/postLetter.ts
+++ b/extensions/elation/actions/postLetter.ts
@@ -84,7 +84,7 @@ export const postLetter: Action<
   title: 'Post letter',
   description: "Post a letter using Elation's patient API.",
   fields,
-  previewable: true,
+  previewable: false,
   dataPoints,
   onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
     try {
@@ -99,13 +99,15 @@ export const postLetter: Action<
       } = payload.fields
 
       const letter = letterSchema.parse({
-        patientId,
-        practiceId,
-        referralOrderId,
+        patient: patientId,
+        practice: practiceId,
+        referral_order: referralOrderId,
         subject,
         body,
-        contactId,
-        letterType,
+        letter_type: letterType,
+        send_to_contact: {
+          id: contactId,
+        },
       })
 
       const api = makeAPIClient(payload.settings)

--- a/extensions/elation/actions/postLetter.ts
+++ b/extensions/elation/actions/postLetter.ts
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { ZodError } from 'zod'
+import {
+  FieldType,
+  type Action,
+  type DataPointDefinition,
+  type Field,
+  Category,
+} from '@awell-health/extensions-core'
+import { type settings } from '../settings'
+import { makeAPIClient } from '../client'
+import { fromZodError } from 'zod-validation-error'
+import { AxiosError } from 'axios'
+import { letterSchema } from '../validation/letter.zod'
+
+const fields = {
+  patientId: {
+    id: 'patientId',
+    label: 'Patient ID',
+    description: 'ID of the patient',
+    type: FieldType.NUMERIC,
+    required: true,
+  },
+  practiceId: {
+    id: 'practiceId',
+    label: 'Practice',
+    description: 'ID of a Practice',
+    type: FieldType.NUMERIC,
+    required: true,
+  },
+  referralOrderId: {
+    id: 'referralOrderId',
+    label: 'Referral Order ID',
+    description: 'Id of the Referral Order (Not needed with subject)',
+    type: FieldType.NUMERIC,
+    required: false,
+  },
+  subject: {
+    id: 'subject',
+    label: 'Subject',
+    description: 'Subject of the letter (Not needed with referral order)',
+    type: FieldType.STRING,
+    required: false,
+  },
+  body: {
+    id: 'body',
+    label: 'Body',
+    description: 'Body of the letter',
+    type: FieldType.TEXT,
+    required: true,
+  },
+  // the following is called `send_to_contact.id` in elation api docs
+  contactId: {
+    id: 'contactId',
+    label: 'Contact ID',
+    description: 'ID of the contact whom you want to send this letter',
+    type: FieldType.NUMERIC,
+    required: true,
+  },
+  letterType: {
+    id: 'letterType',
+    label: 'Type of letter',
+    description:
+      'Type of letter. Defaults to "provider". The type can be one of the following: "patient", "referral", "provider" or "patient_initiated".',
+    type: FieldType.STRING,
+    required: false,
+  },
+} satisfies Record<string, Field>
+
+const dataPoints = {
+  letterId: {
+    key: 'letterId',
+    valueType: 'number',
+  },
+} satisfies Record<string, DataPointDefinition>
+
+export const postLetter: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'postLetter',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Post letter',
+  description: "Post a letter using Elation's patient API.",
+  fields,
+  previewable: true,
+  dataPoints,
+  onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
+    try {
+      const {
+        patientId,
+        practiceId,
+        referralOrderId,
+        subject,
+        body,
+        contactId,
+        letterType,
+      } = payload.fields
+
+      const letter = letterSchema.parse({
+        patientId,
+        practiceId,
+        referralOrderId,
+        subject,
+        body,
+        contactId,
+        letterType,
+      })
+
+      const api = makeAPIClient(payload.settings)
+      const { id } = await api.postNewLetter(letter)
+      await onComplete({
+        data_points: {
+          letterId: String(id),
+        },
+      })
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const error = fromZodError(err)
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: error.message },
+              error: {
+                category: 'WRONG_INPUT',
+                message: error.message,
+              },
+            },
+          ],
+        })
+      } else if (err instanceof AxiosError) {
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: {
+                en: `${err.status ?? '(no status code)'} Error: ${err.message}`,
+              },
+              error: {
+                category: 'SERVER_ERROR',
+                message: `${err.status ?? '(no status code)'} Error: ${
+                  err.message
+                }`,
+              },
+            },
+          ],
+        })
+      } else {
+        const message = (err as Error).message
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: message },
+              error: {
+                category: 'SERVER_ERROR',
+                message,
+              },
+            },
+          ],
+        })
+      }
+    }
+  },
+}

--- a/extensions/elation/client.ts
+++ b/extensions/elation/client.ts
@@ -27,6 +27,7 @@ import {
   type NonVisitNoteInput,
   type NonVisitNoteResponse,
 } from './types/nonVisitNote'
+import { type PostLetterInput, type PostLetterResponse } from './types/letter'
 
 export class ElationDataWrapper extends DataWrapper {
   public async getAppointment(id: number): Promise<AppointmentResponse> {
@@ -173,6 +174,14 @@ export class ElationDataWrapper extends DataWrapper {
       url: `/non_visit_notes/${id}`,
     })
   }
+
+  public async postLetter(obj: PostLetterInput): Promise<PostLetterResponse> {
+    return await this.Request({
+      method: 'POST',
+      url: '/letters',
+      data: obj,
+    })
+  }
 }
 
 interface ElationAPIClientConstructorProps {
@@ -286,6 +295,12 @@ export class ElationAPIClient extends APIClient<ElationDataWrapper> {
     await this.FetchData(async (dw) => {
       await dw.deleteNonVisitNote(id)
     })
+  }
+
+  public async postNewLetter(
+    obj: PostLetterInput
+  ): Promise<PostLetterResponse> {
+    return await this.FetchData(async (dw) => await dw.postLetter(obj))
   }
 }
 

--- a/extensions/elation/types/letter.ts
+++ b/extensions/elation/types/letter.ts
@@ -1,0 +1,8 @@
+import { type z } from 'zod'
+import { type letterSchema } from '../validation/letter.zod'
+
+export type PostLetterInput = z.infer<typeof letterSchema>
+
+export interface PostLetterResponse extends PostLetterInput {
+  id: number
+}

--- a/extensions/elation/validation/letter.zod.ts
+++ b/extensions/elation/validation/letter.zod.ts
@@ -1,5 +1,5 @@
 import { NumericIdSchema } from '@awell-health/extensions-core'
-import { isEmpty } from 'lodash'
+import { isNil } from 'lodash'
 import * as z from 'zod'
 
 // All values taken from Elation's API
@@ -20,15 +20,12 @@ export const letterSchema = z
     practice: NumericIdSchema,
     body: z.string(),
     send_to_contact: contactSchema,
-    subject: z.string().optional().nullable(),
+    subject: z.string().nonempty().optional().nullable(),
     referral_order: NumericIdSchema.optional().nullable(),
     letter_type: letterTypeEnum.default(letterTypeEnum.enum.provider),
   })
+  .strict()
   // subject and referral_order cannot be empty at the same time
-  .refine((data) => isEmpty(data.subject) && isEmpty(data.referral_order), {
+  .refine((input) => !(isNil(input.subject) && isNil(input.referral_order)), {
     message: "One of either 'subject' or 'referral order' is required.",
-  })
-  // subject and referral_order cannot be non-empty at the same time
-  .refine((data) => !isEmpty(data.subject) && !isEmpty(data.referral_order), {
-    message: "Either 'subject' or 'referral order' is required, but not both.",
   })

--- a/extensions/elation/validation/letter.zod.ts
+++ b/extensions/elation/validation/letter.zod.ts
@@ -1,0 +1,34 @@
+import { NumericIdSchema } from '@awell-health/extensions-core'
+import { isEmpty } from 'lodash'
+import * as z from 'zod'
+
+// All values taken from Elation's API
+const letterTypeEnum = z.enum([
+  'patient_initiated',
+  'patient',
+  'referral',
+  'provider',
+])
+
+export const contactSchema = z.object({
+  id: NumericIdSchema,
+})
+
+export const letterSchema = z
+  .object({
+    patient: NumericIdSchema,
+    practice: NumericIdSchema,
+    body: z.string(),
+    send_to_contact: contactSchema,
+    subject: z.string().optional().nullable(),
+    referral_order: NumericIdSchema.optional().nullable(),
+    letter_type: letterTypeEnum.default(letterTypeEnum.enum.provider),
+  })
+  // subject and referral_order cannot be empty at the same time
+  .refine((data) => isEmpty(data.subject) && isEmpty(data.referral_order), {
+    message: "One of either 'subject' or 'referral order' is required.",
+  })
+  // subject and referral_order cannot be non-empty at the same time
+  .refine((data) => !isEmpty(data.subject) && !isEmpty(data.referral_order), {
+    message: "Either 'subject' or 'referral order' is required, but not both.",
+  })


### PR DESCRIPTION
# Post letter action

## Description

The action is used to post a draft letter using Elation API to a provider or a patient.
The action uses this[ API endpoint](https://docs.elationhealth.com/reference/post-letter) to post a letter.

## Input Fields

### Patient ID
- **Label:** Patient ID
- **Description:** ID of the patient
- **Required:** Yes

### Practice ID
- **Label:** Practice
- **Description:** ID of a Practice
- **Required:** Yes

### Referral Order ID
- **Label:** Referral Order ID
- **Description:** ID of the Referral Order (Not needed with subject)
- **Required:** No

### Subject
- **Label:** Subject
- **Description:** Subject of the letter (Not needed with referral order)
- **Required:** No

### Body
- **Label:** Body
- **Description:** Body of the letter
- **Required:** Yes

### Contact ID
- **Label:** Contact ID
- **Description:** ID of the contact whom you want to send this letter
- **Required:** Yes

### Type of Letter
- **Label:** Type of letter
- **Description:** Type of letter. Defaults to "provider". The type can be one of the following: "patient", "referral", "provider" or "patient_initiated".
- **Required:** No

## Data points

### ID of the Letter
- **Type:** number
- **Usage:** Can be used to further update or reference it in the care-flow