### PR TITLE
fix(elation): remove webhook logs not parsed appropriately by GCP

### DIFF
--- a/extensions/elation/webhooks/appointmentCreatedOrUpdated.ts
+++ b/extensions/elation/webhooks/appointmentCreatedOrUpdated.ts
@@ -53,13 +53,6 @@ export const appointmentCreatedOrUpdated: Webhook<
       })
       const { success } = await limiter.limit(appointmentId.toString())
       if (!success) {
-        console.warn({
-          data,
-          resource,
-          action,
-          message:
-            'Rate limit exceeded. 200 OK response sent to Elation to prevent further requests.',
-        })
         await onError({
           response: {
             statusCode: 200,

--- a/extensions/elation/webhooks/patientCreatedOrUpdated.ts
+++ b/extensions/elation/webhooks/patientCreatedOrUpdated.ts
@@ -51,18 +51,10 @@ export const patientCreatedOrUpdated: Webhook<
       })
       const { success } = await limiter.limit(patientId.toString())
       if (!success) {
-        console.warn({
-          data,
-          resource,
-          action,
-          message:
-            'Rate limit exceeded. 200 OK response sent to Elation to prevent further requests.',
-        })
         await onError({
           response: {
             statusCode: 200,
-            message:
-              'Rate limit exceeded. 200 OK response sent to Elation to prevent further requests.',
+            message: `Rate limit exceeded for patient_id=${patientId}. 200 OK response sent to Elation to prevent further requests.`,
           },
         })
         return


### PR DESCRIPTION
Adding a separate ticket to introduce a logger into the helpers. i have also improved webhook logging at the extension-server level, so we do not lose fidelity