### PR TITLE
awell pathway id into salesforce

### DIFF
--- a/extensions/sfdc/actions/createLead/config/fields.ts
+++ b/extensions/sfdc/actions/createLead/config/fields.ts
@@ -9,6 +9,14 @@ export const fields = {
     type: FieldType.JSON,
     required: true,
   },
+  careFlowIdField: {
+    id: 'careFlowIdField',
+    label: 'Care Flow ID Field',
+    description:
+      'The field name in Salesforce that contains the Care Flow ID. If left blank, the Care Flow ID will not be included in the update.',
+    type: FieldType.STRING,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
@@ -44,4 +52,5 @@ export const FieldsValidationSchema = z.object({
       }
     )
     .pipe(z.record(z.unknown())),
+  careFlowIdField: z.string().optional(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/sfdc/actions/createLead/createLead.test.ts
+++ b/extensions/sfdc/actions/createLead/createLead.test.ts
@@ -24,7 +24,7 @@ describe('Salesforce - Create Lead', () => {
           Phone: '123-456-7890',
           Status: 'New',
         }),
-      },
+      } as any,
       settings: mockSettings,
     })
 


### PR DESCRIPTION
### **User description**
currently there is no way to include a special pathway id datapoint to send to salesforce. we're adding this concept manually as a temporary fix


___

### **PR Type**
enhancement


___

### **Description**
- Added support for including a Care Flow ID when creating a lead in Salesforce.
- Introduced a new optional field `careFlowIdField` to specify the Salesforce field for the Care Flow ID.
- Updated the lead creation logic to conditionally include the Care Flow ID based on the presence of `careFlowIdField`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add Care Flow ID Field to Lead Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/sfdc/actions/createLead/config/fields.ts

<li>Added a new field <code>careFlowIdField</code> to the fields configuration.<br> <li> Updated the <code>FieldsValidationSchema</code> to include <code>careFlowIdField</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/472/files#diff-166ff4ebd436c8fe6f8e325aae736494a96da8cdae5f3a6fe3bd6ece52457300">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>createLead.ts</strong><dd><code>Integrate Care Flow ID into Lead Creation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/sfdc/actions/createLead/createLead.ts

<li>Imported <code>isNil</code> from lodash.<br> <li> Integrated <code>careFlowIdField</code> into the lead creation logic.<br> <li> Modified data structure to include Care Flow ID if specified.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/472/files#diff-07869a9f71c0919d2959faa4c8e5e03b49f312998a9b418d041916347c56e40c">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information