### PR TITLE
fix(elation): include service_location when canceling an appointment

### DIFF
--- a/extensions/elation/actions/cancelAppointments/cancelAppointments.ts
+++ b/extensions/elation/actions/cancelAppointments/cancelAppointments.ts
@@ -110,11 +110,25 @@ export const cancelAppointments: Action<
       const trace = await Promise.all(
         appointmentIdsToCancel.map(async (appointmentId) => {
           try {
-            await api.updateAppointment(appointmentId, {
+            // Find the original appointment to get its service_location
+            const appointmentToCancel = appointmentsToCancel.find(
+              (appointment) => appointment.id === appointmentId
+            )
+            
+            // Include service_location in the update if it exists in the original appointment
+            const updateData: Record<string, any> = {
               status: { status: 'Cancelled' },
-            })
+            }
+            
+            const serviceLocation = appointmentToCancel?.service_location;
+            if (!isNil(serviceLocation)) {
+              updateData.service_location = serviceLocation;
+            }
+            
+            await api.updateAppointment(appointmentId, updateData)
             return { appointmentId, status: 'success' }
           } catch (error) {
+            console.error(`Error canceling appointment ${appointmentId}:`, error)
             return { appointmentId, status: 'error' }
           }
         })


### PR DESCRIPTION
Fix Elation Appointment Cancellation for Tenants Requiring Service Location

This PR resolves an issue where appointment cancellation would fail for tenants that require the `service_location `field to be included in all PATCH requests, even when only updating appointment status.
The fix:
- Preserves the original appointment's service_location when cancelling
- Creates a proper update payload with both status and location data
- Maintains backward compatibility with tenants that don't require location
This approach follows Elation team's guidance to include `service_location` in the PATCH body when the tenant has the location requirement feature enabled.