### PR TITLE
vis-109-update-to-use-v2flows-instead-of-deprecated-flows

### DIFF
--- a/extensions/twilio/v2/actions/createFlowExecution/createFlowExecution.ts
+++ b/extensions/twilio/v2/actions/createFlowExecution/createFlowExecution.ts
@@ -32,7 +32,7 @@ export const createFlowExecution: Action<typeof fields, typeof settings> = {
       accountSid,
     })
 
-    const execution = await client.studio.flows(flow_id).executions.create({
+    const execution = await client.studio.v2.flows(flow_id).executions.create({
       to: recipient,
       from,
       parameters,


### PR DESCRIPTION
The createFlowExecution throws an error due to depricated flows
![Uploading Screenshot 2025-03-25 at 16.11.02.png…]()
