### PR TITLE
feat(gridspace): complete uploadContactToCampaign activity after api call

### DIFF
--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.test.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.test.ts
@@ -58,6 +58,6 @@ describe('uploadContactToCampaign', () => {
       ],
     })
 
-    expect(onComplete).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalled()
   })
 })

--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
@@ -13,7 +13,7 @@ export const uploadContactToCampaign = {
   fields,
   dataPoints,
   previewable: false,
-  onEvent: async ({ payload }) => {
+  onEvent: async ({ payload, onComplete }) => {
     const { pathway, patient, activity } = payload
     const {
       fields: { campaignId, data, phoneNumber },
@@ -45,6 +45,14 @@ export const uploadContactToCampaign = {
 
     await client.uploadContactsToCampaign(campaignId, requestBody)
 
-    // No need to call onComplete since Gridspace will complete the activity later
+    await onComplete({
+      events: [
+        {
+          date: new Date().toISOString(),
+          text: { en: `Contact uploaded to campaign ${campaignId}` },
+        },
+      ],
+      data_points: {},
+    })
   },
 } satisfies Action<typeof fields, typeof settings>


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `uploadContactToCampaign` action to call the `onComplete` callback after successfully uploading contacts to a campaign.
- Updated the test case to verify that the `onComplete` function is called, ensuring the completion of the activity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uploadContactToCampaign.test.ts</strong><dd><code>Update test to verify `onComplete` invocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.test.ts

- Modified test to expect `onComplete` to be called.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/489/files#diff-0cad18d8b57d351295ec755ce6a701ecb77c75a0d15b87b4038be43fea486c4f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uploadContactToCampaign.ts</strong><dd><code>Implement `onComplete` callback after contact upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts

<li>Added <code>onComplete</code> parameter to <code>onEvent</code> function.<br> <li> Implemented <code>onComplete</code> call after uploading contacts.<br> <li> Added event logging for contact upload completion.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/489/files#diff-ba1ff1bbb402ccefdac34cc11ee2da6a4ed9447ab3d730ed9c80e274f465fe09">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information