### PR TITLE
issue-with-healthie-create-patient

### DIFF
--- a/extensions/healthie/actions/createPatient/createPatient.ts
+++ b/extensions/healthie/actions/createPatient/createPatient.ts
@@ -31,7 +31,7 @@ export const createPatient: Action<
     })
 
     const dont_send_welcome = fields.send_invite !== true
-
+    const skipped_email = fields.email === undefined || fields.email === '' // if email is empty we still want to create the patient
     try {
       const res = await healthieSdk.client.mutation({
         createClient: {
@@ -44,7 +44,7 @@ export const createPatient: Action<
               phone_number: fields.phone_number,
               dietitian_id:
                 fields.provider_id === '' ? undefined : fields.provider_id,
-              skipped_email: isEmpty(fields.email), // if email is empty we still want to create the patient
+              skipped_email,
               dont_send_welcome,
             },
           },


### PR DESCRIPTION
### **PR Type**
bug_fix
isEmpty returns true sometimes when it shouldn't I want a specific check to avoid weird behaviours

___

### **Description**
- Fixed a bug in the `createPatient` action where the logic to determine if an email should be skipped was incorrect.
- Updated the condition to explicitly check if the email field is undefined or an empty string.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createPatient.ts</strong><dd><code>Fix email skipping logic in patient creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createPatient/createPatient.ts

<li>Fixed the condition to determine if the email is skipped.<br> <li> Replaced <code>isEmpty(fields.email)</code> with a more explicit check for <br>undefined or empty string.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/522/files#diff-cbdbcd217e20138a7bf51f54c50b79f9713b3e0a187ca8ed6236614e63153db4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information