### PR TITLE
Rev-110: Adjust formatting in AI generated track outcome sumary

### DIFF
--- a/extensions/shelly/actions/summarizeForm/summarizeForm.test.ts
+++ b/extensions/shelly/actions/summarizeForm/summarizeForm.test.ts
@@ -140,7 +140,7 @@ describe('summarizeForm - Mocked LLM calls', () => {
     const { summarizeFormWithLLM } = require('../../lib/summarizeFormWithLLM')
     expect(summarizeFormWithLLM).toHaveBeenCalledWith(
       expect.objectContaining({
-        disclaimerMessage: 'Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: whatever).'
+        disclaimerMessage: '**Important Notice:** The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB).'
       })
     )
 
@@ -180,7 +180,7 @@ describe('summarizeForm - Mocked LLM calls', () => {
     const { summarizeFormWithLLM } = require('../../lib/summarizeFormWithLLM')
     expect(summarizeFormWithLLM).toHaveBeenCalledWith(
       expect.objectContaining({
-        disclaimerMessage: 'Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: whatever).',
+        disclaimerMessage: '**Important Notice:** The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB).',
         additionalInstructions: 'Focus on medication details and side effects.'
       })
     )

--- a/extensions/shelly/actions/summarizeForm/summarizeForm.ts
+++ b/extensions/shelly/actions/summarizeForm/summarizeForm.ts
@@ -66,9 +66,9 @@ export const summarizeForm: Action<
     // Create disclaimer message based on version availability
     let disclaimerMessage = '';
     if (!isNil(careFlowDetails.version)) {
-      disclaimerMessage = `Important Notice: The content provided is an AI-generated summary of form responses of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMessage = `**Important Notice:** The content provided is an AI-generated summary of form responses of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${payload.pathway.id}).`;
     } else {
-      disclaimerMessage = `Important Notice: The content provided is an AI-generated summary of form responses of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMessage = `**Important Notice:** The content provided is an AI-generated summary of form responses of Care Flow "${careFlowDetails.title}" (ID: ${payload.pathway.id}).`;
     }
 
     // 4. Generate summary

--- a/extensions/shelly/actions/summarizeForm/summarizeFormRealOpenAI.test.ts
+++ b/extensions/shelly/actions/summarizeForm/summarizeFormRealOpenAI.test.ts
@@ -37,7 +37,7 @@ const generateTestPayload = (overrides = {}) => {
   }
 }
 
-describe('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
+describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
   const { onComplete, onError, helpers, extensionAction, clearMocks } =
     TestHelpers.fromAction(summarizeForm)
 

--- a/extensions/shelly/actions/summarizeForm/summarizeFormRealOpenAI.test.ts
+++ b/extensions/shelly/actions/summarizeForm/summarizeFormRealOpenAI.test.ts
@@ -37,7 +37,7 @@ const generateTestPayload = (overrides = {}) => {
   }
 }
 
-describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
+describe('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
   const { onComplete, onError, helpers, extensionAction, clearMocks } =
     TestHelpers.fromAction(summarizeForm)
 
@@ -147,9 +147,7 @@ describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
-        summary: expect.stringMatching(
-          new RegExp(`Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow".*Test Question.*Test Answer.*`, 's')
-        ),
+        summary: expect.stringContaining('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB)')
       },
     })
     expect(onError).not.toHaveBeenCalled()
@@ -241,9 +239,7 @@ describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
-        summary: expect.stringMatching(
-          new RegExp(`Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow".*Test Question.*Test Answer.*`, 's')
-        ),
+        summary: expect.stringContaining('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB)')
       },
     })
     expect(onError).not.toHaveBeenCalled()
@@ -334,9 +330,7 @@ describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
-        summary: expect.stringMatching(
-          new RegExp(`Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow".*Test Question.*Test Answer.*`, 's')
-        ),
+        summary: expect.stringContaining('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB)')
       },
     })
     expect(onError).not.toHaveBeenCalled()
@@ -427,9 +421,7 @@ describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
-        summary: expect.stringMatching(
-          new RegExp(`Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow".*Test Question.*Test Answer.*`, 's')
-        ),
+        summary: expect.stringContaining('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB)')
       },
     })
     expect(onError).not.toHaveBeenCalled()
@@ -503,9 +495,7 @@ describe.skip('summarizeForm - Real LLM calls with mocked Awell SDK', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4)
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
-        summary: expect.stringMatching(
-          new RegExp(`Important Notice: The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow".*`, 's')
-        ),
+        summary: expect.stringContaining('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of form responses of version 3 of Care Flow "Test Care Flow" (ID: ai4rZaYEocjB)')
       },
     })
     expect(onError).not.toHaveBeenCalled()

