### PR TITLE
add option fields to lock answer group

### DIFF
--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts
@@ -16,9 +16,17 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
+  lockFormAnswerGroup: {
+    id: 'lockFormAnswerGroup',
+    label: 'Lock form answer group',
+    description: 'Locking the form will stop any further editing',
+    type: FieldType.BOOLEAN,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
+  lockFormAnswerGroup: z.boolean().optional(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts
@@ -16,9 +16,17 @@ export const fields = {
     type: FieldType.STRING,
     required: true,
   },
+  lockFormAnswerGroup: {
+    id: 'lockFormAnswerGroup',
+    label: 'Lock form answer group',
+    description: 'Locking the form will stop any further editing',
+    type: FieldType.BOOLEAN,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
   healthiePatientId: z.string().min(1),
   healthieFormId: z.string().min(1),
+  lockFormAnswerGroup: z.boolean().optional(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
@@ -4,7 +4,7 @@ import { validatePayloadAndCreateSdk } from '../../../lib/sdk/validatePayloadAnd
 import { type settings } from '../../../settings'
 import { datapoints, fields, FieldsValidationSchema } from './config'
 import { getSubActivityLogs } from './logs'
-import { isEmpty } from 'lodash'
+import { isEmpty, defaultTo } from 'lodash'
 import {
   HealthieFormResponseNotCreated,
   parseHealthieFormResponseNotCreatedError,
@@ -67,6 +67,9 @@ export const pushFormResponsesToHealthie: Action<
       ({ omittedFormAnswers }) => omittedFormAnswers
     )
 
+    // indicates whether to make form values editable in Healthie
+    const lock = defaultTo(fields.lockFormAnswerGroup, false)
+
     try {
       const res = await healthieSdk.client.mutation({
         createFormAnswerGroup: {
@@ -90,6 +93,21 @@ export const pushFormResponsesToHealthie: Action<
       if (isEmpty(res?.createFormAnswerGroup?.form_answer_group?.id))
         throw new HealthieFormResponseNotCreated(res)
 
+      // separate call to lock the form if needed
+      if (lock) {
+        await healthieSdk.client.mutation({
+          lockFormAnswerGroup: {
+            __args: {
+              input: {
+                id: fields.healthieFormId,
+              },
+            },
+            form_answer_group: {
+              id: true,
+            },
+          },
+        })
+      }
       await onComplete({
         data_points: {
           formAnswerGroupId: String(


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new optional boolean field `lockFormAnswerGroup` to the configuration files for both single and multiple form responses.
- Updated the validation schema to accommodate the new `lockFormAnswerGroup` field.
- Implemented logic in both `pushFormResponseToHealthie.ts` and `pushFormResponsesToHealthie.ts` to handle the locking of form answer groups based on the new field.
- Utilized lodash's `defaultTo` function to manage default values for the lock option.
- Added conditional mutations to lock the form answer group if the `lockFormAnswerGroup` field is set to true.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add lock option to form response fields configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/config/fields.ts

<li>Added a new field <code>lockFormAnswerGroup</code> to the fields configuration.<br> <li> Updated the validation schema to include <code>lockFormAnswerGroup</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/518/files#diff-148919375f3100d5de2da3854943e1146abf7e604703a2b911ec43962d1ce3c2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.ts</strong><dd><code>Implement form locking logic in pushFormResponseToHealthie</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts

<li>Imported <code>defaultTo</code> from lodash.<br> <li> Added logic to handle the locking of form answer groups.<br> <li> Included a conditional mutation to lock the form if required.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/518/files#diff-32ba09fb213cf1d480949c274fdeb5acf3ca95f8acbfc24750a391ef7b89782b">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Add lock option to form responses fields configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/config/fields.ts

<li>Added a new field <code>lockFormAnswerGroup</code> to the fields configuration.<br> <li> Updated the validation schema to include <code>lockFormAnswerGroup</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/518/files#diff-28eb5df38c706b21fbb9adcede484348b01996293b1712ba31040ef5ea8580fe">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.ts</strong><dd><code>Implement form locking logic in pushFormResponsesToHealthie</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts

<li>Imported <code>defaultTo</code> from lodash.<br> <li> Added logic to handle the locking of form answer groups.<br> <li> Included a conditional mutation to lock the form if required.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/518/files#diff-5f1f9429941aa4aaf87aeefdc9eee8b03f7e74aee8841abb4b94de42ed8a3f8c">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information