### PR TITLE
TP-2617: extend create appointment action

### DIFF
--- a/extensions/healthie/actions/createAppointment/config/fields.ts
+++ b/extensions/healthie/actions/createAppointment/config/fields.ts
@@ -42,6 +42,21 @@ export const fields = {
     type: FieldType.DATE,
     required: true,
   },
+  notes: {
+    id: 'notes',
+    label: 'Notes',
+    description: 'Any notes you want to add to the appointment.',
+    type: FieldType.TEXT,
+    required: false,
+  },
+  externalVideochatUrl: {
+    id: 'externalVideochatUrl',
+    label: 'External video chat URL',
+    description:
+      'When passed in, this video chat URL will be used instead of built-in Video Chat or Zoom.',
+    type: FieldType.STRING,
+    required: false,
+  },
   metadata: {
     id: 'metadata',
     label: 'Metadata',
@@ -57,6 +72,14 @@ export const FieldsValidationSchema = z.object({
   contactTypeId: z.string().min(1),
   appointmentTypeId: z.string().min(1),
   datetime: DateTimeSchema,
+  notes: z.string().optional(),
+  externalVideochatUrl: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (isEmpty(val)) return undefined
+      return val
+    }),
   metadata: z
     .string()
     .optional()

--- a/extensions/healthie/actions/createAppointment/createAppointment.test.ts
+++ b/extensions/healthie/actions/createAppointment/createAppointment.test.ts
@@ -1,47 +1,81 @@
 import { generateTestPayload } from '../../../../src/tests'
-import { getSdk } from '../../lib/sdk/graphql-codegen/generated/sdk'
-import {
-  mockGetSdk,
-  mockGetSdkReturn,
-} from '../../lib/sdk/graphql-codegen/generated/__mocks__/sdk'
-import { createAppointment } from '.'
+import { HealthieSdk } from '@extensions/healthie/lib/sdk/genql'
+import { createAppointment as actionInterface } from '.'
+import { TestHelpers } from '@awell-health/extensions-core'
 
-jest.mock('../../lib/sdk/graphql-codegen/generated/sdk')
-jest.mock('../../lib/sdk/graphql-codegen/graphqlClient')
+const mockedMutationResponse = jest.fn().mockResolvedValue({
+  createAppointment: {
+    appointment: {
+      id: 'appointment-id-1',
+    },
+  },
+})
 
-describe('Create appointment action', () => {
-  const onComplete = jest.fn()
-  const onError = jest.fn()
+jest.mock('@extensions/healthie/lib/sdk/genql', () => ({
+  HealthieSdk: jest.fn().mockImplementation(() => ({
+    client: {
+      mutation: mockedMutationResponse,
+    },
+  })),
+}))
 
-  beforeAll(() => {
-    ;(getSdk as jest.Mock).mockImplementation(mockGetSdk)
-  })
+const mockedHealthieSdk = jest.mocked(HealthieSdk)
+
+describe('Healthie - Create appointment', () => {
+  const {
+    extensionAction: action,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(actionInterface)
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    clearMocks()
   })
 
   test('Should create an appointment', async () => {
-    await createAppointment.onActivityCreated!(
-      generateTestPayload({
+    await action.onEvent({
+      payload: generateTestPayload({
         fields: {
           patientId: 'a-patient-id',
           otherPartyId: 'other-party-id',
           contactTypeId: 'contact-type-id',
           appointmentTypeId: 'appointment-type-id',
           datetime: '2024-07-09T07:49:38Z',
+          notes: 'Test appointment\nNew line\n\nDouble enter after new line',
+          externalVideochatUrl: 'https://example.com',
           metadata: JSON.stringify({ hello: 'world' }),
         },
         settings: {
+          apiUrl: 'https://staging-api.gethealthie.com/graphql',
           apiKey: 'apiKey',
-          apiUrl: 'test-url',
         },
       }),
       onComplete,
-      onError
-    )
+      onError,
+      helpers,
+    })
 
-    expect(mockGetSdkReturn.createAppointment).toHaveBeenCalled()
+    expect(mockedHealthieSdk).toHaveBeenCalled()
+    expect(mockedMutationResponse).toHaveBeenCalledWith({
+      createAppointment: {
+        __args: {
+          input: {
+            appointment_type_id: 'appointment-type-id',
+            contact_type: 'contact-type-id',
+            other_party_id: 'other-party-id',
+            datetime: '2024-07-09T07:49:38Z',
+            user_id: 'a-patient-id',
+            metadata: '{"hello":"world"}',
+            notes: 'Test appointment\nNew line\n\nDouble enter after new line',
+            external_videochat_url: 'https://example.com',
+          },
+        },
+        appointment: expect.any(Object),
+      },
+    })
+
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         appointmentId: 'appointment-id-1',

--- a/extensions/healthie/actions/createAppointment/lib/errors.ts
+++ b/extensions/healthie/actions/createAppointment/lib/errors.ts
@@ -1,0 +1,29 @@
+import { type ActivityEvent } from '@awell-health/extensions-core'
+
+export class HealthieAppointmentNotCreated extends Error {
+  errors: Record<string, unknown>
+
+  constructor(errors: Record<string, unknown>) {
+    super('Failed to create the appointment in Healthie.')
+    this.name = 'HealthieAppointmentNotCreated'
+    this.errors = errors
+  }
+}
+
+export const parseHealthieAppointmentNotCreatedError = (
+  error: Record<string, unknown>
+): ActivityEvent => {
+  const category = 'BAD_REQUEST'
+  const message = JSON.stringify(error, null, 2)
+
+  return {
+    date: new Date().toISOString(),
+    text: {
+      en: message,
+    },
+    error: {
+      category,
+      message,
+    },
+  }
+}


### PR DESCRIPTION
### **PR Type**
enhancement, tests, error handling


___

### **Description**
- Extended the create appointment action to include `notes` and `externalVideochatUrl` fields.
- Updated the validation schema to support the new fields.
- Refactored the action to use `onEvent` and improved error handling.
- Enhanced tests to cover the new fields and refactored to use `HealthieSdk` and `TestHelpers`.
- Introduced specific error handling for appointment creation failures.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add notes and external video chat URL fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createAppointment/config/fields.ts

<li>Added <code>notes</code> and <code>externalVideochatUrl</code> fields to the appointment <br>configuration.<br> <li> Updated validation schema to include new fields.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/495/files#diff-de5b7d6e2ee5ad51c9382d929472662148a511ef98cde28cc64962c1ab524b5b">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>createAppointment.ts</strong><dd><code>Refactor and enhance create appointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createAppointment/createAppointment.ts

<li>Refactored to use <code>onEvent</code> instead of <code>onActivityCreated</code>.<br> <li> Integrated error handling for appointment creation.<br> <li> Included new fields in the appointment creation process.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/495/files#diff-25b1919a6d9b815d6a98396a9055fb269d89db5709e860c2189d47f34b8a62bc">+55/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createAppointment.test.ts</strong><dd><code>Update tests for create appointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createAppointment/createAppointment.test.ts

<li>Updated test setup to use <code>HealthieSdk</code> and <code>TestHelpers</code>.<br> <li> Added tests for new fields <code>notes</code> and <code>externalVideochatUrl</code>.<br> <li> Verified mutation response and onComplete callback.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/495/files#diff-20dfa1aca51d260652520870e7606513aecdb25a5d97c753437279900c0e6b48">+58/-24</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.ts</strong><dd><code>Add error handling for appointment creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createAppointment/lib/errors.ts

<li>Introduced <code>HealthieAppointmentNotCreated</code> error class.<br> <li> Added function to parse appointment creation errors.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/495/files#diff-8a883c9b7de22b618be2a8e779e5aab8c25b18174332ae7a378ab093f8a65e05">+29/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information