### PR TITLE
ET-602: allow multiple statuses

### DIFF
--- a/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/config/fields.ts
+++ b/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/config/fields.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNil, capitalize } from 'lodash'
+import { isEmpty, isNil } from 'lodash'
 import { z, type ZodTypeAny } from 'zod'
 import { FieldType, type Field } from '@awell-health/extensions-core'
 import { PathwayStatus } from '../../../gql/graphql'
@@ -7,16 +7,23 @@ export const fields = {
   pathwayStatus: {
     id: 'pathwayStatus',
     label: 'Pathway status',
-    description:
-      'A comma-separated string of care flow statuses that will be used when looking for care flows the patient is already enrolled in. By default, we only look at active care flows.',
+    description: `A comma-separated string of care flow statuses that will be used when looking for care flows the patient is already enrolled in. By default, we only look at active care flows. Possible values are: ${Object.values(
+      PathwayStatus
+    ).join(', ')}.`,
     type: FieldType.STRING,
     required: false,
-    options: {
-      dropdownOptions: Object.values(PathwayStatus).map((status) => ({
-        label: capitalize(status.replace('_', ' ')),
-        value: status,
-      })),
-    },
+    /**
+     * We currently do not support multi-select options for dropdown fields.
+     * Hence why we're not using this and rely on the user to enter a comma-separated string of statuses.
+     * This is a temporary solution and we should revisit this when we have multi-select options for dropdown fields.
+     * See ET-602 and ET-603 for more information.
+     */
+    // options: {
+    //   dropdownOptions: Object.values(PathwayStatus).map((status) => ({
+    //     label: capitalize(status.replace('_', ' ')),
+    //     value: status,
+    //   })),
+    // },
   },
   careFlowDefinitionIds: {
     id: 'careFlowDefinitionIds',


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the `pathwayStatus` field configuration by dynamically including possible values in the description and removing dropdown options due to lack of multi-select support.
- Added detailed comments explaining the temporary solution and referencing related tickets (ET-602 and ET-603).
- Introduced comprehensive test cases for validating the `pathwayStatus` field, including scenarios with single and multiple statuses, handling whitespaces, and ignoring invalid statuses.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Update `pathwayStatus` field configuration and description</code></dd></summary>
<hr>

extensions/awell/v1/actions/isPatientEnrolledInCareFlow/config/fields.ts

<li>Updated the <code>description</code> field to dynamically include possible values <br>for <code>PathwayStatus</code>.<br> <li> Removed the dropdown options configuration for <code>pathwayStatus</code> due to <br>lack of multi-select support.<br> <li> Added a comment explaining the temporary solution and referencing <br>related tickets (ET-602 and ET-603).<br> <li> Removed unused <code>capitalize</code> import from <code>lodash</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/534/files#diff-dfd7cbe53efbaf40bfe84af82b952979b5624cc0950a24207b21ef9bf61c56dc">+16/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>isPatientEnrolledInCareFlow.test.ts</strong><dd><code>Add test cases for `pathwayStatus` field validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/awell/v1/actions/isPatientEnrolledInCareFlow/isPatientEnrolledInCareFlow.test.ts

<li>Added new test cases for validating <code>pathwayStatus</code> field with single <br>and multiple statuses.<br> <li> Included tests for handling whitespaces and ignoring invalid statuses.<br> <li> Introduced <code>FieldsValidationSchema</code> and <code>ZodError</code> for validation testing.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/534/files#diff-d1bfa255115d155576832256f755e875cdbc4ceb588a020e4e51b62374325a86">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information