### PR TITLE
TP-2606: update gridspace uploadContactTocampaign action to return data poitn

### DIFF
--- a/extensions/gridspace/actions/uploadContactToCampaign/config.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/config.ts
@@ -38,6 +38,10 @@ export const dataPoints = {
     key: 'data',
     valueType: 'json',
   },
+  num_uploaded_contacts: {
+    key: 'num_uploaded_contacts',
+    valueType: 'number',
+  },
 } satisfies Record<string, DataPointDefinition>
 
 export const FieldsSchema = z.object({

--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.test.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.test.ts
@@ -58,6 +58,6 @@ describe('uploadContactToCampaign', () => {
       ],
     })
 
-    expect(onComplete).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalled()
   })
 })

--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
@@ -43,7 +43,24 @@ export const uploadContactToCampaign = {
       contact_rows: [contactRow],
     }
 
-    await client.uploadContactsToCampaign(campaignId, requestBody)
+    const { num_uploaded_contacts = 0 } = await client.uploadContactsToCampaign(
+      campaignId,
+      requestBody
+    )
+
+    if (num_uploaded_contacts === 0) {
+      await onComplete({
+        events: [
+          {
+            date: new Date().toISOString(),
+            text: { en: `Contact was NOT uploaded to campaign ${campaignId}` },
+          },
+        ],
+        data_points: {
+          num_uploaded_contacts: String(num_uploaded_contacts),
+        },
+      })
+    }
 
     await onComplete({
       events: [
@@ -52,7 +69,9 @@ export const uploadContactToCampaign = {
           text: { en: `Contact uploaded to campaign ${campaignId}` },
         },
       ],
-      data_points: {},
+      data_points: {
+        num_uploaded_contacts: String(num_uploaded_contacts),
+      },
     })
   },
 } satisfies Action<typeof fields, typeof settings>

--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
@@ -13,7 +13,7 @@ export const uploadContactToCampaign = {
   fields,
   dataPoints,
   previewable: false,
-  onEvent: async ({ payload }) => {
+  onEvent: async ({ payload, onComplete }) => {
     const { pathway, patient, activity } = payload
     const {
       fields: { campaignId, data, phoneNumber },
@@ -45,6 +45,14 @@ export const uploadContactToCampaign = {
 
     await client.uploadContactsToCampaign(campaignId, requestBody)
 
-    // No need to call onComplete since Gridspace will complete the activity later
+    await onComplete({
+      events: [
+        {
+          date: new Date().toISOString(),
+          text: { en: `Contact uploaded to campaign ${campaignId}` },
+        },
+      ],
+      data_points: {},
+    })
   },
 } satisfies Action<typeof fields, typeof settings>

--- a/extensions/gridspace/lib/client.ts
+++ b/extensions/gridspace/lib/client.ts
@@ -1,4 +1,9 @@
 import axios, { type AxiosInstance } from 'axios'
+
+interface UploadContactToCampaignResponse {
+  num_uploaded_contacts: number
+}
+
 export class GridspaceClient {
   private readonly client: AxiosInstance
 
@@ -29,7 +34,10 @@ export class GridspaceClient {
     return resp.data
   }
 
-  async uploadContactsToCampaign(campaignId: string, data: any): Promise<any> {
+  async uploadContactsToCampaign(
+    campaignId: string,
+    data: any
+  ): Promise<UploadContactToCampaignResponse> {
     const response = await this.client.post(
       `/autodialer/${campaignId}/dialees`,
       data


### PR DESCRIPTION
Context: https://linear.app/awell/issue/TP-2606/update-gridspace-uploadcontacttocampaign-action-to-return-num-uploaded

See response of this API call: https://gridspace.stoplight.io/docs/monophone/mm37fjyb66m01-upload-contacts-to-campaign