### PR TITLE
feat(healthie): add frozen attribute in the pushFormResponseToHealthie action

### DIFF
--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
@@ -16,9 +16,18 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
+  freezeResponse: {
+    id: 'freezeResponse',
+    label: 'Freeze Response',
+    description:
+      'Indicates whether the form response should be frozen in Healthie.',
+    type: FieldType.BOOLEAN,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
+  freezeResponse: z.boolean().default(false),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts
@@ -101,4 +101,38 @@ describe('pushFormResponseToHealthie', () => {
       events: [],
     })
   })
+
+  test('Should call onComplete with frozen set', async () => {
+    await action.onEvent({
+      payload: {
+        pathway: {
+          id: '5eN4qWbxZGSA',
+          definition_id: 'whatever',
+        },
+        activity: { id: 'X74HeDQ4N0gtdaSEuzF8s' },
+        patient: { id: 'whatever' },
+        fields: {
+          healthiePatientId: '357883',
+          healthieFormId: '1686361',
+          freezeResponse: true,
+        },
+        settings: {
+          apiUrl: 'https://staging-api.gethealthie.com/graphql',
+          apiKey: 'apiKey',
+        },
+      },
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(mockedHealthieSdk).toHaveBeenCalled()
+    expect(helpers.awellSdk).toHaveBeenCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        formAnswerGroupId: '99999',
+      },
+      events: [],
+    })
+  })
 })

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
@@ -4,7 +4,7 @@ import { validatePayloadAndCreateSdk } from '../../../lib/sdk/validatePayloadAnd
 import { type settings } from '../../../settings'
 import { datapoints, fields, FieldsValidationSchema } from './config'
 import { getSubActivityLogs } from './logs'
-import { isEmpty } from 'lodash'
+import { defaultTo, isEmpty } from 'lodash'
 import {
   HealthieFormResponseNotCreated,
   parseHealthieFormResponseNotCreatedError,
@@ -60,13 +60,16 @@ export const pushFormResponseToHealthie: Action<
         awellFormResponse: formResponse,
       })
 
+    // indicates whether to make form values editable in Healthie
+    const frozen = defaultTo(fields.freezeResponse, false)
+
     try {
       const res = await healthieSdk.client.mutation({
         createFormAnswerGroup: {
           __args: {
             input: {
               finished: true,
-              frozen: fields.freezeResponse,
+              frozen,
               custom_module_form_id: fields.healthieFormId,
               user_id: fields.healthiePatientId,
               form_answers: healthieFormAnswerInputs.map((input) => ({

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
@@ -66,6 +66,7 @@ export const pushFormResponseToHealthie: Action<
           __args: {
             input: {
               finished: true,
+              frozen: fields.freezeResponse,
               custom_module_form_id: fields.healthieFormId,
               user_id: fields.healthiePatientId,
               form_answers: healthieFormAnswerInputs.map((input) => ({


### PR DESCRIPTION
### **User description**
**Docs:**
https://docs.gethealthie.com/schema/formanswergroup.doc

**Schema:**

```gql
type FormAnswerGroup {

  # when true, the note cannot be edited
  frozen: Boolean

}
```

---

This change adds the `frozen` flag in the mutation.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added a new `freezeResponse` field to the Healthie form configuration, allowing form responses to be optionally frozen.
- Updated the Healthie mutation request to include the `frozen` attribute based on the `freezeResponse` field.
- Added a test case to verify the correct behavior of the `freezeResponse` functionality, ensuring that the `onComplete` callback is called with the expected parameters.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add `freezeResponse` field to Healthie form configuration</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts

<li>Added a new field <code>freezeResponse</code> to the fields configuration.<br> <li> Set <code>freezeResponse</code> as a boolean type with a default value of false.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/497/files#diff-148919375f3100d5de2da3854943e1146abf7e604703a2b911ec43962d1ce3c2">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.ts</strong><dd><code>Integrate `freezeResponse` into Healthie mutation request</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts

<li>Integrated <code>freezeResponse</code> into the Healthie mutation request.<br> <li> Ensured the <code>frozen</code> attribute is set based on <code>freezeResponse</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/497/files#diff-32ba09fb213cf1d480949c274fdeb5acf3ca95f8acbfc24750a391ef7b89782b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.test.ts</strong><dd><code>Add test for `freezeResponse` functionality in Healthie integration</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts

<li>Added a test case to verify the <code>freezeResponse</code> functionality.<br> <li> Ensured <code>onComplete</code> is called with the correct parameters when <br><code>freezeResponse</code> is set.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/497/files#diff-f05a04b8e35327a20cf8f9170aed8464be7d8b79dc269f4d634fbaacf6e7a93c">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information