### PR TITLE
DRAFT: ET-914: Add "Get Patient Vitals" action in Elation extension

### DIFF
--- a/extensions/elation/__mocks__/client.ts
+++ b/extensions/elation/__mocks__/client.ts
@@ -117,6 +117,11 @@ export const mockClientReturn = {
   createReferralOrder: jest.fn(() => {
     return referralOrderExample
   }),
+  findVitals: jest.fn(() => {
+    return {
+      results: [vitalsResponseExample],
+    }
+  }),
 }
 const ElationAPIClientMock = jest.fn((params) => {
   return mockClientReturn

--- a/extensions/elation/actions/getPatientVitals/config/dataPoints.ts
+++ b/extensions/elation/actions/getPatientVitals/config/dataPoints.ts
@@ -1,0 +1,16 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  vitals: {
+    key: 'vitals',
+    valueType: 'json',
+  },
+  documentDate: {
+    key: 'documentDate',
+    valueType: 'string',
+  },
+  vitalsId: {
+    key: 'vitalsId',
+    valueType: 'number',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/elation/actions/getPatientVitals/config/fields.ts
+++ b/extensions/elation/actions/getPatientVitals/config/fields.ts
@@ -1,0 +1,20 @@
+import {
+  FieldType,
+  NumericIdSchema,
+  type Field,
+} from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+
+export const fields = {
+  patientId: {
+    id: 'patientId',
+    label: 'Patient ID',
+    description: 'The patient for whom the vitals are being retrieved',
+    type: FieldType.NUMERIC,
+    required: true,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  patientId: NumericIdSchema,
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/elation/actions/getPatientVitals/config/index.ts
+++ b/extensions/elation/actions/getPatientVitals/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/elation/actions/getPatientVitals/getPatientVitals.test.ts
+++ b/extensions/elation/actions/getPatientVitals/getPatientVitals.test.ts
@@ -1,0 +1,62 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+
+import { getPatientVitals as action } from './getPatientVitals'
+import { ZodError } from 'zod'
+
+jest.mock('../../client')
+
+describe('Elation - Get Patient Vitals', () => {
+  const {
+    extensionAction: getPatientVitals,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  const settings = {
+    client_id: 'clientId',
+    client_secret: 'clientSecret',
+    username: 'username',
+    password: 'password',
+    auth_url: 'authUrl',
+    base_url: 'baseUrl',
+  }
+
+  const patientDetails = {
+    patientId: 123,
+  }
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should call onComplete when successful', async () => {
+    await getPatientVitals.onEvent({
+      payload: {
+        fields: patientDetails,
+        settings,
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  test('Should call onError when patientId is missing', async () => {
+    const resp = getPatientVitals.onEvent({
+      payload: {
+        fields: {},
+        settings,
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    await expect(resp).rejects.toThrow(ZodError)
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+})

--- a/extensions/elation/actions/getPatientVitals/getPatientVitals.ts
+++ b/extensions/elation/actions/getPatientVitals/getPatientVitals.ts
@@ -1,0 +1,55 @@
+import { type Action, Category, validate } from '@awell-health/extensions-core'
+import { z } from 'zod'
+import { makeAPIClient } from '../../client'
+import { SettingsValidationSchema, type settings } from '../../settings'
+import type {
+  FindVitalsInputType
+} from '../../types/vitals'
+import {
+  FieldsValidationSchema,
+  dataPoints,
+  fields as elationFields,
+} from './config'
+
+
+export const getPatientVitals: Action<
+  typeof elationFields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getPatientVitals',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get Patient Vitals',
+  description: 'Get vitals for the patient',
+  fields: elationFields,
+  previewable: true,
+  dataPoints,
+  onEvent: async ({ payload, onComplete }): Promise<void> => {
+    const { fields, settings } = validate({
+      schema: z.object({
+        fields: FieldsValidationSchema,
+        settings: SettingsValidationSchema,
+      }),
+      payload,
+    })
+
+    const api = makeAPIClient(settings)
+
+    const body: FindVitalsInputType = {
+      patient: [fields.patientId],
+    }
+
+    const { results } = await api.findVitals(body)
+
+    // TODO: this is paginated, we need to get all the pages
+    const lastVital = results[results.length - 1]
+
+    await onComplete({
+      data_points: {
+        vitalsId: String(lastVital.id),
+        documentDate: lastVital.document_date,
+        vitals: JSON.stringify(lastVital),
+      },
+    })
+  },
+}

--- a/extensions/elation/actions/getPatientVitals/index.ts
+++ b/extensions/elation/actions/getPatientVitals/index.ts
@@ -1,0 +1,1 @@
+export { getPatientVitals } from './getPatientVitals'

--- a/extensions/elation/actions/index.ts
+++ b/extensions/elation/actions/index.ts
@@ -29,6 +29,7 @@ import { findFutureAppointment } from './findFutureAppointment'
 import { findAppointmentsByPrompt } from './findAppointmentsByPrompt'
 import { signNonVisitNote } from './signNonVisitNote/signNonVisitNote'
 import { updateReferralOrderResolution } from './updateReferralOrderResolution'
+import { getPatientVitals } from './getPatientVitals'
 
 export const actions = {
   getPatient,
@@ -62,4 +63,5 @@ export const actions = {
   findAppointmentsByPrompt,
   signNonVisitNote,
   updateReferralOrderResolution,
+  getPatientVitals,
 }

--- a/extensions/elation/client.ts
+++ b/extensions/elation/client.ts
@@ -38,7 +38,7 @@ import {
   type CreateVisitNoteInputType,
   type CreateVisitNoteResponseType,
   type PharmacyResponse,
-  type AddVitalsInputType,
+  type AddVitalsInputType,  
   type AddVitalsResponseType,
   PharmacySchema,
   type PostCareGapInput,
@@ -49,6 +49,8 @@ import {
   type GetReferralOrderInputType,
   type GetReferralOrderResponseType,
   type AddMessageToThreadInput,
+  type FindVitalsInputType,
+  type FindVitalsResponseType,
 } from './types'
 import { elationCacheService } from './cache'
 import { isEmpty } from 'lodash'
@@ -353,6 +355,19 @@ export class ElationDataWrapper extends DataWrapper {
     return res
   }
 
+  public async findVitals(
+    obj: FindVitalsInputType,
+  ): Promise<FindVitalsResponseType> {
+    const req = this.Request<FindVitalsResponseType>({
+      method: 'GET',
+      url: `/vitals`,
+      params: obj,
+    })
+    const res = await req
+    return res
+  }
+
+
   public async getPharmacy(ncpdpId: string): Promise<PharmacyResponse> {
     return PharmacySchema.parse(
       await this.Request<PharmacyResponse>({
@@ -615,6 +630,12 @@ export class ElationAPIClient extends APIClient<ElationDataWrapper> {
     obj: AddVitalsInputType,
   ): Promise<AddVitalsResponseType> {
     return await this.FetchData(async (dw) => await dw.addVitals(obj))
+  }
+
+  public async findVitals(
+    obj: FindVitalsInputType,
+  ): Promise<FindVitalsResponseType> {
+    return await this.FetchData(async (dw) => await dw.findVitals(obj))
   }
 
   public async getPharmacy(ncpdpId: string): Promise<PharmacyResponse> {

--- a/extensions/elation/types/vitals.ts
+++ b/extensions/elation/types/vitals.ts
@@ -74,8 +74,56 @@ export const AddVitalsInputSchema = z
   })
   .strict()
 
+export const FindVitalsInputSchema = z.object({
+  patient: z.array(z.number()).optional(),
+  practice: z.array(z.number()).optional(),
+  visit_note: z.array(z.number()).optional(),
+  non_visit_note: z.array(z.number()).optional(),
+})
+
+
 export type AddVitalsInputType = z.infer<typeof AddVitalsInputSchema>
+export type FindVitalsInputType = z.infer<typeof FindVitalsInputSchema>
 
 export interface AddVitalsResponseType extends AddVitalsInputType {
   id: number
+}
+
+interface Measurement {
+  value: string
+  units: string
+  note: string
+}
+
+export interface VitalsResponseType {
+  id: number
+  bmi?: number
+  height?: Measurement[]
+  weight?: Measurement[]
+  oxygen?: Measurement[]
+  rr?: Measurement[]
+  hr?: Measurement[]
+  hc?: Measurement[]
+  temperature?: Measurement[]
+  bp?: Measurement[]
+  pain?: Measurement[]
+  bmi_percentile?: number
+  length_for_weight_percentile?: number
+  patient: number
+  practice: number
+  visit_note?: number
+  non_visit_note?: number
+  document_date?: string
+  chart_date?: string
+  signed_date?: string
+  signed_by?: number
+  created_date: string
+  deleted_date?: string
+}
+
+export interface FindVitalsResponseType {
+  count: number
+  next?: string
+  previous?: string
+  results: VitalsResponseType[]
 }


### PR DESCRIPTION
2 requirements missing:

- What to do in case of pagination of the response object? How do we fetch the last collected vitals.
- The scores PHQ-9 and GAD7 are not mentioned in the Elation object definition. 