### PR TITLE
feat(): bland.ai

### DIFF
--- a/extensions/bland/CHANGELOG.md
+++ b/extensions/bland/CHANGELOG.md
@@ -1,0 +1,1 @@
+# CHANGELOG

--- a/extensions/bland/README.md
+++ b/extensions/bland/README.md
@@ -1,0 +1,8 @@
+---
+title: Bland.ai
+description: To do
+---
+
+# Bland.ai
+
+To do

--- a/extensions/bland/actions/index.ts
+++ b/extensions/bland/actions/index.ts
@@ -1,0 +1,7 @@
+import { sendCall } from './sendCall'
+import { sendCallWithPathway } from './sendCallWithPathway'
+
+export const actions = {
+  sendCallWithPathway,
+  sendCall,
+}

--- a/extensions/bland/actions/sendCall/__tests__/sendCall.test.ts
+++ b/extensions/bland/actions/sendCall/__tests__/sendCall.test.ts
@@ -1,0 +1,66 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { BlandApiClient } from '../../../api/client'
+import { sendCall as action } from '../sendCall'
+
+jest.mock('../../../api/client', () => ({
+  BlandApiClient: jest.fn().mockImplementation(() => ({
+    sendCall: jest.fn().mockResolvedValue({
+      data: {
+        status: 'success',
+        call_id: '9d404c1b-6a23-4426-953a-a52c392ff8f1',
+      },
+    }),
+  })),
+}))
+
+const mockedSdk = jest.mocked(BlandApiClient)
+
+describe('Bland.ai - Send call', () => {
+  const {
+    extensionAction: sendCall,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await sendCall.onEvent({
+      payload: {
+        fields: {
+          phoneNumber: '1234567890',
+          task: 'Some task',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(mockedSdk).toHaveBeenCalled()
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: expect.objectContaining({
+          callId: '9d404c1b-6a23-4426-953a-a52c392ff8f1',
+          status: 'success',
+        }),
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            date: expect.any(String),
+            text: {
+              en: 'Call sent to Bland. Status: success, Call ID: 9d404c1b-6a23-4426-953a-a52c392ff8f1',
+            },
+          }),
+        ]),
+      })
+    )
+  })
+})

--- a/extensions/bland/actions/sendCall/config/dataPoints.ts
+++ b/extensions/bland/actions/sendCall/config/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  callId: {
+    key: 'callId',
+    valueType: 'string',
+  },
+  status: {
+    key: 'status',
+    valueType: 'string',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/bland/actions/sendCall/config/fields.ts
+++ b/extensions/bland/actions/sendCall/config/fields.ts
@@ -1,0 +1,30 @@
+import {
+  FieldType,
+  StringType,
+  type Field,
+} from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {
+  phoneNumber: {
+    id: 'phoneNumber',
+    label: 'Phone number',
+    description: '',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  task: {
+    id: 'task',
+    label: 'Task',
+    description:
+      'Provide instructions, relevant information, and examples of the ideal conversation flow.',
+    type: FieldType.TEXT,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  phoneNumber: z.string().min(1),
+  task: z.string().min(1),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/sendCall/config/index.ts
+++ b/extensions/bland/actions/sendCall/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/bland/actions/sendCall/index.ts
+++ b/extensions/bland/actions/sendCall/index.ts
@@ -1,0 +1,1 @@
+export * from './sendCall'

--- a/extensions/bland/actions/sendCall/sendCall.ts
+++ b/extensions/bland/actions/sendCall/sendCall.ts
@@ -1,0 +1,43 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+import { validatePayloadAndCreateSdk } from '../../lib/validatePayloadAndCreateSdk'
+import { type settings } from '../../settings'
+import { fields, FieldsValidationSchema, dataPoints } from './config'
+
+export const sendCall: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'sendCall',
+  category: Category.COMMUNICATION,
+  title: 'Send call',
+  description: 'Send an AI phone call with a custom objective and actions.',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({ payload, onComplete }): Promise<void> => {
+    const { fields, blandSdk } = await validatePayloadAndCreateSdk({
+      fieldsSchema: FieldsValidationSchema,
+      payload,
+    })
+
+    const { data } = await blandSdk.sendCall({
+      phone_number: fields.phoneNumber,
+      task: fields.task,
+    })
+
+    await onComplete({
+      data_points: {
+        callId: data.call_id,
+        status: data.status,
+      },
+      events: [
+        addActivityEventLog({
+          message: `Call sent to Bland. Status: ${data.status}, Call ID: ${data.call_id}`,
+        }),
+      ],
+    })
+  },
+}

--- a/extensions/bland/actions/sendCallWithPathway/__tests__/sendCallWithPathway.test.ts
+++ b/extensions/bland/actions/sendCallWithPathway/__tests__/sendCallWithPathway.test.ts
@@ -1,0 +1,66 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { BlandApiClient } from '../../../api/client'
+import { sendCallWithPathway as action } from '../sendCallWithPathway'
+
+jest.mock('../../../api/client', () => ({
+  BlandApiClient: jest.fn().mockImplementation(() => ({
+    sendCall: jest.fn().mockResolvedValue({
+      data: {
+        status: 'success',
+        call_id: '9d404c1b-6a23-4426-953a-a52c392ff8f1',
+      },
+    }),
+  })),
+}))
+
+const mockedSdk = jest.mocked(BlandApiClient)
+
+describe('Bland.ai - Send call', () => {
+  const {
+    extensionAction: sendCallWithPathway,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await sendCallWithPathway.onEvent({
+      payload: {
+        fields: {
+          phoneNumber: '1234567890',
+          pathwayId: '123',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(mockedSdk).toHaveBeenCalled()
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: expect.objectContaining({
+          callId: '9d404c1b-6a23-4426-953a-a52c392ff8f1',
+          status: 'success',
+        }),
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            date: expect.any(String),
+            text: {
+              en: 'Call sent to Bland. Status: success, Call ID: 9d404c1b-6a23-4426-953a-a52c392ff8f1',
+            },
+          }),
+        ]),
+      })
+    )
+  })
+})

