### PR TITLE
the implementation is faulty and need to be reverted

### DIFF
--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
@@ -16,18 +16,9 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
-  freezeResponse: {
-    id: 'freezeResponse',
-    label: 'Freeze Response',
-    description:
-      'Indicates whether the form response should be frozen in Healthie.',
-    type: FieldType.BOOLEAN,
-    required: false,
-  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
-  freezeResponse: z.boolean().default(false),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts
@@ -114,7 +114,6 @@ describe('pushFormResponseToHealthie', () => {
         fields: {
           healthiePatientId: '357883',
           healthieFormId: '1686361',
-          freezeResponse: true,
         },
         settings: {
           apiUrl: 'https://staging-api.gethealthie.com/graphql',

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
@@ -4,7 +4,7 @@ import { validatePayloadAndCreateSdk } from '../../../lib/sdk/validatePayloadAnd
 import { type settings } from '../../../settings'
 import { datapoints, fields, FieldsValidationSchema } from './config'
 import { getSubActivityLogs } from './logs'
-import { defaultTo, isEmpty } from 'lodash'
+import { isEmpty } from 'lodash'
 import {
   HealthieFormResponseNotCreated,
   parseHealthieFormResponseNotCreatedError,
@@ -60,16 +60,12 @@ export const pushFormResponseToHealthie: Action<
         awellFormResponse: formResponse,
       })
 
-    // indicates whether to make form values editable in Healthie
-    const frozen = defaultTo(fields.freezeResponse, false)
-
     try {
       const res = await healthieSdk.client.mutation({
         createFormAnswerGroup: {
           __args: {
             input: {
               finished: true,
-              frozen,
               custom_module_form_id: fields.healthieFormId,
               user_id: fields.healthiePatientId,
               form_answers: healthieFormAnswerInputs.map((input) => ({

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
@@ -16,18 +16,9 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
-  freezeResponse: {
-    id: 'freezeResponse',
-    label: 'Freeze Response',
-    description:
-      'Indicates whether the form response should be frozen in Healthie.',
-    type: FieldType.BOOLEAN,
-    required: false,
-  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
-  freezeResponse: z.boolean().default(false),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
@@ -83,7 +83,6 @@ describe('pushFormResponsesToHealthie', () => {
         fields: {
           healthiePatientId: '357883',
           healthieFormId: '1686361',
-          freezeResponse: false,
         },
         settings: {
           apiUrl: 'https://staging-api.gethealthie.com/graphql',

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
@@ -4,7 +4,7 @@ import { validatePayloadAndCreateSdk } from '../../../lib/sdk/validatePayloadAnd
 import { type settings } from '../../../settings'
 import { datapoints, fields, FieldsValidationSchema } from './config'
 import { getSubActivityLogs } from './logs'
-import { defaultTo, isEmpty } from 'lodash'
+import { isEmpty } from 'lodash'
 import {
   HealthieFormResponseNotCreated,
   parseHealthieFormResponseNotCreatedError,
@@ -67,16 +67,12 @@ export const pushFormResponsesToHealthie: Action<
       ({ omittedFormAnswers }) => omittedFormAnswers
     )
 
-    // indicates whether to make form values editable in Healthie
-    const frozen = defaultTo(fields.freezeResponse, false)
-
     try {
       const res = await healthieSdk.client.mutation({
         createFormAnswerGroup: {
           __args: {
             input: {
               finished: true,
-              frozen,
               custom_module_form_id: fields.healthieFormId,
               user_id: fields.healthiePatientId,
               form_answers: mergedHealthieFormAnswers.map((input) => ({


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the `freezeResponse` field from the configuration and validation schema in both `pushFormResponseToHealthie` and `pushFormResponsesToHealthie`.
- Updated test cases to exclude the `freezeResponse` field.
- Removed the `frozen` variable and its usage in the mutation logic, simplifying the code.
- Simplified import statements by removing unnecessary imports.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Remove `freezeResponse` field from pushFormResponse configuration</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts

<li>Removed the <code>freezeResponse</code> field from the configuration.<br> <li> Updated the <code>FieldsValidationSchema</code> to exclude <code>freezeResponse</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-148919375f3100d5de2da3854943e1146abf7e604703a2b911ec43962d1ce3c2">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.ts</strong><dd><code>Remove `frozen` logic from pushFormResponse function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts

<li>Removed the <code>frozen</code> variable and its usage in the mutation.<br> <li> Simplified the import statements by removing <code>defaultTo</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-32ba09fb213cf1d480949c274fdeb5acf3ca95f8acbfc24750a391ef7b89782b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Remove `freezeResponse` field from pushFormResponses configuration</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts

<li>Removed the <code>freezeResponse</code> field from the configuration.<br> <li> Updated the <code>FieldsValidationSchema</code> to exclude <code>freezeResponse</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-28eb5df38c706b21fbb9adcede484348b01996293b1712ba31040ef5ea8580fe">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.ts</strong><dd><code>Remove `frozen` logic from pushFormResponses function</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts

<li>Removed the <code>frozen</code> variable and its usage in the mutation.<br> <li> Simplified the import statements by removing <code>defaultTo</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-5f1f9429941aa4aaf87aeefdc9eee8b03f7e74aee8841abb4b94de42ed8a3f8c">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.test.ts</strong><dd><code>Update test cases to exclude `freezeResponse` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.test.ts

- Removed `freezeResponse` from test case fields.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-f05a04b8e35327a20cf8f9170aed8464be7d8b79dc269f4d634fbaacf6e7a93c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.test.ts</strong><dd><code>Update test cases to exclude `freezeResponse` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts

- Removed `freezeResponse` from test case fields.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/500/files#diff-70f877268e0bccd21f879ca9fdffa30c56af7d02b35d9dd2ef4bc4fcbc5a2df5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information