### PR TITLE
add tests

### DIFF
--- a/extensions/healthie/actions/createPatient/config/fields.ts
+++ b/extensions/healthie/actions/createPatient/config/fields.ts
@@ -62,7 +62,7 @@ export const FieldsValidationSchema = z.object({
   first_name: z.string().min(1),
   last_name: z.string().min(1),
   legal_name: z.string().optional(),
-  email: z.string().email().optional(),
+  email: z.string().optional(),
   phone_number: z.string().optional(),
   send_invite: z.boolean().optional(),
   provider_id: z.string().optional(),

--- a/extensions/healthie/actions/createPatient/createPatient.test.ts
+++ b/extensions/healthie/actions/createPatient/createPatient.test.ts
@@ -93,4 +93,64 @@ describe('Healthie - createPatient', () => {
       },
     })
   })
+
+  test('Should create a new patient with skipeed email false when email is empty string', async () => {
+    await action.onEvent({
+      payload: generateTestPayload({
+        fields: {
+          first_name: 'Test',
+          last_name: 'Test',
+          legal_name: 'Official Test Name',
+          email: '',
+          phone_number: '+1234567890',
+          provider_id: undefined,
+          send_invite: false,
+        },
+        settings: {
+          apiUrl: 'https://staging-api.gethealthie.com/graphql',
+          apiKey: 'apiKey',
+        },
+      }),
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(mockedHealthieSdk).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        healthiePatientId: 'patient-1',
+      },
+    })
+  })
+
+  test('Should create a new patient with skipeed email false when email is undefined', async () => {
+    await action.onEvent({
+      payload: generateTestPayload({
+        fields: {
+          first_name: 'Test',
+          last_name: 'Test',
+          legal_name: 'Official Test Name',
+          email: undefined,
+          phone_number: '+1234567890',
+          provider_id: undefined,
+          send_invite: false,
+        },
+        settings: {
+          apiUrl: 'https://staging-api.gethealthie.com/graphql',
+          apiKey: 'apiKey',
+        },
+      }),
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(mockedHealthieSdk).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        healthiePatientId: 'patient-1',
+      },
+    })
+  })
 })

--- a/extensions/healthie/actions/createPatient/createPatient.ts
+++ b/extensions/healthie/actions/createPatient/createPatient.ts
@@ -31,6 +31,10 @@ export const createPatient: Action<
     })
 
     const dont_send_welcome = fields.send_invite !== true
+    const dietitian_id =
+      fields.provider_id === undefined || fields.provider_id === ''
+        ? undefined
+        : fields.provider_id
     const skipped_email = fields.email === undefined || fields.email === '' // if email is empty we still want to create the patient
     try {
       const res = await healthieSdk.client.mutation({
@@ -42,8 +46,7 @@ export const createPatient: Action<
               legal_name: fields.legal_name,
               email: fields.email,
               phone_number: fields.phone_number,
-              dietitian_id:
-                fields.provider_id === '' ? undefined : fields.provider_id,
+              dietitian_id,
               skipped_email,
               dont_send_welcome,
             },


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Relaxed the email validation in `FieldsValidationSchema` to allow optional empty strings.
- Added new tests to verify patient creation when the email is an empty string or undefined.
- Refactored the patient creation logic to introduce a `dietitian_id` variable and handle optional email more cleanly.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Relax email validation to allow empty strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createPatient/config/fields.ts

- Removed email validation to allow optional empty strings.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/523/files#diff-0f7df399b7157d55405c9aa140342ab5e05338305645fc6e32e7f58930686382">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>createPatient.ts</strong><dd><code>Refactor patient creation logic and handle optional email</code></dd></summary>
<hr>

extensions/healthie/actions/createPatient/createPatient.ts

<li>Introduced <code>dietitian_id</code> variable for cleaner code.<br> <li> Updated logic to handle empty or undefined email.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/523/files#diff-cbdbcd217e20138a7bf51f54c50b79f9713b3e0a187ca8ed6236614e63153db4">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createPatient.test.ts</strong><dd><code>Add tests for patient creation with optional email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/healthie/actions/createPatient/createPatient.test.ts

<li>Added tests for creating a patient with empty and undefined email.<br> <li> Ensured patient creation proceeds with skipped email set to false.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/523/files#diff-f28cfc2b8dd6fc86d9a633b32e96ad2a479fe879baef6c12cf9bf5d40e952bac">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information