### PR TITLE
fix(healthie): retry getSetPasswordLink using exponential backoff 

### DIFF
--- a/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.test.ts
+++ b/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.test.ts
@@ -6,6 +6,7 @@ import { getSetPasswordLink as actionInterface } from '.'
 jest.mock('@extensions/healthie/lib/sdk/genql', () => ({
   HealthieSdk: jest.fn().mockImplementation(() => ({
     client: {
+      mutation: jest.fn(),
       query: jest.fn().mockResolvedValue({
         user: {
           set_password_link:
@@ -19,6 +20,8 @@ jest.mock('@extensions/healthie/lib/sdk/genql', () => ({
 const mockedHealthieSdk = jest.mocked(HealthieSdk)
 
 describe('Healthie - Get password link', () => {
+  let mockedClient: any
+
   const {
     extensionAction: action,
     onComplete,
@@ -29,6 +32,10 @@ describe('Healthie - Get password link', () => {
 
   beforeEach(() => {
     clearMocks()
+    mockedClient = {
+      query: jest.fn(),
+      mutation: jest.fn(),
+    }
   })
 
   test('Should call onComplete', async () => {
@@ -49,6 +56,47 @@ describe('Healthie - Get password link', () => {
     })
 
     expect(mockedHealthieSdk).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        setPasswordLink:
+          'https://securestaging.gethealthie.com/set_initial_password?signup_token=some-token',
+      },
+    })
+  })
+
+  test('Should retry if set_password_link is null and succeed after retries', async () => {
+    // Mock the SDK to return null for the first two attempts, and succeed on the third attempt
+    mockedClient.query
+      .mockResolvedValueOnce({ user: { set_password_link: null } }) // First attempt
+      .mockResolvedValueOnce({ user: { set_password_link: null } }) // Second attempt
+      .mockResolvedValueOnce({
+        user: {
+          set_password_link:
+            'https://securestaging.gethealthie.com/set_initial_password?signup_token=some-token',
+        },
+      }) // Third attempt
+    ;(HealthieSdk as jest.Mock).mockImplementationOnce(() => ({
+      client: mockedClient,
+    }))
+
+    await action.onEvent({
+      payload: {
+        ...testPayload,
+        fields: {
+          healthiePatientId: '453019',
+        },
+        settings: {
+          apiUrl: 'https://staging-api.gethealthie.com/graphql',
+          apiKey: 'apiKey',
+        },
+      },
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    // Ensure the query was called 3 times and succeeded on the third attempt
+    expect(mockedClient.query).toHaveBeenCalledTimes(3)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         setPasswordLink:

--- a/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.ts
+++ b/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.ts
@@ -3,6 +3,7 @@ import { Category } from '@awell-health/extensions-core'
 import { type settings } from '../../settings'
 import { fields, FieldsValidationSchema, dataPoints } from './config'
 import { validatePayloadAndCreateSdk } from '../../lib/sdk/validatePayloadAndCreateSdk'
+import { isNil } from 'lodash'
 
 export const getSetPasswordLink: Action<typeof fields, typeof settings> = {
   key: 'getSetPasswordLink',
@@ -13,27 +14,47 @@ export const getSetPasswordLink: Action<typeof fields, typeof settings> = {
   previewable: false,
   dataPoints,
   onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
+    const MAX_RETRIES = 3
+    const BASE_DELAY_MS = process.env.NODE_ENV === 'test' ? 10 : 1000
+
     const { fields, healthieSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
     })
 
-    const res = await healthieSdk.client.query({
-      user: {
-        __args: {
-          id: fields.healthiePatientId,
+    let setPasswordLink: string | undefined
+
+    /**
+     * We need to retry the API call because:
+     * - The setPasswordLink field is not immediately available after creating a new user.
+     * - The API response is inconsistent
+     */
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      const res = await healthieSdk.client.query({
+        user: {
+          __args: {
+            id: fields.healthiePatientId,
+          },
+          set_password_link: true,
         },
-        set_password_link: true,
-      },
-    })
+      })
+
+      if (!isNil(res.user?.set_password_link)) {
+        setPasswordLink = String(res.user?.set_password_link)
+        break
+      }
+
+      // Exponential backoff delay calculation
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
 
     await onComplete({
       data_points: {
         setPasswordLink:
-          res.user?.set_password_link === undefined ||
-          res.user?.set_password_link === null
+          setPasswordLink === undefined || setPasswordLink === null
             ? undefined
-            : String(res.user.set_password_link),
+            : String(setPasswordLink),
       },
     })
   },


### PR DESCRIPTION
### **User description**
Context here: https://linear.app/awell/issue/TP-2564/investigate-failure-of-get-set-password-link-healthie-action


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Implemented retry logic with exponential backoff in the `getSetPasswordLink` action to handle null responses from the API.
- Added a test case to verify the retry mechanism, ensuring that the query is retried up to three times and succeeds on the third attempt.
- Utilized lodash's `isNil` for checking null or undefined values, improving code readability and reliability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getSetPasswordLink.test.ts</strong><dd><code>Add test for retry logic in getSetPasswordLink action</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.test.ts

<li>Added a new test to verify retry logic when <code>set_password_link</code> is null.<br> <li> Mocked SDK to simulate retry behavior.<br> <li> Ensured query is called three times and succeeds on the third attempt.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/485/files#diff-c8386ddfc229311ed6d2e275ff9a26279eea2b1eb4996e7e8673bf143efb66ee">+48/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getSetPasswordLink.ts</strong><dd><code>Implement retry logic with exponential backoff in getSetPasswordLink</code></dd></summary>
<hr>

extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.ts

<li>Implemented retry logic with exponential backoff for API calls.<br> <li> Used lodash's <code>isNil</code> to check for null or undefined values.<br> <li> Introduced constants for maximum retries and base delay.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/485/files#diff-e99f8b76ad2604e65446827665773d1a6b47882b344ec39b8f0a27c16a81c093">+31/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information