### PR TITLE
feat(ehrs): Epic & Cerner

### DIFF
--- a/extensions/cerner/CHANGELOG.md
+++ b/extensions/cerner/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Cerner changelog

--- a/extensions/cerner/README.md
+++ b/extensions/cerner/README.md
@@ -1,0 +1,8 @@
+---
+title: Cerner
+description: Cerner EHR is a cloud-based healthcare IT solution used to streamline clinical, administrative, and financial workflows by practices of all sizes.
+---
+
+## Cerner
+
+Cerner EHR is a cloud-based healthcare IT solution used to streamline clinical, administrative, and financial workflows by practices of all sizes.

--- a/extensions/cerner/actions/createClinicalNote/config/datapoints.ts
+++ b/extensions/cerner/actions/createClinicalNote/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/cerner/actions/createClinicalNote/config/fields.ts
+++ b/extensions/cerner/actions/createClinicalNote/config/fields.ts
@@ -1,0 +1,6 @@
+import { type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/cerner/actions/createClinicalNote/config/index.ts
+++ b/extensions/cerner/actions/createClinicalNote/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/cerner/actions/createClinicalNote/createClinicalNote.test.ts
+++ b/extensions/cerner/actions/createClinicalNote/createClinicalNote.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { createClinicalNote as action } from './createClinicalNote'
+
+describe('Epic - Create clinical note', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/cerner/actions/createClinicalNote/createClinicalNote.ts
+++ b/extensions/cerner/actions/createClinicalNote/createClinicalNote.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const createClinicalNote: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'createClinicalNote',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Create clinical note',
+  description: 'Create a clinical note in Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/cerner/actions/createClinicalNote/index.ts
+++ b/extensions/cerner/actions/createClinicalNote/index.ts
@@ -1,0 +1,1 @@
+export { createClinicalNote } from './createClinicalNote'

--- a/extensions/cerner/actions/createPatient/config/datapoints.ts
+++ b/extensions/cerner/actions/createPatient/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/cerner/actions/createPatient/config/fields.ts
+++ b/extensions/cerner/actions/createPatient/config/fields.ts
@@ -1,0 +1,6 @@
+import {  type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/cerner/actions/createPatient/config/index.ts
+++ b/extensions/cerner/actions/createPatient/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/cerner/actions/createPatient/createPatient.test.ts
+++ b/extensions/cerner/actions/createPatient/createPatient.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { createPatient as action } from './createPatient'
+
+describe('Epic - Create patient', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/cerner/actions/createPatient/createPatient.ts
+++ b/extensions/cerner/actions/createPatient/createPatient.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const createPatient: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'createPatient',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Create patient',
+  description: 'Create a patient in Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/cerner/actions/createPatient/index.ts
+++ b/extensions/cerner/actions/createPatient/index.ts
@@ -1,0 +1,1 @@
+export { createPatient } from './createPatient'

--- a/extensions/cerner/actions/getAppointment/config/datapoints.ts
+++ b/extensions/cerner/actions/getAppointment/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/cerner/actions/getAppointment/config/fields.ts
+++ b/extensions/cerner/actions/getAppointment/config/fields.ts
@@ -1,0 +1,6 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/cerner/actions/getAppointment/config/index.ts
+++ b/extensions/cerner/actions/getAppointment/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/cerner/actions/getAppointment/getAppointment.test.ts
+++ b/extensions/cerner/actions/getAppointment/getAppointment.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { getAppointment as action } from './getAppointment'
+
+describe('Epic - Get appointment', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/cerner/actions/getAppointment/getAppointment.ts
+++ b/extensions/cerner/actions/getAppointment/getAppointment.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const getAppointment: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getAppointment',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get appointment',
+  description: 'Retrieve appointment details from Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/cerner/actions/getAppointment/index.ts
+++ b/extensions/cerner/actions/getAppointment/index.ts
@@ -1,0 +1,1 @@
+export { getAppointment } from './getAppointment'

--- a/extensions/cerner/actions/getPatient/config/datapoints.ts
+++ b/extensions/cerner/actions/getPatient/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/cerner/actions/getPatient/config/fields.ts
+++ b/extensions/cerner/actions/getPatient/config/fields.ts
@@ -1,0 +1,6 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/cerner/actions/getPatient/config/index.ts
+++ b/extensions/cerner/actions/getPatient/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/cerner/actions/getPatient/getPatient.test.ts
+++ b/extensions/cerner/actions/getPatient/getPatient.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { getPatient as action } from './getPatient'
+
+describe('Epic - Get patient', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/cerner/actions/getPatient/getPatient.ts
+++ b/extensions/cerner/actions/getPatient/getPatient.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const getPatient: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getPatient',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get patient',
+  description: 'Retrieve patient details from Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/cerner/actions/getPatient/index.ts
+++ b/extensions/cerner/actions/getPatient/index.ts
@@ -1,0 +1,1 @@
+export { getPatient } from './getPatient'

--- a/extensions/cerner/actions/index.ts
+++ b/extensions/cerner/actions/index.ts
@@ -1,0 +1,13 @@
+import { createPatient } from './createPatient'
+import { getPatient } from './getPatient'
+import { getAppointment } from './getAppointment'
+import { createClinicalNote } from './createClinicalNote'
+
+const actions = {
+  getPatient,
+  getAppointment,
+  createPatient,
+  createClinicalNote,
+}
+
+export default actions

--- a/extensions/cerner/index.ts
+++ b/extensions/cerner/index.ts
@@ -1,0 +1,22 @@
+import {
+  type Extension,
+  Category,
+  AuthorType,
+} from '@awell-health/extensions-core'
+import actions from './actions'
+import { settings } from './settings'
+
+export const cerner: Extension = {
+  key: 'cerner',
+  title: 'Cerner',
+  description:
+    'Cerner EHR is a cloud-based healthcare IT solution used to streamline clinical, administrative, and financial workflows by practices of all sizes.',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1736327719/Awell%20Extensions/CERN-4c75d8aa.png',
+  category: Category.EHR_INTEGRATIONS,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  settings,
+  actions,
+}

--- a/extensions/cerner/settings.ts
+++ b/extensions/cerner/settings.ts
@@ -1,0 +1,6 @@
+import { type Setting } from '@awell-health/extensions-core'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({} satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/epic/CHANGELOG.md
+++ b/extensions/epic/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Epic changelog

--- a/extensions/epic/README.md
+++ b/extensions/epic/README.md
@@ -1,0 +1,8 @@
+---
+title: Epic
+description: Epic is a cloud-based EHR built for hospitals with the functionality to handle the day-to-day operations of a practice, including patient medical records.
+---
+
+## Epic
+
+Epic is a cloud-based EHR built for hospitals with the functionality to handle the day-to-day operations of a practice, including patient medical records.

--- a/extensions/epic/actions/createClinicalNote/config/datapoints.ts
+++ b/extensions/epic/actions/createClinicalNote/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/epic/actions/createClinicalNote/config/fields.ts
+++ b/extensions/epic/actions/createClinicalNote/config/fields.ts
@@ -1,0 +1,6 @@
+import { type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/epic/actions/createClinicalNote/config/index.ts
+++ b/extensions/epic/actions/createClinicalNote/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/epic/actions/createClinicalNote/createClinicalNote.test.ts
+++ b/extensions/epic/actions/createClinicalNote/createClinicalNote.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { createClinicalNote as action } from './createClinicalNote'
+
+describe('Epic - Create clinical note', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/epic/actions/createClinicalNote/createClinicalNote.ts
+++ b/extensions/epic/actions/createClinicalNote/createClinicalNote.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const createClinicalNote: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'createClinicalNote',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Create clinical note',
+  description: 'Create a clinical note in Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/epic/actions/createClinicalNote/index.ts
+++ b/extensions/epic/actions/createClinicalNote/index.ts
@@ -1,0 +1,1 @@
+export { createClinicalNote } from './createClinicalNote'

--- a/extensions/epic/actions/createPatient/config/datapoints.ts
+++ b/extensions/epic/actions/createPatient/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/epic/actions/createPatient/config/fields.ts
+++ b/extensions/epic/actions/createPatient/config/fields.ts
@@ -1,0 +1,6 @@
+import {  type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/epic/actions/createPatient/config/index.ts
+++ b/extensions/epic/actions/createPatient/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/epic/actions/createPatient/createPatient.test.ts
+++ b/extensions/epic/actions/createPatient/createPatient.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { createPatient as action } from './createPatient'
+
+describe('Epic - Create patient', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/epic/actions/createPatient/createPatient.ts
+++ b/extensions/epic/actions/createPatient/createPatient.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const createPatient: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'createPatient',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Create patient',
+  description: 'Create a patient in Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/epic/actions/createPatient/index.ts
+++ b/extensions/epic/actions/createPatient/index.ts
@@ -1,0 +1,1 @@
+export { createPatient } from './createPatient'

--- a/extensions/epic/actions/getAppointment/config/datapoints.ts
+++ b/extensions/epic/actions/getAppointment/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/epic/actions/getAppointment/config/fields.ts
+++ b/extensions/epic/actions/getAppointment/config/fields.ts
@@ -1,0 +1,6 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/epic/actions/getAppointment/config/index.ts
+++ b/extensions/epic/actions/getAppointment/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/epic/actions/getAppointment/getAppointment.test.ts
+++ b/extensions/epic/actions/getAppointment/getAppointment.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { getAppointment as action } from './getAppointment'
+
+describe('Epic - Get appointment', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/epic/actions/getAppointment/getAppointment.ts
+++ b/extensions/epic/actions/getAppointment/getAppointment.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const getAppointment: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getAppointment',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get appointment',
+  description: 'Retrieve appointment details from Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/epic/actions/getAppointment/index.ts
+++ b/extensions/epic/actions/getAppointment/index.ts
@@ -1,0 +1,1 @@
+export { getAppointment } from './getAppointment'

--- a/extensions/epic/actions/getPatient/config/datapoints.ts
+++ b/extensions/epic/actions/getPatient/config/datapoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/epic/actions/getPatient/config/fields.ts
+++ b/extensions/epic/actions/getPatient/config/fields.ts
@@ -1,0 +1,6 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/epic/actions/getPatient/config/index.ts
+++ b/extensions/epic/actions/getPatient/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './datapoints'

--- a/extensions/epic/actions/getPatient/getPatient.test.ts
+++ b/extensions/epic/actions/getPatient/getPatient.test.ts
@@ -1,0 +1,32 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { getPatient as action } from './getPatient'
+
+describe('Epic - Get patient', () => {
+  const {
+    extensionAction,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should work', async () => {
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        settings: {
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/epic/actions/getPatient/getPatient.ts
+++ b/extensions/epic/actions/getPatient/getPatient.ts
@@ -1,0 +1,20 @@
+import { Category, type Action } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields, dataPoints } from './config'
+
+export const getPatient: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getPatient',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get patient',
+  description: 'Retrieve patient details from Epic',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({payload, onComplete, onError}): Promise<void> => {
+    await onComplete()
+  },
+}

--- a/extensions/epic/actions/getPatient/index.ts
+++ b/extensions/epic/actions/getPatient/index.ts
@@ -1,0 +1,1 @@
+export { getPatient } from './getPatient'

--- a/extensions/epic/actions/index.ts
+++ b/extensions/epic/actions/index.ts
@@ -1,0 +1,13 @@
+import { createPatient } from './createPatient'
+import { getPatient } from './getPatient'
+import { getAppointment } from './getAppointment'
+import { createClinicalNote } from './createClinicalNote'
+
+const actions = {
+  getPatient,
+  getAppointment,
+  createPatient,
+  createClinicalNote,
+}
+
+export default actions

--- a/extensions/epic/index.ts
+++ b/extensions/epic/index.ts
@@ -1,0 +1,22 @@
+import {
+  type Extension,
+  Category,
+  AuthorType,
+} from '@awell-health/extensions-core'
+import actions from './actions'
+import { settings } from './settings'
+
+export const epic: Extension = {
+  key: 'epic',
+  title: 'Epic',
+  description:
+    'Epic is a cloud-based EHR built for hospitals with the functionality to handle the day-to-day operations of a practice, including patient medical records.',
+  icon_url:
+    'https://res.cloudinary.com/da7x4rzl4/image/upload/v1736327686/Awell%20Extensions/epiclogo_2_1.webp',
+  category: Category.EHR_INTEGRATIONS,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  settings,
+  actions,
+}

--- a/extensions/epic/settings.ts
+++ b/extensions/epic/settings.ts
@@ -1,0 +1,6 @@
+import { type Setting } from '@awell-health/extensions-core'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({} satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -4,6 +4,7 @@ import { bland } from './bland'
 import { CalDotCom } from './calDotCom'
 import { Calendly } from './calendly'
 import { CanvasMedical } from './canvasMedical'
+import { cerner } from './cerner'
 import { Cloudinary } from './cloudinary'
 import { CmDotCom } from './cmDotCom'
 import { CollectData } from './collectData'
@@ -11,6 +12,7 @@ import { dockHealth } from './dockHealth'
 import { DocuSign } from './docuSign'
 import { DropboxSign } from './dropboxSign'
 import { Elation } from './elation'
+import { epic} from './epic'
 import { Experimental } from './experimental'
 import { ExternalServer } from './external-server'
 import { Formsort } from './formsort'
@@ -54,6 +56,7 @@ export const extensions = [
   CalDotCom,
   Calendly,
   CanvasMedical,
+  cerner,
   Cloudinary,
   CmDotCom,
   CollectData,
@@ -61,6 +64,7 @@ export const extensions = [
   DocuSign,
   DropboxSign,
   Elation,
+  epic,
   Experimental,
   ExternalServer,
   Formsort,


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added new `Cerner` and `Epic` EHR integrations with actions.

- Implemented actions for creating and retrieving patients, appointments, and clinical notes.

- Included unit tests for all actions in both integrations.

- Provided documentation and changelogs for `Cerner` and `Epic` integrations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>47 files</summary><table>
<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Cerner's createClinicalNote action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-0ea9c815b013f20fd4058e8fff47292d500cfef4eae17a68522144eee3939774">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Cerner's createClinicalNote </code><br><code>action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-65abce19f2dae8e07908499f329cbdd93feaef19e7862011c7b7c6900ca1b534">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Cerner's createClinicalNote action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-c35f16ac7dc6cce651e2b84b195fe886447774560c84580c425779be24b4e09c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createClinicalNote.ts</strong><dd><code>Implement Cerner's createClinicalNote action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-89558f80c2a57a3a2ffdda39c1dfdc909641f4184c9b14f3868bd998ec8dbc93">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export createClinicalNote action for Cerner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-08a690ef6bd111e32f0f1b3919067154ae51ff7b43ef1a8c5f54459612b72f48">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Cerner's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-ca743c8f5bba88b40b078e9291560115492e9c1baeea45724888bb506e475329">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Cerner's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-2622b4bf2135dba7e42e8557a59a1d2f297d70a8a6ef16bae3e70f01ef9dbe8a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Cerner's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-cb665f6a5de58f3660a81f7960e0828985dea1d2170eb1f8d372e06fe843224d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createPatient.ts</strong><dd><code>Implement Cerner's createPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-8f0431aedbc7d0c0695176b52e23bf3cf281692ea47808492842070f1e58d9e2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export createPatient action for Cerner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-bcb26e88f686060e7f7aff1d380ba28a1b199df2dfc4d2136aad78316a005044">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Cerner's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-6a7e3f29e52c4ad7272ab77328123c09ffed3f01ee47ba9e114572c935a792de">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Cerner's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-536b7be588c7844978a19dc48ae056d0690f159ccf8c9f46e5f32c9b653776da">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Cerner's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-8c52242d970ba6962f2507634cb549b9f2576b78fa31e5bceb3e2da7a445abfe">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getAppointment.ts</strong><dd><code>Implement Cerner's getAppointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-6440915f8c84529856dad1a31bdf830f7d7df0f95dd86ea899bbf2b8e69ae0bf">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export getAppointment action for Cerner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-4658db63d606068750f13a34c1a88fd25e73c709e9d237e3911f9cff8707249c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Cerner's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-9510186b74ee3516e3860fa463f87ae67fe1d6b381998440c7efd83932ccb011">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Cerner's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-fcb6fff92460afc0ab87d2b8533ec92eff04c813d309c5ea47e4eec2b68d1178">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Cerner's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-f04d2075d6a7e743c2ca740157cab1cdc1c4330a35310db667a2ab23dc89bc05">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getPatient.ts</strong><dd><code>Implement Cerner's getPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-b1e98b3ee30bbbd6cf8358437bf6b70f537c31bbf5a51aa39b8d915abd139117">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export getPatient action for Cerner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-dee3f3469f1e198ccdf99592843f28f119061b46860df31b0f0fe9be46a2d673">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Aggregate and export all Cerner actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-fff0a049bf210c77c7de2c4f00a5ef102fe32baf9347f6036f87044c41932545">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Define Cerner extension with actions and settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-182e012c705aa397d451f9ae6448fed82bdc834d8353f7049669b33647ffecec">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings.ts</strong><dd><code>Define settings and validation schema for Cerner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-9fcbffdd7f02d4ed74a99f5410fd1e8ef92b10f918efa83ee3351e30b74690c5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Epic's createClinicalNote action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-8d39d7e8ff8127b6d4f9dad0a0c44857f574a6c8599e5535c627e02761282084">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Epic's createClinicalNote </code><br><code>action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-dbfaaa08d051baeb4fe4309e4808daaa97d290d3b3ab5b0d0b33ab7b7c868e5f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Epic's createClinicalNote action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-c108807ac88a1994a2e4c308504a02358058aa067f65c3bf8cda1d0048fffa5e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createClinicalNote.ts</strong><dd><code>Implement Epic's createClinicalNote action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-43da3e9383f221e5ff2b535e988aadd3eef75039e6122513cbd0ba8311405298">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export createClinicalNote action for Epic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-a8fe78920df3d279de0b991e3377d5765ab2334ec7b4a11c44ce3fd5fe360775">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Epic's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-6638c05166694f204581b2070a5f85ebb70279764c24eabad8bcf4d67f2f3f1a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Epic's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-ffd0d2c4efdf7680fef86933c95e4a979252acd466d47a42c3197fce5af63cc3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Epic's createPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-f9c6b65a5532ab8d1d67039d53a7ba95cb0d9ad112662825a6958932890eb2bf">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createPatient.ts</strong><dd><code>Implement Epic's createPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-daa006415ac86402a69ad0460fc96d3e24b724e18b63b05899217b755584ed6b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export createPatient action for Epic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-b4631ab1bc0eef2299e0012e6ab70d15b4ffbd560e72082b584b8de4656f0bcd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Epic's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-ade2b4dd3acf8bfd8fbd0bd4bb6701af4ecf2a1ff841a1aa54779c32c5c377df">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Epic's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-2fa546f81468d67dcb02a94fa00077a8f220c6b1413a2984b069ba12e4aa6c03">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Epic's getAppointment action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-97f197b23e6decb87ffd9319be4049173f46a43b20ccffdec7d20032d47bd86a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getAppointment.ts</strong><dd><code>Implement Epic's getAppointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-9cd375fdb4abfc2eea5036a30fd67442eeab8ce1fb1ebe78d905540de97a6ada">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export getAppointment action for Epic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-08d0166454b4a3f6e524b02ed145e50f3401d758e5101dd195a1dbadc74bfd1e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datapoints.ts</strong><dd><code>Define datapoints configuration for Epic's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-31f2e7933d211979ecfed846920338894ae08830d74495f6cd26080543827f8b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Define fields and validation schema for Epic's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-25f83eba0750e23aa98d5c770b2d8a266025aa5309504757cce3ee5799bf0faa">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export fields and datapoints for Epic's getPatient action</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-f63a7505b585968429400b5b92a056eaebb0d345cd12f2385c20d6f8ffb11d25">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getPatient.ts</strong><dd><code>Implement Epic's getPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-e3ca6b6a4d36798ffe4954cad777e0e874377d01a77f8f22db8f08a50cb4d775">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export getPatient action for Epic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-06a2ed153450ba60ff34691b91a47669b9a5f10948ade5203b10cf491dbe2a18">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Aggregate and export all Epic actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-650b1742b2f350702c2a22f6e3ab236fa0dff4ca211bdaf849237228b2ae01b8">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Define Epic extension with actions and settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-f2341bbfdc22efa57978306219e2036139d5d4a4c342c84fa9d57a653d709b62">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings.ts</strong><dd><code>Define settings and validation schema for Epic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-ef1ee6704a3c9f9da320bcd1fad25c3e3b2c42ef644edd26076fddbfd1ee4c83">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Register Cerner and Epic extensions in the main index</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-7ddceb2fa455ec880b6b3532d7948237aefbc3cef0301232681906d47fbfe4cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>createClinicalNote.test.ts</strong><dd><code>Add unit test for Cerner's createClinicalNote action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-718c3366bb5b52bebf6a5b825bde87513ddb6ad83968157e56bf5714fc76e47c">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createPatient.test.ts</strong><dd><code>Add unit test for Cerner's createPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-cb98b6d9c3f3ed749bcab359b8f7acc58276c3ad0d590c2e8bea5ec66a9bf630">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getAppointment.test.ts</strong><dd><code>Add unit test for Cerner's getAppointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-ad5987511f90624c84a056c70b6d020cc4bc40dd0e964331ac9796581213dda3">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getPatient.test.ts</strong><dd><code>Add unit test for Cerner's getPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-244c8c44bb2e7cf286784c728dd3d6bc10166a8a43a03f8df8339b3f508ec61d">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createClinicalNote.test.ts</strong><dd><code>Add unit test for Epic's createClinicalNote action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-646bd31e712b1358c57bdff3c8d4ffcbdc51d1b51ffd587cb7249c572157aa5c">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createPatient.test.ts</strong><dd><code>Add unit test for Epic's createPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-0450b750360de0ee7b6fee61742e0658a43a6a54c0d4478ee03f8e8ff2ca9e74">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getAppointment.test.ts</strong><dd><code>Add unit test for Epic's getAppointment action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-59ae9af3e601f56924ce66fbea9c2326d292ba61176e986c1ba7ac2e09472e7b">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getPatient.test.ts</strong><dd><code>Add unit test for Epic's getPatient action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-68501910ffe464183152f716c53a133597f0fe35824357ca96debf9305e4ebb9">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add changelog for Cerner extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-1675dfa1619f7e3538d04dc9f68a0f5abe0a16ea2d1b6321f4d4b027d60088bd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add README for Cerner extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-a34b597aa4e1d6f55f079ba223ddc4a1e73485e2b4847c4e794543aaad39fa0a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add changelog for Epic extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-2329099b3ed8345952b8c8eee8bb79d994ea55b4cc3e78e00b46f3d5f6fa3c92">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add README for Epic extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/544/files#diff-97f6cedea0f896886e792fbab6ea24589836542d03a410834b4203994fb85b63">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information