### PR TITLE
TP-1689-remove-update-baseline-datapoints-action-from-cases

### DIFF
--- a/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
+++ b/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
@@ -18,7 +18,7 @@ export const updateBaselineInfo: Action<typeof fields, typeof settings> = {
     'Update some (or all) of the baseline datapoints for the patient currently enrolled in the care flow.',
   fields,
   dataPoints,
-  previewable: true,
+  previewable: false,
   onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
     const {
       settings: { apiUrl, apiKey },


### PR DESCRIPTION
The extension server tried to execute mutation `UpdateBaselineInfo` in orchestration for cases which throws not authorized error as the care flow only exists in design. 
Where the extension is executed is determined by the URL passed in settings which is the orchestration URL. Also, the mutation does not exist in Design Api