### PR TITLE
fix(elation): sending '  ' for clearing patient tags raises an error

### DIFF
--- a/extensions/elation/actions/updatePatientTags/updateTags.ts
+++ b/extensions/elation/actions/updatePatientTags/updateTags.ts
@@ -3,8 +3,7 @@ import { type ElationAPIClient } from '../../client'
 export const updateElationTags = async (api: ElationAPIClient, patientId: number, tags: string[]): Promise<void> => {
     if (tags.length === 0) {
       await api.updatePatient(patientId, {
-        // @ts-expect-error - elation api does not clear tags on an empty array
-        tags: ' ',
+        tags: [],
       })
     } else {
       await api.updatePatient(patientId, {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where sending a single space (' ') to clear patient tags caused an error.

- Updated the code to use an empty array (`[]`) for clearing tags instead.

We are getting `External service returned with error - (ERR_BAD_REQUEST) Request failed with status code 400` when trying to set ' ' for clearing the tags.
Based on the documentation (no clear info about empty tags) but we should be sending array anyways.
Let's merge and check.
If it works will clear if-then part.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>updateTags.ts</strong><dd><code>Fix clearing patient tags using empty array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/elation/actions/updatePatientTags/updateTags.ts

<li>Replaced the use of a single space (' ') with an empty array (<code>[]</code>) for <br>clearing patient tags.<br> <li> Removed a comment about the Elation API not clearing tags with an <br>empty array.


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-extensions/pull/566/files#diff-bdd60bf158a0476497e18f687362de946a02ce2b5cbe30b3e7ea0b9f6bf11515">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>