### PR TITLE
fix(elation): add datetime awareness to findAppointmentsWithLLM

### DIFF
--- a/extensions/elation/actions/findAppointmentsWithAI/__testdata__/GetAppointments.mock.ts
+++ b/extensions/elation/actions/findAppointmentsWithAI/__testdata__/GetAppointments.mock.ts
@@ -1,9 +1,9 @@
-import { addDays } from 'date-fns'
+import { addHours } from 'date-fns'
 
 export const appointmentsMock = [
   {
     id: 123,
-    scheduled_date: addDays(new Date(), 1).toISOString(),
+    scheduled_date: addHours(new Date(), 12).toISOString(),
     duration: 60,
     billing_details: null,
     payment: null,
@@ -47,7 +47,7 @@ export const appointmentsMock = [
   },
   {
     id: 456,
-    scheduled_date: addDays(new Date(), 2).toISOString(),
+    scheduled_date: addHours(new Date(), 25).toISOString(),
     duration: 60,
     billing_details: null,
     payment: null,

--- a/extensions/elation/actions/findAppointmentsWithAI/findAppointmentsWithAIRealOpenAI.test.ts
+++ b/extensions/elation/actions/findAppointmentsWithAI/findAppointmentsWithAIRealOpenAI.test.ts
@@ -98,13 +98,18 @@ describe.skip('findAppointmentsWithAI - Real OpenAI calls', () => {
       }
     },
     {
-      name: 'find established patient visits',
-      prompt: 'Find established patient visits',
+      name: 'find appointments from now until 30 hours from now',
+      prompt: 'Find appointments from now until 30 hours from now',
       shouldFind: true,
-      expectedCount: 2,
+      expectedCount: 1,
       validate: (appointments: typeof appointmentsMock) => {
+        expect(appointments).toHaveLength(1)
         appointments.forEach(apt => {
-          expect(apt.reason).toContain('Est. Patient')
+          const aptDate = new Date(apt.scheduled_date)
+          const now = new Date()
+          const thirtyHoursFromNow = new Date(now.getTime() + 30 * 60 * 60 * 1000)
+          expect(aptDate.getTime()).toBeGreaterThanOrEqual(now.getTime())
+          expect(aptDate.getTime()).toBeLessThanOrEqual(thirtyHoursFromNow.getTime())
         })
       }
     },

--- a/extensions/elation/actions/findFutureAppointment/__testdata__/GetAppointments.mock.ts
+++ b/extensions/elation/actions/findFutureAppointment/__testdata__/GetAppointments.mock.ts
@@ -1,4 +1,4 @@
-import { addDays } from 'date-fns'
+import { addDays, addHours } from 'date-fns'
 
 export const appointmentsMock = [
   {
@@ -47,7 +47,51 @@ export const appointmentsMock = [
   },
   {
     id: 456,
-    scheduled_date: addDays(new Date(), 2).toISOString(),
+    scheduled_date: addDays(new Date(), 3).toISOString(),
+    duration: 60,
+    billing_details: null,
+    payment: null,
+    time_slot_type: 'appointment',
+    time_slot_status: null,
+    reason: 'PCP: Est. Patient Office',
+    mode: 'VIDEO',
+    description: '',
+    status: {
+      status: 'Scheduled',
+      room: null,
+      status_date: '2023-07-12T20:44:22Z',
+      status_detail: null,
+    },
+    patient: 12345,
+    patient_forms: {
+      patient_can_receive_forms: true,
+      anonymous_url:
+        'https://sandbox.elationemr.com/appointments/141701667029082/patient-forms/?key=642301d3930ac1e4d052ff65c093c5f1da1697e6b861a18f43a042b5afca50a1',
+      overrides: [],
+      short_code: null,
+      statuses: [
+        {
+          id: 316,
+          name: 'COVID-19 Screening Form',
+          status: 'incomplete',
+        },
+      ],
+      hours_prior: 0,
+    },
+    physician: 141114870071298,
+    practice: 141114865745924,
+    instructions: '',
+    recurring_event_schedule: null,
+    metadata: null,
+    created_date: '2023-07-12T20:44:22Z',
+    last_modified_date: '2023-07-12T20:44:22Z',
+    deleted_date: null,
+    service_location: null,
+    telehealth_details: '',
+  },
+  {
+    id: 789,
+    scheduled_date: addHours(new Date(), 1).toISOString(),
     duration: 60,
     billing_details: null,
     payment: null,

--- a/extensions/elation/lib/findAppointmentsWithLLM/findAppointmentsWithLLM.ts
+++ b/extensions/elation/lib/findAppointmentsWithLLM/findAppointmentsWithLLM.ts
@@ -26,7 +26,7 @@ export const findAppointmentsWithLLM = async ({
     
     const result = await chain.invoke(
       await systemPrompt.format({
-        currentDate: new Date().toISOString().split('T')[0],
+        currentDateTime: new Date().toISOString(),
         appointments: formattedAppointments,
         prompt,
       }),

--- a/extensions/elation/lib/findAppointmentsWithLLM/prompt.ts
+++ b/extensions/elation/lib/findAppointmentsWithLLM/prompt.ts
@@ -13,7 +13,7 @@ Your goal is to carefully analyze the provided instructions and the list of appo
 - You must be **thorough** in your search but only return results when you are **certain** that they match.
 - If multiple appointments match, return **all** their IDs.
 - If no appointments match, return an empty array—this is a valid outcome.
-- Be **meticulous when evaluating time-based criteria**, ensuring all matches are **precise** relative to \${currentDate}.
+- Be **meticulous when evaluating time-based criteria**, ensuring all matches are **precise** relative to \${currentDateTime}.
 
 ---
 ### **Important Instructions**
@@ -23,9 +23,13 @@ Your goal is to carefully analyze the provided instructions and the list of appo
   - Use your expertise for matching but do not assume connections—appointments must explicitly fit the given instructions.
   - If an instruction is vague or ambiguous, only match appointments if the data supports it directly.
 - **Evaluate time constraints precisely**:
-  - If the instruction mentions "past" appointments, **only include** those scheduled **before** \${currentDate}.
-  - If "future" appointments are requested, **only include** those scheduled **after** \${currentDate}.
+  - If the instruction mentions "past" appointments, **only include** those scheduled **before** \${currentDateTime}.
+  - If "future" appointments are requested, **only include** those scheduled **after** \${currentDateTime}.
   - If an exact date is specified, match it **precisely**.
+  - For relative time windows (e.g., “within the next 12 hours”):
+    - Calculate the exact time difference between an appointment's scheduled date/time and \${currentDateTime}.
+    - Example: If an appointment is scheduled at a time such that the time difference from \${currentDateTime} is more than 0 but less than or equal to 12 hours, then it qualifies.
+    - It is critical to ensure the accuracy of your time comparison. Double check your calculation and reasoning.
 - **Only include appointment IDs that exist in the provided input array**.
 - **Do not fabricate matches**—returning an empty array is preferable to an incorrect match.
 
@@ -49,10 +53,11 @@ Your output must be a valid JSON object with the following fields:
 ### Ensure that the explanation strictly matches the appointmentIds:
 - If appointmentIds contains **selected appointments**, the explanation must accurately describe **why they were chosen**.
 - If appointmentIds is **empty**, the explanation must clearly state **why no matches were found**.
-- **Do not contradict yourself**: The explanation must always align with the selected appointments.
 
 ### Be thorough and precise:
 - Carefully **analyze all appointments** before making a decision.
 - **Double-check** your reasoning to confirm that **only valid matches** are included.
 - Ensure that no appointments that **do not meet the criteria** are selected.
-- **Maintain strict consistency** between appointmentIds and explanation.`)
+- **Maintain strict consistency** between appointmentIds and explanation.
+- **Do not contradict yourself**: The explanation must always align with the selected appointments appointmentIds. Double check your explanation against the appointmentIds.
+`)


### PR DESCRIPTION
- Expanded LLM awareness from **dates** to **datetime**, enabling more granular reasoning about time.  
- Updated the prompt to support this change:  
  - Expanded **RealOpenAI tests** and verified all cases.  
  - Ran a full evaluation, confirming **100% accuracy**.  
- Evaluation results: [Langsmith experiment link](https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/a594ad63-aa2b-4328-a771-bd5d057a9c25?paginationState=%7B%22pageIndex%22%3A0%2C%22pageSize%22%3A10%7D).