--- a/extensions/bland/actions/sendCallWithPathway/config/dataPoints.ts
+++ b/extensions/bland/actions/sendCallWithPathway/config/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  callId: {
+    key: 'callId',
+    valueType: 'string',
+  },
+  status: {
+    key: 'status',
+    valueType: 'string',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/bland/actions/sendCallWithPathway/config/fields.ts
+++ b/extensions/bland/actions/sendCallWithPathway/config/fields.ts
@@ -1,0 +1,30 @@
+import {
+  FieldType,
+  StringType,
+  type Field,
+} from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {
+  phoneNumber: {
+    id: 'phoneNumber',
+    label: 'Phone number',
+    description: '',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  pathwayId: {
+    id: 'pathwayId',
+    label: 'Pathway ID',
+    description:
+      'Follows the conversational pathway you created to guide the conversation.',
+    type: FieldType.TEXT,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  phoneNumber: z.string().min(1),
+  pathwayId: z.string().min(1),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/sendCallWithPathway/config/index.ts
+++ b/extensions/bland/actions/sendCallWithPathway/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/bland/actions/sendCallWithPathway/index.ts
+++ b/extensions/bland/actions/sendCallWithPathway/index.ts
@@ -1,0 +1,1 @@
+export * from './sendCallWithPathway'

--- a/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
+++ b/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
@@ -1,0 +1,44 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+import { validatePayloadAndCreateSdk } from '../../lib/validatePayloadAndCreateSdk'
+import { type settings } from '../../settings'
+import { fields, FieldsValidationSchema, dataPoints } from './config'
+
+export const sendCallWithPathway: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'sendCallWithPathway',
+  category: Category.COMMUNICATION,
+  title: 'Send call with pathway',
+  description: 'Send an AI phone call based on a pathway',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({ payload, onComplete }): Promise<void> => {
+    const { fields, blandSdk } = await validatePayloadAndCreateSdk({
+      fieldsSchema: FieldsValidationSchema,
+      payload,
+    })
+
+    const { data } = await blandSdk.sendCall({
+      phone_number: fields.phoneNumber,
+      pathway_id: fields.pathwayId,
+      task: '',
+    })
+
+    await onComplete({
+      data_points: {
+        callId: data.call_id,
+        status: data.status,
+      },
+      events: [
+        addActivityEventLog({
+          message: `Call sent to Bland. Status: ${data.status}, Call ID: ${data.call_id}`,
+        }),
+      ],
+    })
+  },
+}

--- a/extensions/bland/api/client.ts
+++ b/extensions/bland/api/client.ts
@@ -1,0 +1,27 @@
+import axios, { type AxiosResponse, type AxiosInstance } from 'axios'
+import { type SendCallResponseType, type SendCallInputType } from './schema'
+
+export class BlandApiClient {
+  private readonly client: AxiosInstance
+
+  constructor({ baseUrl, apiKey }: { baseUrl: string; apiKey: string }) {
+    this.client = axios.create({
+      baseURL: baseUrl,
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  async sendCall(
+    input: SendCallInputType
+  ): Promise<AxiosResponse<SendCallResponseType>> {
+    const response = await this.client.post<SendCallResponseType>(
+      `/calls`,
+      input
+    )
+
+    return response
+  }
+}

--- a/extensions/bland/api/schema/SendCall.schema.ts
+++ b/extensions/bland/api/schema/SendCall.schema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+export const SendCallInputSchema = z.object({
+  phone_number: z.string().min(1), // For best results, use the E.164 format.
+  task: z.string().min(1),
+  pathway_id: z.string().optional(),
+  start_node_id: z.string().optional(),
+  voice: z.string().optional(),
+  background_track: z.string().optional(),
+  first_sentence: z.string().optional(),
+  wait_for_greeting: z.boolean().optional(),
+  block_interruptions: z.boolean().optional(),
+  interruption_threshold: z.number().optional(),
+  model: z.string().optional(),
+  temperature: z.number().optional(),
+  keywords: z.array(z.string()).optional(),
+  pronunciation_guide: z.array(z.record(z.string(), z.string())).optional(),
+  transfer_phone_number: z.string().optional(),
+  transfer_list: z.record(z.string(), z.string()).optional(),
+  language: z.string().optional(),
+  timezone: z.string().optional(),
+  request_data: z.record(z.string(), z.any()).optional(),
+  tools: z.array(z.record(z.string(), z.any())).optional(),
+  dynamic_data: z
+    .array(
+      z.object({
+        response_data: z.array(z.record(z.string(), z.any())),
+      })
+    )
+    .optional(),
+  start_time: z.string().optional(),
+  voicemail_message: z.string().optional(),
+  voicemail_action: z.record(z.string(), z.any()).optional(),
+  retry: z.record(z.string(), z.any()).optional(),
+  max_duration: z.number().optional(),
+  record: z.boolean().optional(),
+  from: z.string().optional(),
+  webhook: z.string().optional(),
+  webhook_events: z.array(z.string()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  summary_prompt: z.string().optional(),
+  analysis_prompt: z.string().optional(),
+  analysis_schema: z.record(z.string(), z.any()).optional(),
+  answered_by_enabled: z.boolean().optional(),
+})
+
+export type SendCallInputType = z.infer<typeof SendCallInputSchema>
+
+export const SendCallResponseSchema = z.object({
+  status: z.string(),
+  call_id: z.string().uuid(),
+})
+
+export type SendCallResponseType = z.infer<typeof SendCallResponseSchema>

--- a/extensions/bland/api/schema/index.ts
+++ b/extensions/bland/api/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './SendCall.schema'

--- a/extensions/bland/index.ts
+++ b/extensions/bland/index.ts
@@ -1,0 +1,18 @@
+import { type Extension } from '@awell-health/extensions-core'
+import { AuthorType, Category } from '@awell-health/extensions-core'
+import { actions } from './actions'
+import { settings } from './settings'
+
+export const bland: Extension = {
+  key: 'bland',
+  title: 'Bland.ai',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1731027387/Awell%20Extensions/Bland-AI.jpg',
+  description: 'Automate your phone calls with AI',
+  category: Category.COMMUNICATION,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  actions,
+  settings,
+}

--- a/extensions/bland/lib/validatePayloadAndCreateSdk.ts
+++ b/extensions/bland/lib/validatePayloadAndCreateSdk.ts
@@ -1,0 +1,54 @@
+import {
+  type NewActivityPayload,
+  validate,
+  type Pathway,
+  type Patient,
+} from '@awell-health/extensions-core'
+import z from 'zod'
+import { SettingsValidationSchema } from '../settings'
+import { type Activity } from '@awell-health/extensions-core/dist/types/Activity'
+import { BlandApiClient } from '../api/client'
+
+type ValidatePayloadAndCreateSdk = <
+  T extends z.ZodTypeAny,
+  P extends NewActivityPayload<any, any>
+>(args: {
+  fieldsSchema: T
+  payload: P
+}) => Promise<{
+  blandSdk: BlandApiClient
+  fields: z.infer<(typeof args)['fieldsSchema']>
+  settings: z.infer<typeof SettingsValidationSchema>
+  pathway: Pathway
+  patient: Patient
+  activity: Activity
+}>
+
+export const validatePayloadAndCreateSdk: ValidatePayloadAndCreateSdk = async ({
+  fieldsSchema,
+  payload,
+}) => {
+  const { settings, fields } = validate({
+    schema: z.object({
+      fields: fieldsSchema,
+      settings: SettingsValidationSchema,
+    }),
+    payload,
+  })
+
+  const { patient, pathway, activity } = payload
+
+  const blandSdk = new BlandApiClient({
+    baseUrl: 'https://api.bland.ai/v1',
+    apiKey: settings.apiKey,
+  })
+
+  return {
+    blandSdk,
+    settings,
+    fields,
+    patient,
+    pathway,
+    activity,
+  }
+}

--- a/extensions/bland/settings.ts
+++ b/extensions/bland/settings.ts
@@ -1,0 +1,16 @@
+import { type Setting } from '@awell-health/extensions-core'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {
+  apiKey: {
+    key: 'apiKey',
+    label: 'Bland API key',
+    obfuscated: true,
+    description: '',
+    required: true,
+  },
+} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({
+  apiKey: z.string().min(1),
+} satisfies Record<keyof typeof settings, ZodTypeAny>)


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Implemented `sendCall` and `sendCallWithPathway` actions for Bland.ai, allowing AI-driven phone calls with customizable objectives and pathways.
- Added unit tests for both `sendCall` and `sendCallWithPathway` actions to ensure functionality and reliability.
- Created `BlandApiClient` class to handle API interactions with Bland.ai, including sending call requests.
- Defined schemas for API input and response validation using `zod`.
- Established configuration files for fields and data points, ensuring structured data handling.
- Added documentation files including a README and CHANGELOG for the Bland.ai extension.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add exports for Bland.ai actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/index.ts

<li>Added exports for <code>sendCall</code> and <code>sendCallWithPathway</code> actions.<br> <li> Defined an <code>actions</code> object to manage these exports.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-f445f817a0f43154155b9a1fabf0f29dbe3383fcd08f28e1606dc86f1678f716">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dataPoints.ts</strong><dd><code>Define data points for sendCall action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/config/dataPoints.ts

<li>Defined data points for <code>callId</code> and <code>status</code>.<br> <li> Ensured data points conform to <code>DataPointDefinition</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-c5fee42192a63301fdaa6506b6f00596143f50c95cab0acbc7debf3e1bee41fb">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Define fields and validation for sendCall action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/config/fields.ts

<li>Defined fields for <code>phoneNumber</code> and <code>task</code>.<br> <li> Added validation schema for fields.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-d05d41dbc7bb6a5ce7fbf772ca46d4a0a76d9680fc8511024ff7366544d23b2d">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export configuration for sendCall action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/config/index.ts

- Exported fields and data points configurations.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-0d92388ca7ae8f44bd5335202c7f2bf585c6db34fe7c64d7ac4517b10d3e3a99">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export sendCall action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/index.ts

- Exported `sendCall` action.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-8854587a36d73f91b90ea265deb6f4980f47bf64f6ea62eb418456dcad5f81d6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sendCall.ts</strong><dd><code>Implement sendCall action for Bland.ai</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/sendCall.ts

<li>Implemented <code>sendCall</code> action for Bland.ai.<br> <li> Integrated payload validation and SDK creation.<br> <li> Handled API call and completion events.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-e9b9f941a9ce55bb88a6f20e59cc4a76816ce3314b22d9ee3e63817e74dc6e80">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dataPoints.ts</strong><dd><code>Define data points for sendCallWithPathway action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/config/dataPoints.ts

<li>Defined data points for <code>callId</code> and <code>status</code>.<br> <li> Ensured data points conform to <code>DataPointDefinition</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-9672858e82018f75ff08e803adb2cb257dcb45e2be31ed524c46d4ee3ef890cb">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Define fields and validation for sendCallWithPathway action</code></dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/config/fields.ts

<li>Defined fields for <code>phoneNumber</code> and <code>pathwayId</code>.<br> <li> Added validation schema for fields.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-9456092d8512887bd347e3dff3a5200160132bab7c9e0fd2a96649275d9902bc">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export configuration for sendCallWithPathway action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/config/index.ts

- Exported fields and data points configurations.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-e2053ecf7bde027927d78e7ae5624f4d0087c2932de5ed4a3acba8a8c4651353">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export sendCallWithPathway action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/index.ts

- Exported `sendCallWithPathway` action.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-158da37bfc40436656c37fb240c6047656affcdb1c3b55c29bc9c60392852998">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sendCallWithPathway.ts</strong><dd><code>Implement sendCallWithPathway action for Bland.ai</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts

<li>Implemented <code>sendCallWithPathway</code> action for Bland.ai.<br> <li> Integrated payload validation and SDK creation.<br> <li> Handled API call and completion events.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-a07c5c40fe64a15635e3c501ee6b2de77f5f8771b1b601ed2478b1f279837c70">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Create BlandApiClient for API interactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/api/client.ts

<li>Created <code>BlandApiClient</code> class for API interactions.<br> <li> Implemented <code>sendCall</code> method to post call data.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-c614572f237e862da0d678fc40927b1dea08363a59e579930f5e088133e0a2b8">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SendCall.schema.ts</strong><dd><code>Define schemas for SendCall API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/api/schema/SendCall.schema.ts

<li>Defined schemas for <code>SendCall</code> input and response.<br> <li> Used <code>zod</code> for schema validation.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-db4f0ba2678dd2a7445b1f103fdf2f6505cbb88d3f2f59ee1dcaa0c4527a79f6">+54/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export SendCall schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/api/schema/index.ts

- Exported `SendCall` schema.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-4ed590ba7652956648e1f0cfaa7c4881ce82213f4a61966330d5af1f48f492e2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Define Bland.ai extension metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/index.ts

- Defined `bland` extension with metadata and actions.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-69fc5a09c26afa655810cce33c4337133fb7acfdae222c0cd947867ff344bb96">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>validatePayloadAndCreateSdk.ts</strong><dd><code>Implement payload validation and SDK creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/lib/validatePayloadAndCreateSdk.ts

<li>Implemented function to validate payload and create SDK.<br> <li> Integrated with <code>BlandApiClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-39f02f7f84bf362546a43117e93b4aefb466dc3ec5634cb21f02f12038f0dc78">+54/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>settings.ts</strong><dd><code>Define settings for Bland.ai extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/settings.ts

<li>Defined settings for Bland.ai extension.<br> <li> Included API key configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-99864d775fa9d6ba91851cba401708067a3c1b0e74b4e99c678004ea50b5a540">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>sendCall.test.ts</strong><dd><code>Add unit tests for sendCall action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCall/__tests__/sendCall.test.ts

<li>Added unit tests for <code>sendCall</code> action.<br> <li> Mocked <code>BlandApiClient</code> to simulate API responses.<br> <li> Verified that the <code>sendCall</code> action completes successfully.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-df5605e7f1831cf0915f9c3dc860add8298fcedf25841e30ac97e1515eec39fe">+66/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sendCallWithPathway.test.ts</strong><dd><code>Add unit tests for sendCallWithPathway action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/actions/sendCallWithPathway/__tests__/sendCallWithPathway.test.ts

<li>Added unit tests for <code>sendCallWithPathway</code> action.<br> <li> Mocked <code>BlandApiClient</code> to simulate API responses.<br> <li> Verified that the <code>sendCallWithPathway</code> action completes successfully.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-a31b48b68664e642dea7a8cc4acea008fe5feb7dc9ffa5ee6eae4342c6a7ed05">+66/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add CHANGELOG file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/CHANGELOG.md

- Added CHANGELOG file.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-ef29aa9a27aa44f24db3bc893572d5728f9b1825c3d50a2b2044616105a1f946">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add README file for Bland.ai</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/bland/README.md

- Added README file with basic structure.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/502/files#diff-81202c3b21d7f43567ae7ce231a68c3422764cf82f4b54c6f644d6c1bb38c2f5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information