### PR TITLE
ET-350-extend-freeze-answer-to-responses-healthie-action

### DIFF
--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
@@ -16,9 +16,18 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
+  freezeResponse: {
+    id: 'freezeResponse',
+    label: 'Freeze Response',
+    description:
+      'Indicates whether the form response should be frozen in Healthie.',
+    type: FieldType.BOOLEAN,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
+  freezeResponse: z.boolean().default(false),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
@@ -83,6 +83,7 @@ describe('pushFormResponsesToHealthie', () => {
         fields: {
           healthiePatientId: '357883',
           healthieFormId: '1686361',
+          freezeResponse: false,
         },
         settings: {
           apiUrl: 'https://staging-api.gethealthie.com/graphql',

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
@@ -4,7 +4,7 @@ import { validatePayloadAndCreateSdk } from '../../../lib/sdk/validatePayloadAnd
 import { type settings } from '../../../settings'
 import { datapoints, fields, FieldsValidationSchema } from './config'
 import { getSubActivityLogs } from './logs'
-import { isEmpty } from 'lodash'
+import { defaultTo, isEmpty } from 'lodash'
 import {
   HealthieFormResponseNotCreated,
   parseHealthieFormResponseNotCreatedError,
@@ -67,12 +67,16 @@ export const pushFormResponsesToHealthie: Action<
       ({ omittedFormAnswers }) => omittedFormAnswers
     )
 
+    // indicates whether to make form values editable in Healthie
+    const frozen = defaultTo(fields.freezeResponse, false)
+
     try {
       const res = await healthieSdk.client.mutation({
         createFormAnswerGroup: {
           __args: {
             input: {
               finished: true,
+              frozen,
               custom_module_form_id: fields.healthieFormId,
               user_id: fields.healthiePatientId,
               form_answers: mergedHealthieFormAnswers.map((input) => ({


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a new `freezeResponse` field in the form configuration to indicate if form responses should be frozen.
- Updated the validation schema to include the `freezeResponse` field with a default value of `false`.
- Enhanced the form submission logic to handle the `freezeResponse` field, making form values editable or frozen in Healthie.
- Updated test cases to include the `freezeResponse` field, ensuring comprehensive test coverage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add `freezeResponse` field to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts

<li>Added a new field <code>freezeResponse</code> to the <code>fields</code> object.<br> <li> Updated <code>FieldsValidationSchema</code> to include <code>freezeResponse</code> with a <br>default value.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/499/files#diff-28eb5df38c706b21fbb9adcede484348b01996293b1712ba31040ef5ea8580fe">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.ts</strong><dd><code>Implement `freezeResponse` logic in form submission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts

<li>Imported <code>defaultTo</code> from lodash.<br> <li> Added logic to handle <code>freezeResponse</code> field.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/499/files#diff-5f1f9429941aa4aaf87aeefdc9eee8b03f7e74aee8841abb4b94de42ed8a3f8c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.test.ts</strong><dd><code>Update tests to include `freezeResponse` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts

- Added test data for `freezeResponse` field in test cases.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/499/files#diff-70f877268e0bccd21f879ca9fdffa30c56af7d02b35d9dd2ef4bc4fcbc5a2df5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information