### PR TITLE
TP-2828: Elation - sign note

### DIFF
--- a/extensions/elation/actions/index.ts
+++ b/extensions/elation/actions/index.ts
@@ -26,6 +26,7 @@ import { updatePatientTags } from './updatePatientTags'
 import { getReferralOrder } from './getReferralOrder'
 import { findFutureAppointment } from './findFutureAppointment'
 import { findAppointmentsByPrompt } from './findAppointmentsByPrompt'
+import { signNonVisitNote } from './signNonVisitNote/signNonVisitNote'
 
 export const actions = {
   getPatient,
@@ -56,4 +57,5 @@ export const actions = {
   getReferralOrder,
   findFutureAppointment,
   findAppointmentsByPrompt,
+  signNonVisitNote,
 }

--- a/extensions/elation/actions/signNonVisitNote/config/dataPoints.ts
+++ b/extensions/elation/actions/signNonVisitNote/config/dataPoints.ts
@@ -1,0 +1,3 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {} satisfies Record<string, DataPointDefinition>

--- a/extensions/elation/actions/signNonVisitNote/config/fields.ts
+++ b/extensions/elation/actions/signNonVisitNote/config/fields.ts
@@ -1,0 +1,29 @@
+import { z, type ZodTypeAny } from 'zod'
+import {
+  type Field,
+  FieldType,
+  NumericIdSchema,
+} from '@awell-health/extensions-core'
+
+export const fields = {
+  nonVisitNoteId: {
+    id: 'nonVisitNoteId',
+    label: 'Non-Visit Note ID',
+    type: FieldType.NUMERIC,
+    required: true,
+    description: '',
+  },
+  signedBy: {
+    id: 'signedBy',
+    label: 'Signed by',
+    description:
+      'The ID of the physician who signs the note. Note: it has to be a physician ID, not a user ID.',
+    type: FieldType.NUMERIC,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  nonVisitNoteId: NumericIdSchema,
+  signedBy: NumericIdSchema,
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/elation/actions/signNonVisitNote/config/index.ts
+++ b/extensions/elation/actions/signNonVisitNote/config/index.ts
@@ -1,0 +1,2 @@
+export { dataPoints } from './dataPoints'
+export { fields, FieldsValidationSchema } from './fields'

--- a/extensions/elation/actions/signNonVisitNote/index.ts
+++ b/extensions/elation/actions/signNonVisitNote/index.ts
@@ -1,0 +1,1 @@
+export { signNonVisitNote } from './signNonVisitNote'

--- a/extensions/elation/actions/signNonVisitNote/signNonVisitNote.test.ts
+++ b/extensions/elation/actions/signNonVisitNote/signNonVisitNote.test.ts
@@ -1,0 +1,110 @@
+import { makeAPIClientMockFunc } from '../../__mocks__/client'
+import { makeAPIClient } from '../../client'
+import { signNonVisitNote as action } from './signNonVisitNote'
+import { TestHelpers } from '@awell-health/extensions-core'
+
+jest.mock('../../client', () => ({
+  makeAPIClient: jest.fn(),
+}))
+
+describe('Elation - Sign non-visit note', () => {
+  const { extensionAction, onComplete, onError, helpers, clearMocks } =
+    TestHelpers.fromAction(action)
+
+  const mockGetPhysician = jest.fn()
+  const mockUpdateNonVisitNote = jest.fn()
+
+  beforeAll(() => {
+    const mockAPIClient = makeAPIClient as jest.Mock
+    mockAPIClient.mockImplementation(makeAPIClientMockFunc)
+  })
+
+  beforeAll(() => {
+    const mockAPIClient = makeAPIClient as jest.Mock
+    mockAPIClient.mockImplementation(() => ({
+      getPhysician: mockGetPhysician,
+      updateNonVisitNote: mockUpdateNonVisitNote,
+    }))
+  })
+
+  beforeEach(() => {
+    clearMocks()
+    jest.clearAllMocks()
+  })
+
+  describe('When the signedBy field is not a valid physician', () => {
+    beforeEach(() => {
+      mockGetPhysician.mockRejectedValue({
+        detail: 'No PhysicianProxy matches the given query.',
+      })
+      mockUpdateNonVisitNote.mockResolvedValue({})
+    })
+
+    test('Should return an error', async () => {
+      await extensionAction.onEvent({
+        payload: {
+          fields: {
+            nonVisitNoteId: 142685415604249,
+            signedBy: 141402084933634,
+          },
+          settings: {
+            client_id: 'clientId',
+            client_secret: 'clientSecret',
+            username: 'username',
+            password: 'password',
+            auth_url: 'authUrl',
+            base_url: 'baseUrl',
+          },
+        } as any,
+        onComplete,
+        onError,
+        helpers,
+      })
+
+      expect(onError).toHaveBeenCalledWith({
+        events: [
+          {
+            date: expect.any(String),
+            text: {
+              en: 'Failed to retrieve the physician (141402084933634) to sign the note. Non-visit notes have to be signed by a physician.',
+            },
+          },
+        ],
+      })
+    })
+  })
+
+  describe('When the signedBy field is a valid physician', () => {
+    beforeEach(() => {
+      mockGetPhysician.mockResolvedValue({
+        id: 141402084933634,
+      })
+      mockUpdateNonVisitNote.mockResolvedValue({})
+    })
+
+    test('Should return the correct letter', async () => {
+      await extensionAction.onEvent({
+        payload: {
+          fields: {
+            nonVisitNoteId: 142685415604249,
+            signedBy: 141402084933634,
+          },
+          settings: {
+            client_id: 'clientId',
+            client_secret: 'clientSecret',
+            username: 'username',
+            password: 'password',
+            auth_url: 'authUrl',
+            base_url: 'baseUrl',
+          },
+        } as any,
+        onComplete,
+        onError,
+        helpers,
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(onComplete).toHaveBeenCalled()
+    })
+  })
+})

--- a/extensions/elation/actions/signNonVisitNote/signNonVisitNote.ts
+++ b/extensions/elation/actions/signNonVisitNote/signNonVisitNote.ts
@@ -1,0 +1,48 @@
+import { type Action, Category } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { makeAPIClient } from '../../client'
+import { FieldsValidationSchema, fields, dataPoints } from './config'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+
+export const signNonVisitNote: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'signNonVisitNote',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Sign non-visit note',
+  description: 'Sign a non-visit note in Elation.',
+  fields,
+  previewable: false,
+  dataPoints,
+  onEvent: async ({ payload, onComplete, onError }): Promise<void> => {
+    const { nonVisitNoteId, signedBy } = FieldsValidationSchema.parse(
+      payload.fields,
+    )
+    const api = makeAPIClient(payload.settings)
+
+    /**
+     * A non-visit note can only be signed by a physician.
+     * We will validate if the signedBy is a physician and throw a readable error if not.
+     */
+    try {
+      await api.getPhysician(signedBy)
+    } catch (error) {
+      await onError({
+        events: [
+          addActivityEventLog({
+            message: `Failed to retrieve the physician (${signedBy}) to sign the note. Non-visit notes have to be signed by a physician.`,
+          }),
+        ],
+      })
+      return
+    }
+
+    await api.updateNonVisitNote(nonVisitNoteId, {
+      signed_by: signedBy,
+    })
+
+    await onComplete()
+  },
+}

--- a/extensions/elation/actions/updateNonVisitNote.ts
+++ b/extensions/elation/actions/updateNonVisitNote.ts
@@ -91,7 +91,8 @@ const fields = {
   signed_by: {
     id: 'signed_by',
     label: 'Signed by (user ID)',
-    description: 'ID of a user who signed the note.',
+    description:
+      '⚠️ DEPRECATED - Please use the "Sign non-visit note" action to sign a non-visit note instead.',
     type: FieldType.NUMERIC,
     required: false,
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "node dist/src/index.js",
     "lint": "eslint \"**/*.ts\"",
     "test": "jest --verbose --testPathIgnorePatterns '.*\\.local\\.test\\.ts$'",
+    "test-local": "jest --verbose",
     "prepack": "yarn build",
     "test-server": "ts-node-dev --respawn --transpile-only ./src/test-server.ts",
     "prepare": "husky"

--- a/tests/createAxiosError.ts
+++ b/tests/createAxiosError.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios'
+
+// Helper function to mock AxiosError
+export const createAxiosError = (
+  status: number,
+  statusText: string,
+  data: any,
+): AxiosError => {
+  const response = {
+    status: status,
+    statusText: statusText,
+    data: JSON.parse(data),
+  }
+
+  const error = new AxiosError(
+    `Request failed with status code ${status}`,
+    status.toString(), // This sets the error code, e.g., "400"
+    undefined, // This represents the config, but can be left empty for a mock
+    undefined, // This represents the request, but can be left empty for a mock
+    // @ts-expect-error this is fine for the mock
+    response,
+  )
+  return error
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,1 +1,2 @@
 export * from './constants'
+export * from './createAxiosError'


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added a new action `signNonVisitNote` for signing non-visit notes.

- Implemented validation to ensure only physicians can sign notes.

- Deprecated `signed_by` field in `updateNonVisitNote` action.

- Added comprehensive tests for the `signNonVisitNote` functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Added `signNonVisitNote` to the actions export list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-9a1c0055b212081498d2441b821c3c51501a8ff23fa020ebccd3e99395c37a08">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Exported `signNonVisitNote` action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-f23737538bb8ed23c0d74af102da569a73dd9fa6bb3ad594a54b5607ec75478d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>signNonVisitNote.ts</strong><dd><code>Implemented `signNonVisitNote` action logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-58340f48d12bf89055d6f20ed751320c2e7c605a1e5d4c0e900480c7c791ab89">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dataPoints.ts</strong><dd><code>Defined data points configuration for `signNonVisitNote`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-a5047af05097fadbc25e5db86997cf73ce2c1ce2c2362e80846d870f241020ca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.ts</strong><dd><code>Defined fields and validation schema for `signNonVisitNote`</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-5f2f649e67e1d92492e7b0d6d88f77a6054393555078e368b958be469274bad3">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Exported configuration for `signNonVisitNote`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-cc3f5d4656385ba8839393b8845dc33381f7c7d5fd4f226d8205f8d66bfc890b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Added `test-local` script for running local tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>signNonVisitNote.test.ts</strong><dd><code>Added tests for `signNonVisitNote` action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-c2ad2250762750e660b3a2542047824a13074decf82b95a646076982b5cb2e86">+110/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>updateNonVisitNote.ts</strong><dd><code>Deprecated `signed_by` field in favor of `signNonVisitNote`</code></dd></td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/559/files#diff-69770521bdc7fc0d4d9963d972a49b56b0d210a1856cf520f02f1a5e2ce800d6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information