### PR TITLE
fix(elation): make document date a datetime field in 'Create Lab Order' action in elation extension

### DIFF
--- a/extensions/elation/validation/labOrder.zod.ts
+++ b/extensions/elation/validation/labOrder.zod.ts
@@ -1,4 +1,4 @@
-import { DateOnlySchema, NumericIdSchema } from '@awell-health/extensions-core'
+import { DateTimeSchema, NumericIdSchema } from '@awell-health/extensions-core'
 import * as z from 'zod'
 
 const testSchema = z.object({
@@ -34,7 +34,7 @@ export const labOrderSchema = z
   .object({
     practice: NumericIdSchema,
     patient: NumericIdSchema,
-    document_date: DateOnlySchema,
+    document_date: DateTimeSchema,
     ordering_physician: NumericIdSchema,
     vendor: NumericIdSchema.optional(),
     content: jsonParseableContentSchema.refine(


### PR DESCRIPTION
The document date field should be ISO stringified date with timezone. The Zod schema converted the date into date only value which throws an error in Elation API.