### PR TITLE
feat(openai): increase timeout and retry attempts

### DIFF
--- a/src/lib/llm/openai/constants.ts
+++ b/src/lib/llm/openai/constants.ts
@@ -6,8 +6,8 @@
  */
 export const OPENAI_CONFIG = {
   temperature: 0,
-  maxRetries: 3,
-  timeout: 10000,
+  maxRetries: 5,
+  timeout: 30000,
 } as const
 
 /**


### PR DESCRIPTION
[ET-869: Increase OpenAI timeout and retry attempts to AI Actions](https://linear.app/awell/issue/ET-869/increase-openai-timeout-and-retry-attempts-to-ai-actions)

- Increase timeout to 30s and number of attempts to 5
- This change will be applied to all AI actions
- Nothing will be changed - this just gives us more robustness with OpenAI and networking issues.
- RealOpenAI tests run locally - all good.  
