### PR TITLE
TP-2574: add location as a new data point in "get booking" action in cal.com

### DIFF
--- a/extensions/calDotCom/actions/getBooking/config/dataPoints.ts
+++ b/extensions/calDotCom/actions/getBooking/config/dataPoints.ts
@@ -49,6 +49,10 @@ export const dataPoints = {
     key: 'userEmail',
     valueType: 'string',
   },
+  location: {
+    key: 'location',
+    valueType: 'string',
+  },
   // Note: This data point can indeed have a null value in response to a 200, as opposed to other data points that will hold a definite value. If the user intends to utilize this value, they can verify if it's empty and/or opt to use a fallback value in a dynamic variable.
   videoCallUrl: {
     key: 'videoCallUrl',

--- a/extensions/calDotCom/actions/getBooking/getBooking.test.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.test.ts
@@ -95,7 +95,7 @@ describe('Cal.com GetBooking action', () => {
     let metadata: Booking['metadata']
     let user: User
     let attendees: User[]
-    let location: string
+    let responses: Booking['responses']
 
     beforeEach(() => {
       eventTypeId = faker.number.int()
@@ -104,7 +104,11 @@ describe('Cal.com GetBooking action', () => {
       startTime = faker.date.anytime().toISOString()
       endTime = faker.date.anytime().toISOString()
       status = faker.string.sample()
-      location = faker.location.country()
+      responses = {
+        location: {
+          value: 'inPerson',
+        },
+      }
       id = faker.number.int()
       uid = faker.string.uuid()
       metadata = {
@@ -138,7 +142,7 @@ describe('Cal.com GetBooking action', () => {
           metadata,
           user,
           attendees,
-          location,
+          responses,
         })
     })
 
@@ -171,7 +175,7 @@ describe('Cal.com GetBooking action', () => {
           videoCallUrl: metadata.videoCallUrl,
           firstAttendeeEmail: attendees[0].email,
           firstAttendeeTimezone: attendees[0].timeZone,
-          location,
+          location: 'inPerson',
           firstAttendeeName: attendees[0].name,
           userEmail: user.email,
         },

--- a/extensions/calDotCom/actions/getBooking/getBooking.test.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.test.ts
@@ -95,6 +95,7 @@ describe('Cal.com GetBooking action', () => {
     let metadata: Booking['metadata']
     let user: User
     let attendees: User[]
+    let location: string
 
     beforeEach(() => {
       eventTypeId = faker.number.int()
@@ -103,6 +104,7 @@ describe('Cal.com GetBooking action', () => {
       startTime = faker.date.anytime().toISOString()
       endTime = faker.date.anytime().toISOString()
       status = faker.string.sample()
+      location = faker.location.country()
       id = faker.number.int()
       uid = faker.string.uuid()
       metadata = {
@@ -136,6 +138,7 @@ describe('Cal.com GetBooking action', () => {
           metadata,
           user,
           attendees,
+          location,
         })
     })
 
@@ -168,6 +171,7 @@ describe('Cal.com GetBooking action', () => {
           videoCallUrl: metadata.videoCallUrl,
           firstAttendeeEmail: attendees[0].email,
           firstAttendeeTimezone: attendees[0].timeZone,
+          location,
           firstAttendeeName: attendees[0].name,
           userEmail: user.email,
         },

--- a/extensions/calDotCom/actions/getBooking/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.ts
@@ -44,6 +44,7 @@ export const getBooking: Action<typeof fields, typeof settings> = {
           firstAttendeeTimezone: booking.attendees[0].timeZone,
           firstAttendeeName: booking.attendees[0].name,
           userEmail: booking.user.email,
+          location: booking.location,
         },
       })
     } catch (error) {

--- a/extensions/calDotCom/actions/getBooking/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking/getBooking.ts
@@ -44,7 +44,7 @@ export const getBooking: Action<typeof fields, typeof settings> = {
           firstAttendeeTimezone: booking.attendees[0].timeZone,
           firstAttendeeName: booking.attendees[0].name,
           userEmail: booking.user.email,
-          location: booking.location,
+          location: booking.responses?.location?.value,
         },
       })
     } catch (error) {

--- a/extensions/calDotCom/schema.ts
+++ b/extensions/calDotCom/schema.ts
@@ -26,7 +26,18 @@ export const BookingSchema = z.object({
   user: UserSchema,
   attendees: z.array(UserSchema),
   metadata: z.object({ videoCallUrl: z.string().optional() }),
-  location: z.string(),
+  responses: z
+    .object({
+      email: z.string().optional(),
+      name: z.string().optional(),
+      location: z
+        .object({
+          optionValue: z.string().optional(),
+          value: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 })
 
 export const GetBookingResponseSchema = z.object({

--- a/extensions/calDotCom/schema.ts
+++ b/extensions/calDotCom/schema.ts
@@ -26,6 +26,7 @@ export const BookingSchema = z.object({
   user: UserSchema,
   attendees: z.array(UserSchema),
   metadata: z.object({ videoCallUrl: z.string().optional() }),
+  location: z.string(),
 })
 
 export const GetBookingResponseSchema = z.object({


### PR DESCRIPTION
### **User description**
Context: https://linear.app/awell/issue/TP-2574/add-location-as-a-new-data-point-in-get-booking-action-in-calcom

This PR implements the following object in the response, from this [API documentation](https://cal.com/docs/api-reference/v1/bookings/find-a-booking).

<img width="499" alt="Screenshot 2024-10-17 at 2 17 47 PM" src="https://github.com/user-attachments/assets/7852cbcb-e4d5-4c47-b19e-c27e0b5f6aeb">


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added a new `location` data point to the `getBooking` action configuration.
- Updated the `BookingSchema` to include `responses` with an optional `location` field.
- Modified the `getBooking` action to include `location` in the response object.
- Enhanced tests to verify the inclusion of `location` in booking responses.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataPoints.ts</strong><dd><code>Add location data point to booking configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/calDotCom/actions/getBooking/config/dataPoints.ts

- Added a new data point `location` with `valueType` as `string`.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/488/files#diff-ed44f1002bef0f8de91b67499cb5f926ef4ccc9551f52f394736f768d4d92686">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>getBooking.ts</strong><dd><code>Add location to booking response object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/calDotCom/actions/getBooking/getBooking.ts

- Included `location` in the booking response object.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/488/files#diff-c140abe7405480eb229cf33ef25267c77eb67daa3a26b6c2062fac95c8525d31">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Extend BookingSchema to include location in responses</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/calDotCom/schema.ts

<li>Extended <code>BookingSchema</code> to include optional <code>responses</code> with <code>location</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/488/files#diff-4df4672a505f042510f7119829b601754be675eb1202cda806d686bd91a2ffcf">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getBooking.test.ts</strong><dd><code>Update tests to include location data point</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/calDotCom/actions/getBooking/getBooking.test.ts

<li>Introduced <code>responses</code> variable in test setup.<br> <li> Added <code>location</code> to mock responses in tests.<br> <li> Verified <code>location</code> in test assertions.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/488/files#diff-30de40fd600ba513b3b16e29fd17f269e24766b9de370b55c7bb6852fc5eeb9d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information