### PR TITLE
ET-712 | fix(mailgun): support multiple email addresses

### DIFF
--- a/extensions/mailgun/v1/actions/sendEmail/config/fields.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/config/fields.ts
@@ -1,6 +1,6 @@
 import { z, type ZodTypeAny } from 'zod'
 import { type Field, FieldType } from '@awell-health/extensions-core'
-import { getEmailValidation } from '../../../../../../src/lib/awell'
+import { CommaSeparatedEmailsValidationSchema } from '../../../../../../src/lib/awell'
 
 export const fields = {
   to: {
@@ -32,7 +32,12 @@ export const fields = {
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
-  to: getEmailValidation(),
+  to: CommaSeparatedEmailsValidationSchema.refine(
+    (emails) => emails.length > 0,
+    {
+      message: 'At least one email address is required',
+    }
+  ),
   subject: z.string(),
   body: z.string(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
@@ -30,7 +30,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
 
       const res = await mg.messages.create(domain, {
         from: `${fromName} <${fromEmail}>`,
-        to: [to],
+        to,
         subject,
         html: body,
         'o:testmode': testMode,

--- a/extensions/mailgun/v1/actions/sendEmailWithTemplate/config/fields.ts
+++ b/extensions/mailgun/v1/actions/sendEmailWithTemplate/config/fields.ts
@@ -1,7 +1,7 @@
 import { isNil } from 'lodash'
 import { z, type ZodTypeAny } from 'zod'
-import { type Field, FieldType , type json } from '@awell-health/extensions-core'
-import { getEmailValidation } from '../../../../../../src/lib/awell'
+import { type Field, FieldType, type json } from '@awell-health/extensions-core'
+import { CommaSeparatedEmailsValidationSchema } from '../../../../../../src/lib/awell'
 
 export const fields = {
   to: {
@@ -41,7 +41,12 @@ export const fields = {
 } satisfies Record<string, Field>
 
 export const FieldsValidationSchema = z.object({
-  to:  getEmailValidation(),
+  to: CommaSeparatedEmailsValidationSchema.refine(
+    (emails) => emails.length > 0,
+    {
+      message: 'At least one email address is required',
+    }
+  ),
   subject: z.string(),
   template: z.string(),
   variables: z

--- a/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
+++ b/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
@@ -31,7 +31,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
 
       const res = await mg.messages.create(domain, {
         from: `${fromName} <${fromEmail}>`,
-        to: [to],
+        to,
         subject,
         template,
         'h:X-Mailgun-Variables': JSON.stringify(variables),

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
@@ -2,17 +2,6 @@ import { ZodError } from 'zod'
 import { CommaSeparatedEmailsValidationSchema } from './getEmailValidation'
 
 describe('CommaSeparatedEmailsValidationSchema', () => {
-  test('should throw a ZodError when no email address is provided', async () => {
-    expect(() => {
-      const res = CommaSeparatedEmailsValidationSchema.safeParse('')
-
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
-    }).not.toThrow(ZodError)
-  })
-
   test('should throw a ZodError when email address is invalid', async () => {
     expect(() => {
       const res = CommaSeparatedEmailsValidationSchema.safeParse(
@@ -27,72 +16,43 @@ describe('CommaSeparatedEmailsValidationSchema', () => {
   })
 
   test('should work with undefined', async () => {
-    expect(() => {
-      const res = CommaSeparatedEmailsValidationSchema.safeParse(undefined)
-
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
-
-      expect(res.data).toEqual([])
-    }).not.toThrow(ZodError)
+    const res = CommaSeparatedEmailsValidationSchema.safeParse(undefined)
+    expect(res.data).toEqual([])
   })
 
   test('should work with an empty string', async () => {
-    expect(() => {
-      const res = CommaSeparatedEmailsValidationSchema.safeParse('')
+    const res = CommaSeparatedEmailsValidationSchema.safeParse('')
+    expect(res.data).toEqual([])
+  })
 
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
+  test('should work with multiple empty strings', async () => {
+    const res = CommaSeparatedEmailsValidationSchema.safeParse(',')
+    expect(res.data).toEqual([])
+  })
 
-      expect(res.data).toEqual([])
-    }).not.toThrow(ZodError)
+  test('should work with valid and empty strings', async () => {
+    const res = CommaSeparatedEmailsValidationSchema.safeParse(
+      'hello@world.com,   , hello-2@world.com'
+    )
+    expect(res.data).toEqual(['hello@world.com', 'hello-2@world.com'])
   })
 
   test('should work with a single email address', async () => {
-    expect(() => {
-      const res =
-        CommaSeparatedEmailsValidationSchema.safeParse('hello@world.com')
-
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
-
-      expect(res.data).toEqual(['hello@world.com'])
-    }).not.toThrow(ZodError)
+    const res = CommaSeparatedEmailsValidationSchema.parse('hello@world.com')
+    expect(res).toEqual(['hello@world.com'])
   })
 
   test('should work with multiple email addresses', async () => {
-    expect(() => {
-      const res = CommaSeparatedEmailsValidationSchema.safeParse(
-        'hello-1@world.com, hello-2@world.com'
-      )
-
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
-
-      expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
-    }).not.toThrow(ZodError)
+    const res = CommaSeparatedEmailsValidationSchema.safeParse(
+      'hello-1@world.com, hello-2@world.com'
+    )
+    expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
   })
 
   test('should work with multiple email addresses and various whitespaces', async () => {
-    expect(() => {
-      const res = CommaSeparatedEmailsValidationSchema.safeParse(
-        '   hello-1@world.com    ,      hello-2@world.com     '
-      )
-
-      if (!res.success) {
-        console.log(JSON.stringify(res.error, null, 2))
-        throw new ZodError(res.error.issues)
-      }
-
-      expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
-    }).not.toThrow(ZodError)
+    const res = CommaSeparatedEmailsValidationSchema.safeParse(
+      '   hello-1@world.com    ,      hello-2@world.com     '
+    )
+    expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
   })
 })

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
@@ -1,0 +1,74 @@
+import { ZodError } from 'zod'
+import { CommaSeparatedEmailsValidationSchema } from './getEmailValidation'
+
+describe('Fields validation', () => {
+  describe('to', () => {
+    test('should throw a ZodError when no email address is provided', async () => {
+      expect(() => {
+        const res = CommaSeparatedEmailsValidationSchema.safeParse('')
+
+        if (!res.success) {
+          console.log(JSON.stringify(res.error, null, 2))
+          throw new ZodError(res.error.issues)
+        }
+      }).toThrow(ZodError)
+    })
+
+    test('should throw a ZodError when email address is invalid', async () => {
+      expect(() => {
+        const res = CommaSeparatedEmailsValidationSchema.safeParse(
+          'invalid-email-address'
+        )
+
+        if (!res.success) {
+          console.log(JSON.stringify(res.error.issues, null, 2))
+          throw new ZodError(res.error.issues)
+        }
+      }).toThrow(ZodError)
+    })
+
+    test('should work with a single email address', async () => {
+      expect(() => {
+        const res =
+          CommaSeparatedEmailsValidationSchema.safeParse('hello@world.com')
+
+        if (!res.success) {
+          console.log(JSON.stringify(res.error, null, 2))
+          throw new ZodError(res.error.issues)
+        }
+
+        expect(res.data).toEqual(['hello@world.com'])
+      }).not.toThrow(ZodError)
+    })
+
+    test('should work with multiple email addresses', async () => {
+      expect(() => {
+        const res = CommaSeparatedEmailsValidationSchema.safeParse(
+          'hello-1@world.com, hello-2@world.com'
+        )
+
+        if (!res.success) {
+          console.log(JSON.stringify(res.error, null, 2))
+          throw new ZodError(res.error.issues)
+        }
+
+        expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
+      }).not.toThrow(ZodError)
+    })
+
+    test('should work with multiple email addresses and various whitespaces', async () => {
+      expect(() => {
+        const res = CommaSeparatedEmailsValidationSchema.safeParse(
+          '   hello-1@world.com    ,      hello-2@world.com     '
+        )
+
+        if (!res.success) {
+          console.log(JSON.stringify(res.error, null, 2))
+          throw new ZodError(res.error.issues)
+        }
+
+        expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
+      }).not.toThrow(ZodError)
+    })
+  })
+})

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts
@@ -1,74 +1,98 @@
 import { ZodError } from 'zod'
 import { CommaSeparatedEmailsValidationSchema } from './getEmailValidation'
 
-describe('Fields validation', () => {
-  describe('to', () => {
-    test('should throw a ZodError when no email address is provided', async () => {
-      expect(() => {
-        const res = CommaSeparatedEmailsValidationSchema.safeParse('')
+describe('CommaSeparatedEmailsValidationSchema', () => {
+  test('should throw a ZodError when no email address is provided', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse('')
 
-        if (!res.success) {
-          console.log(JSON.stringify(res.error, null, 2))
-          throw new ZodError(res.error.issues)
-        }
-      }).toThrow(ZodError)
-    })
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
+    }).not.toThrow(ZodError)
+  })
 
-    test('should throw a ZodError when email address is invalid', async () => {
-      expect(() => {
-        const res = CommaSeparatedEmailsValidationSchema.safeParse(
-          'invalid-email-address'
-        )
+  test('should throw a ZodError when email address is invalid', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse(
+        'invalid-email-address'
+      )
 
-        if (!res.success) {
-          console.log(JSON.stringify(res.error.issues, null, 2))
-          throw new ZodError(res.error.issues)
-        }
-      }).toThrow(ZodError)
-    })
+      if (!res.success) {
+        console.log(JSON.stringify(res.error.issues, null, 2))
+        throw new ZodError(res.error.issues)
+      }
+    }).toThrow(ZodError)
+  })
 
-    test('should work with a single email address', async () => {
-      expect(() => {
-        const res =
-          CommaSeparatedEmailsValidationSchema.safeParse('hello@world.com')
+  test('should work with undefined', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse(undefined)
 
-        if (!res.success) {
-          console.log(JSON.stringify(res.error, null, 2))
-          throw new ZodError(res.error.issues)
-        }
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
 
-        expect(res.data).toEqual(['hello@world.com'])
-      }).not.toThrow(ZodError)
-    })
+      expect(res.data).toEqual([])
+    }).not.toThrow(ZodError)
+  })
 
-    test('should work with multiple email addresses', async () => {
-      expect(() => {
-        const res = CommaSeparatedEmailsValidationSchema.safeParse(
-          'hello-1@world.com, hello-2@world.com'
-        )
+  test('should work with an empty string', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse('')
 
-        if (!res.success) {
-          console.log(JSON.stringify(res.error, null, 2))
-          throw new ZodError(res.error.issues)
-        }
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
 
-        expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
-      }).not.toThrow(ZodError)
-    })
+      expect(res.data).toEqual([])
+    }).not.toThrow(ZodError)
+  })
 
-    test('should work with multiple email addresses and various whitespaces', async () => {
-      expect(() => {
-        const res = CommaSeparatedEmailsValidationSchema.safeParse(
-          '   hello-1@world.com    ,      hello-2@world.com     '
-        )
+  test('should work with a single email address', async () => {
+    expect(() => {
+      const res =
+        CommaSeparatedEmailsValidationSchema.safeParse('hello@world.com')
 
-        if (!res.success) {
-          console.log(JSON.stringify(res.error, null, 2))
-          throw new ZodError(res.error.issues)
-        }
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
 
-        expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
-      }).not.toThrow(ZodError)
-    })
+      expect(res.data).toEqual(['hello@world.com'])
+    }).not.toThrow(ZodError)
+  })
+
+  test('should work with multiple email addresses', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse(
+        'hello-1@world.com, hello-2@world.com'
+      )
+
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
+
+      expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
+    }).not.toThrow(ZodError)
+  })
+
+  test('should work with multiple email addresses and various whitespaces', async () => {
+    expect(() => {
+      const res = CommaSeparatedEmailsValidationSchema.safeParse(
+        '   hello-1@world.com    ,      hello-2@world.com     '
+      )
+
+      if (!res.success) {
+        console.log(JSON.stringify(res.error, null, 2))
+        throw new ZodError(res.error.issues)
+      }
+
+      expect(res.data).toEqual(['hello-1@world.com', 'hello-2@world.com'])
+    }).not.toThrow(ZodError)
   })
 })

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash'
 import { z } from 'zod'
 
 /**
@@ -16,12 +17,14 @@ export const getEmailValidation = (): z.ZodTypeAny => {
  */
 export const CommaSeparatedEmailsValidationSchema = z
   .string()
-  .trim()
+  .optional()
   /**
    * Transform the value to an array of email addresses
    * and trim each email address
    */
   .transform((value) => {
+    if (isEmpty(value) || value === undefined) return []
+
     const emails = value.split(',')
     return emails.map((email) => email.trim())
   })

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
@@ -7,5 +7,35 @@ import { z } from 'zod'
 export const getEmailValidation = (): z.ZodTypeAny => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-  return z.string().regex(emailRegex)
+  return z.string().regex(emailRegex, { message: 'Invalid email address' })
 }
+
+/**
+ * Zod validation schema for multiple email addresses
+ * collected via a comma separated string
+ */
+export const CommaSeparatedEmailsValidationSchema = z
+  .string()
+  .trim()
+  /**
+   * Transform the value to an array of email addresses
+   * and trim each email address
+   */
+  .transform((value) => {
+    const emails = value.split(',')
+    return emails.map((email) => email.trim())
+  })
+  /**
+   * Validate each email address
+   */
+  .superRefine((emails, ctx) => {
+    const emailValidation = getEmailValidation()
+    emails.forEach((email) => {
+      if (!emailValidation.safeParse(email).success) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Invalid email address: ${email}`,
+        })
+      }
+    })
+  })

--- a/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
+++ b/src/lib/awell/getEmailValidationRegex/getEmailValidation.ts
@@ -26,7 +26,13 @@ export const CommaSeparatedEmailsValidationSchema = z
     if (isEmpty(value) || value === undefined) return []
 
     const emails = value.split(',')
-    return emails.map((email) => email.trim())
+    return emails
+      .map((email) => {
+        const trimmedEmail = email.trim()
+        if (isEmpty(trimmedEmail)) return undefined
+        return trimmedEmail
+      })
+      .filter((email) => email !== undefined) as string[]
   })
   /**
    * Validate each email address


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated email validation logic to support multiple email addresses using `CommaSeparatedEmailsValidationSchema`.
- Modified email sending and template sending logic to handle multiple recipients.
- Added unit tests to validate the new schema, covering various scenarios including invalid and valid email inputs.
- Enhanced error messages for invalid email addresses.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Update email validation to support multiple addresses.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/mailgun/v1/actions/sendEmail/config/fields.ts

<li>Replaced <code>getEmailValidation</code> with <code>CommaSeparatedEmailsValidationSchema</code> <br>for validating multiple email addresses.<br> <li> Added a refinement to ensure at least one email address is provided.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-51d1091a0b9a00735901718a43a22eac46283595debe2401db93d98a251d0856">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sendEmail.ts</strong><dd><code>Modify email sending logic to handle multiple recipients.</code></dd></summary>
<hr>

extensions/mailgun/v1/actions/sendEmail/sendEmail.ts

<li>Updated the <code>to</code> field to directly accept multiple email addresses.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-5e9e2e57bb394221eb925f38e19d4102988a7c9bce7dffb2c87acf47ada77154">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fields.ts</strong><dd><code>Update email template validation to support multiple addresses.</code></dd></summary>
<hr>

extensions/mailgun/v1/actions/sendEmailWithTemplate/config/fields.ts

<li>Replaced <code>getEmailValidation</code> with <code>CommaSeparatedEmailsValidationSchema</code> <br>for validating multiple email addresses.<br> <li> Added a refinement to ensure at least one email address is provided.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-e8bc50e6454d5f4c23db0d3fd21bf876b3eef5d8ca2c07d45c7f51d72c786f57">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sendEmailWithTemplate.ts</strong><dd><code>Modify email template sending logic to handle multiple recipients.</code></dd></summary>
<hr>

extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts

<li>Updated the <code>to</code> field to directly accept multiple email addresses.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-d35c295fe003e4426e90e4ca07da6c1cef6bba23c231d14aab2fe73fd5a0ad94">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getEmailValidation.ts</strong><dd><code>Implement validation schema for multiple email addresses.</code></dd></summary>
<hr>

src/lib/awell/getEmailValidationRegex/getEmailValidation.ts

<li>Added <code>CommaSeparatedEmailsValidationSchema</code> for validating multiple <br>email addresses.<br> <li> Enhanced error messages for invalid email addresses.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-400e736e69e6e61c311ca752cb7e3b39fafb20b31729e4601643f7c0427c18e3">+31/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getEmailValidation.test.ts</strong><dd><code>Add tests for validating multiple email addresses.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/awell/getEmailValidationRegex/getEmailValidation.test.ts

<li>Added unit tests for <code>CommaSeparatedEmailsValidationSchema</code>.<br> <li> Tested scenarios for no email, invalid email, single email, and <br>multiple emails with/without whitespaces.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/543/files#diff-8549f80320f378116d836e9e5a482c7fd97d67d09a42b43df2709227afd127de">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information