### PR TITLE
fix what id we pass

### DIFF
--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
@@ -82,17 +82,19 @@ export const pushFormResponseToHealthie: Action<
           },
         },
       })
+      const formAnswerGroupId =
+        res?.createFormAnswerGroup?.form_answer_group?.id
 
-      if (isEmpty(res?.createFormAnswerGroup?.form_answer_group?.id))
+      if (isEmpty(formAnswerGroupId))
         throw new HealthieFormResponseNotCreated(res)
 
       // separate call to lock the form if needed
-      if (lock) {
+      if (lock && formAnswerGroupId !== undefined) {
         await healthieSdk.client.mutation({
           lockFormAnswerGroup: {
             __args: {
               input: {
-                id: fields.healthieFormId,
+                id: formAnswerGroupId,
               },
             },
             form_answer_group: {
@@ -104,9 +106,7 @@ export const pushFormResponseToHealthie: Action<
 
       await onComplete({
         data_points: {
-          formAnswerGroupId: String(
-            res.createFormAnswerGroup?.form_answer_group?.id
-          ),
+          formAnswerGroupId: String(formAnswerGroupId),
         },
         events: getSubActivityLogs(omittedFormAnswers),
       })

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
@@ -89,17 +89,19 @@ export const pushFormResponsesToHealthie: Action<
           },
         },
       })
+      const formAnswerGroupId =
+        res?.createFormAnswerGroup?.form_answer_group?.id
 
-      if (isEmpty(res?.createFormAnswerGroup?.form_answer_group?.id))
+      if (isEmpty(formAnswerGroupId))
         throw new HealthieFormResponseNotCreated(res)
 
       // separate call to lock the form if needed
-      if (lock) {
+      if (lock && formAnswerGroupId !== undefined) {
         await healthieSdk.client.mutation({
           lockFormAnswerGroup: {
             __args: {
               input: {
-                id: fields.healthieFormId,
+                id: formAnswerGroupId,
               },
             },
             form_answer_group: {
@@ -110,9 +112,7 @@ export const pushFormResponsesToHealthie: Action<
       }
       await onComplete({
         data_points: {
-          formAnswerGroupId: String(
-            res.createFormAnswerGroup?.form_answer_group?.id
-          ),
+          formAnswerGroupId: String(formAnswerGroupId),
         },
         events: getSubActivityLogs(mergedOmittedFormAnswers),
       })


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic for handling form answer group ID in `pushFormResponseToHealthie` and `pushFormResponsesToHealthie` functions.
- Introduced a variable `formAnswerGroupId` to store the ID, improving code readability and maintainability.
- Updated mutation calls to use the correct form answer group ID.
- Simplified the assignment of `formAnswerGroupId` in the `onComplete` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushFormResponseToHealthie.ts</strong><dd><code>Fix form answer group ID handling in pushFormResponseToHealthie</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts

<li>Introduced a variable <code>formAnswerGroupId</code> to store the form answer group <br>ID.<br> <li> Updated condition to check <code>formAnswerGroupId</code> instead of accessing it <br>directly.<br> <li> Changed the ID used in the mutation call to <code>formAnswerGroupId</code>.<br> <li> Simplified the assignment of <code>formAnswerGroupId</code> in the <code>onComplete</code> <br>function.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/520/files#diff-32ba09fb213cf1d480949c274fdeb5acf3ca95f8acbfc24750a391ef7b89782b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pushFormResponsesToHealthie.ts</strong><dd><code>Fix form answer group ID handling in pushFormResponsesToHealthie</code></dd></summary>
<hr>

extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts

<li>Introduced a variable <code>formAnswerGroupId</code> to store the form answer group <br>ID.<br> <li> Updated condition to check <code>formAnswerGroupId</code> instead of accessing it <br>directly.<br> <li> Changed the ID used in the mutation call to <code>formAnswerGroupId</code>.<br> <li> Simplified the assignment of <code>formAnswerGroupId</code> in the <code>onComplete</code> <br>function.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/520/files#diff-5f1f9429941aa4aaf87aeefdc9eee8b03f7e74aee8841abb4b94de42ed8a3f8c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information