--- a/extensions/shelly/actions/summarizeTrackOutcome/lib/summarizeTrackOutcomeWithLLM/prompt.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/lib/summarizeTrackOutcomeWithLLM/prompt.ts
@@ -71,12 +71,12 @@ Structure your summary as follows:
 - **Only describe completed actions**—do not include planned future steps or what happens next.  
   - **Correct:**  
     \`\`\`
-    ## Outcome:
+    **Outcome:**
     The alternate treatment plan (ATP) was not accepted.
     \`\`\`
   - **Incorrect:**  
     \`\`\`
-    ## Outcome:
+    **Outcome:**
     The alternate treatment plan (ATP) was not accepted, and the case was directed toward pre-certification.
     \`\`\`
 - **Avoid mentioning the patient unless explicitly necessary.** Instead, focus on what occurred:  
@@ -110,10 +110,10 @@ Structure your summary as follows:
 
 ----------
 # Example Output Format
-## **Outcome:**
+**Outcome:**
 The alternate treatment plan (ATP) was not accepted.
 
-## **Details Supporting the Outcome:**
+**Details Supporting the Outcome:**
 - During the initial hernia triage, it was indicated that the hernia was reducible and did not affect the patient's activities of daily living (ADLs).
 - A physician was presented with a form to accept an Alternate Treatment Plan (ATP).
 - The physician declined the ATP, as indicated by the form response.

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.test.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.test.ts
@@ -26,10 +26,10 @@ jest.mock('../../../../src/lib/llm/openai', () => ({
   createOpenAIModel: jest.fn().mockResolvedValue({
     model: {
       invoke: jest.fn().mockResolvedValue({
-        content: `## Outcome:
+        content: `**Outcome:**
 The patient's medication refill request was processed successfully.
 
-## Details supporting the outcome:
+**Details supporting the outcome:**
 - Patient John Doe requested a refill for Lisinopril 10mg
 - The request was categorized as a Medication Refill Request
 - Dr. Smith approved and processed the refill for 90 days
@@ -137,7 +137,7 @@ describe('summarizeTrackOutcome - Mocked LLM calls', () => {
     })
 
     // Verify the disclaimer is included
-    const expectedDisclaimerMsg = `Important Notice: The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check" (ID: ty0CmaHm2jlX).`
+    const expectedDisclaimerMsg = `<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check" (ID: ty0CmaHm2jlX).</p>`
     
     // Verify onComplete was called with the expected data
     expect(onComplete).toHaveBeenCalled()

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.test.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.test.ts
@@ -137,7 +137,7 @@ describe('summarizeTrackOutcome - Mocked LLM calls', () => {
     })
 
     // Verify the disclaimer is included
-    const expectedDisclaimerMsg = `<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check" (ID: ty0CmaHm2jlX).</p>`
+    const expectedDisclaimerMsg = `<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check" (ID: xQ2P4uBn2cY8).</p>`
     
     // Verify onComplete was called with the expected data
     expect(onComplete).toHaveBeenCalled()

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
@@ -92,9 +92,9 @@ export const summarizeTrackOutcome: Action<
     // Create version string if version is available
     let disclaimerMsg = '';
     if (!isNil(careFlowDetails.version)) {
-      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${pathway.id}).`;
     } else {
-      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of Care Flow "${careFlowDetails.title}" (ID: ${pathway.id}).`;
     }
 
     const htmlSummary = await markdownToHtml(`${disclaimerMsg}\n\n${summary}`)

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
@@ -92,9 +92,9 @@ export const summarizeTrackOutcome: Action<
     // Create version string if version is available
     let disclaimerMsg = '';
     if (!isNil(careFlowDetails.version)) {
-      disclaimerMsg = `Important Notice: The content provided is an AI-generated summary of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of version ${careFlowDetails.version} of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
     } else {
-      disclaimerMsg = `Important Notice: The content provided is an AI-generated summary of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
+      disclaimerMsg = `**Important Notice:** The content provided is an AI-generated summary of Care Flow "${careFlowDetails.title}" (ID: ${careFlowDetails.id}).`;
     }
 
     const htmlSummary = await markdownToHtml(`${disclaimerMsg}\n\n${summary}`)

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcomeRealOpenAI.test.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcomeRealOpenAI.test.ts
@@ -25,7 +25,7 @@ jest.setTimeout(30000) // Increase timeout for real LLM calls
 
 // Use describe.skip to prevent this test from running in normal CI/CD pipelines
 // Remove .skip when you want to run this test locally with a real OpenAI API key
-describe.skip('summarizeTrackOutcome - Real LLM calls with mocked Awell SDK', () => {
+describe('summarizeTrackOutcome - Real LLM calls with mocked Awell SDK', () => {
   const { onComplete, onError, helpers, extensionAction, clearMocks } =
     TestHelpers.fromAction(summarizeTrackOutcome)
 
@@ -115,7 +115,7 @@ describe.skip('summarizeTrackOutcome - Real LLM calls with mocked Awell SDK', ()
       const summary = onComplete.mock.calls[0][0].data_points.outcomeSummary
       
       // Verify the summary contains the disclaimer with version
-      expect(summary).toContain('Important Notice: The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check"')
+      expect(summary).toContain('<p><strong>Important Notice:</strong> The content provided is an AI-generated summary of version 6 of Care Flow "AI Actions Check"')
       
       // Verify the summary contains relevant information about the track
       // These are key terms that should appear in any reasonable summary of our mock data

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcomeRealOpenAI.test.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcomeRealOpenAI.test.ts
@@ -25,7 +25,7 @@ jest.setTimeout(30000) // Increase timeout for real LLM calls
 
 // Use describe.skip to prevent this test from running in normal CI/CD pipelines
 // Remove .skip when you want to run this test locally with a real OpenAI API key
-describe('summarizeTrackOutcome - Real LLM calls with mocked Awell SDK', () => {
+describe.skip('summarizeTrackOutcome - Real LLM calls with mocked Awell SDK', () => {
   const { onComplete, onError, helpers, extensionAction, clearMocks } =
     TestHelpers.fromAction(summarizeTrackOutcome)
 


### PR DESCRIPTION
[REV-110: Adjust Formatting in AI-Generated Summary (Headers Too Large)](https://linear.app/awell/issue/REV-110/adjust-formatting-in-ai-generated-summary-headers-too-large)

Minor styling improvements:
- header -> build styling for Summarize Track Outcome sections
- using care flow ID instead of care flow definition id in the disclaiemr message