### PR TITLE
ET-764: store `signed_by` from Elation letter

### DIFF
--- a/extensions/elation/actions/getLetter/config/dataPoints.ts
+++ b/extensions/elation/actions/getLetter/config/dataPoints.ts
@@ -5,4 +5,8 @@ export const dataPoints = {
     key: 'body',
     valueType: 'string',
   },
+  signedBy: {
+    key: 'signedBy',
+    valueType: 'number',
+  },
 } satisfies Record<string, DataPointDefinition>

--- a/extensions/elation/actions/getLetter/getLetter.test.ts
+++ b/extensions/elation/actions/getLetter/getLetter.test.ts
@@ -47,6 +47,7 @@ describe('Elation - Get letter', () => {
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         body: 'Diagnosis:\nLength of Time needed:\n\nAmbulatory Devices:\n[x] Wheelchair\n[] Cane\n[] Walker\n[] Walker with Wheels and Seat (Rollator)\n[] Power Wheel Chair',
+        signedBy: '12323455',
       },
     })
   })

--- a/extensions/elation/actions/getLetter/getLetter.ts
+++ b/extensions/elation/actions/getLetter/getLetter.ts
@@ -24,6 +24,10 @@ export const getLetter: Action<
     await onComplete({
       data_points: {
         body: res.body,
+        signedBy:
+          typeof res?.signed_by === 'number'
+            ? String(res.signed_by)
+            : undefined,
       },
     })
   },

--- a/extensions/elation/types/letter.ts
+++ b/extensions/elation/types/letter.ts
@@ -35,15 +35,24 @@ export interface GetLetterResponseType {
     id: number
     document_type: string
   }>
-  sign_date: string
-  signed_by: number
+  sign_date?: string
+  signed_by?: number
   tags: string[]
   document_date: string
   patient: number
   practice: number
 }
 
-export type PostLetterInput = Pick<z.infer<typeof letterSchema>, 'patient' | 'practice' | 'body' | 'subject' | 'referral_order' | 'letter_type' | 'send_to_contact'>
+export type PostLetterInput = Pick<
+  z.infer<typeof letterSchema>,
+  | 'patient'
+  | 'practice'
+  | 'body'
+  | 'subject'
+  | 'referral_order'
+  | 'letter_type'
+  | 'send_to_contact'
+>
 
 export interface PostLetterResponse extends z.infer<typeof letterSchema> {
   id: number


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `signedBy` data point to Elation letter handling.

- Updated `getLetter` action to process `signed_by` field.

- Adjusted type definitions for optional `signed_by` and `sign_date`.

- Enhanced test coverage for `signedBy` data point.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataPoints.ts</strong><dd><code>Add `signedBy` data point definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/elation/actions/getLetter/config/dataPoints.ts

- Added `signedBy` data point with key and valueType.


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/545/files#diff-e07ca56875c25eb65d9dd23964916c06c328e8b18f694f34132d1d82f02ab06d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getLetter.ts</strong><dd><code>Update `getLetter` action to handle `signedBy`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/elation/actions/getLetter/getLetter.ts

<li>Updated <code>getLetter</code> action to include <code>signedBy</code> in response.<br> <li> Handled type conversion for <code>signed_by</code> field.


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/545/files#diff-f4740fd0e19abb1eba0af4f4b56f465fb6b606426062ec5fccda8d055f0ab19b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>letter.ts</strong><dd><code>Adjust type definitions for optional fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/elation/types/letter.ts

<li>Made <code>signed_by</code> and <code>sign_date</code> fields optional.<br> <li> Reformatted <code>PostLetterInput</code> type for readability.


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/545/files#diff-120ee6767ce11d653387847fd7734786098635f11ce9bc71005ed30f4db232c5">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getLetter.test.ts</strong><dd><code>Add test for `signedBy` data point</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/elation/actions/getLetter/getLetter.test.ts

- Added test case to validate `signedBy` data point.


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/545/files#diff-a586d48620336ccd2011e9b0779d2c4b8d30f05b7a7704f1d6d667d8caf4a09f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information