### PR TITLE
fix(awell-extension): Fix awell extension mutations when using SDK

### DIFF
--- a/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
+++ b/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
@@ -36,6 +36,8 @@ export const stopCareFlow: Action<typeof fields, typeof settings> = {
             reason,
           },
         },
+        code: true,
+        success: true
       },
     })
 

--- a/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
+++ b/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
@@ -40,6 +40,8 @@ export const updateBaselineInfo: Action<typeof fields, typeof settings> = {
             baseline_info: baselineInfo,
           },
         },
+        code: true,
+        success: true
       },
     })
 


### PR DESCRIPTION
Fix awell extension mutations for stopCareLow and updateBaselineInfo - we must specify returning values otherwise the graphql mutation is going to be invalid