### PR TITLE
ET-599: remote single select - store full json option

### DIFF
--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoint.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoint.ts
@@ -9,4 +9,8 @@ export const dataPoints = {
     key: 'label',
     valueType: 'string',
   },
+  selectedOption: {
+    key: 'selectedOption',
+    valueType: 'json',
+  },
 } satisfies Record<string, DataPointDefinition>

--- a/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts
@@ -49,7 +49,7 @@ export const fields = {
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
-  label: z.string().nonempty(),
+  label: z.string().min(1),
   url: z.string().url(),
   headers: makeStringOptional(JsonStringValidationSchema),
   queryParam: makeStringOptional(z.string()),

--- a/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.ts
+++ b/extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.ts
@@ -3,8 +3,6 @@ import { dataPoints, fields } from './config'
 import { Category } from '@awell-health/extensions-core'
 import { type settings } from '../../../settings'
 import { validateActionFields } from './config/fields'
-import { fromZodError } from 'zod-validation-error'
-import { ZodError } from 'zod'
 
 export const remoteSingleSelect: Action<typeof fields, typeof settings> = {
   key: 'remoteSingleSelect',
@@ -22,43 +20,10 @@ export const remoteSingleSelect: Action<typeof fields, typeof settings> = {
   },
   previewable: false, // We don't have Awell Hosted Pages in Preview so cannot be previewed.
   onActivityCreated: async (payload, onComplete, onError) => {
-    try {
-      validateActionFields(payload.fields)
+    validateActionFields(payload.fields)
 
-      /**
-       * Completion happens in Awell Hosted Pages
-       */
-    } catch (err) {
-      if (err instanceof ZodError) {
-        const error = fromZodError(err)
-        await onError({
-          events: [
-            {
-              date: new Date().toISOString(),
-              text: { en: error.name },
-              error: {
-                category: 'WRONG_INPUT',
-                message: `${error.message}`,
-              },
-            },
-          ],
-        })
-        return
-      }
-
-      const error = err as Error
-      await onError({
-        events: [
-          {
-            date: new Date().toISOString(),
-            text: { en: 'Something went wrong while orchestrating the action' },
-            error: {
-              category: 'SERVER_ERROR',
-              message: error.message,
-            },
-          },
-        ],
-      })
-    }
+    /**
+     * Completion happens in Awell Hosted Pages
+     */
   },
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a new `selectedOption` data point with `json` value type to support storing full JSON objects.
- Updated validation for the `label` field to use `min(1)` instead of `nonempty` for better clarity and correctness.
- Simplified the `onActivityCreated` function by removing error handling logic for field validation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataPoint.ts</strong><dd><code>Add `selectedOption` data point with JSON value type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/collectData/v1/actions/remoteSingleSelect/config/dataPoint.ts

- Added a new `selectedOption` data point with `json` value type.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/538/files#diff-e4f1e2472530cc763f8e703611a8615a4ba5269e92bbf1929effe3beef459d0c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remoteSingleSelect.ts</strong><dd><code>Simplify field validation and remove error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/collectData/v1/actions/remoteSingleSelect/remoteSingleSelect.ts

<li>Removed error handling logic for field validation.<br> <li> Simplified <code>onActivityCreated</code> function by directly calling <br><code>validateActionFields</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/538/files#diff-5ef99708428b84d8b25654edd78bfd4684f57e0c251b0336ac5bf46b8faaabf7">+4/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Update validation for `label` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/collectData/v1/actions/remoteSingleSelect/config/fields.ts

<li>Updated validation for <code>label</code> field to use <code>min(1)</code> instead of <code>nonempty</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/538/files#diff-e611ed6f583d8803888c1b5efc803f033c71a0530e2cb637b7dbc6980e02eeaa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information