### PR TITLE
feat(awell-tasks): add event when last task has no performer

### DIFF
--- a/extensions/awellTasks/actions/getLastTaskPerformer/getLastTaskPerformer.test.ts
+++ b/extensions/awellTasks/actions/getLastTaskPerformer/getLastTaskPerformer.test.ts
@@ -1,17 +1,18 @@
 import { TestHelpers } from '@awell-health/extensions-core'
-import { TasksApiClient } from '../../api/client'
-import { getLastTaskPerformer as action } from './getLastTaskPerformer'
 import { tasksMock } from './__testdata__/completedTasks.mock'
+import { getLastTaskPerformer as action } from './getLastTaskPerformer'
+
+const mockGetTasks = jest.fn().mockResolvedValue({
+  data: tasksMock,
+})
+
+const mockTasksApiClient = {
+  getTasks: mockGetTasks,
+}
 
 jest.mock('../../api/client', () => ({
-  TasksApiClient: jest.fn().mockImplementation(() => ({
-    getTasks: jest.fn().mockResolvedValue({
-      data: tasksMock,
-    }),
-  })),
+  TasksApiClient: jest.fn().mockImplementation(() => mockTasksApiClient),
 }))
-
-const mockedSdk = jest.mocked(TasksApiClient)
 
 describe('Task Service - Get last task performer', () => {
   const { extensionAction, onComplete, onError, helpers, clearMocks } =
@@ -38,12 +39,63 @@ describe('Task Service - Get last task performer', () => {
       helpers,
     })
 
-    expect(mockedSdk).toHaveBeenCalled()
-    expect(onComplete).toHaveBeenCalledWith({
-      data_points: {
-        stytchUserId: 'stytch-member-id',
-        email: 'nick@awellhealth.com',
-      },
+    expect(mockTasksApiClient.getTasks).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: {
+          stytchUserId: 'stytch-member-id',
+          email: 'nick@awellhealth.com',
+        },
+      }),
+    )
+  })
+
+  test('Should work when there is no performer', async () => {
+    const tasksMockWithoutPerformer = {
+      ...tasksMock,
+      tasks: tasksMock.tasks.map((task) => ({
+        ...task,
+        performer: null,
+      })),
+    }
+
+    mockTasksApiClient.getTasks.mockResolvedValue({
+      data: tasksMockWithoutPerformer,
     })
+
+    await extensionAction.onEvent({
+      payload: {
+        fields: {},
+        pathway: {
+          id: 'pathway-id',
+        },
+        settings: {
+          baseUrl: 'https://api.awellhealth.com',
+          apiKey: 'api-key',
+        },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: {
+          stytchUserId: undefined,
+          email: undefined,
+        },
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            date: expect.any(String),
+            text: expect.objectContaining({
+              en: expect.stringMatching(
+                'The last completed task in this care flow .* has no performer.',
+              ),
+            }),
+          }),
+        ]),
+      }),
+    )
   })
 })

--- a/extensions/awellTasks/actions/getLastTaskPerformer/getLastTaskPerformer.ts
+++ b/extensions/awellTasks/actions/getLastTaskPerformer/getLastTaskPerformer.ts
@@ -37,7 +37,7 @@ export const getLastTaskPerformer: Action<
     })
 
     const lastTask = first(data.tasks)
-    
+
     if (isNil(lastTask)) {
       await onError({
         events: [
@@ -45,9 +45,9 @@ export const getLastTaskPerformer: Action<
             date: new Date().toISOString(),
             text: {
               en: `No completed task found in this care flow`,
-          },  
-          error: {
-            category: 'SERVER_ERROR',
+            },
+            error: {
+              category: 'SERVER_ERROR',
               message: `No completed task found in this care flow`,
             },
           },
@@ -56,11 +56,25 @@ export const getLastTaskPerformer: Action<
       return
     }
 
+    const performer = get(lastTask, 'performer')
+
+    const events = isNil(performer)
+      ? [
+          {
+            date: new Date().toISOString(),
+            text: {
+              en: `The last completed task in this care flow (${lastTask.title} - ${lastTask.id}) has no performer.`,
+            },
+          },
+        ]
+      : []
+
     await onComplete({
       data_points: {
-        stytchUserId: get(lastTask, 'performer.stytch_user_id') ?? undefined,
-        email: get(lastTask, 'performer.email') ?? undefined,
+        stytchUserId: get(performer, 'stytch_user_id') ?? undefined,
+        email: get(performer, 'email') ?? undefined,
       },
+      events,
     })
   },
 }


### PR DESCRIPTION
- this helps users understand what causes the returned performer
to be undefined