### PR TITLE
feat(elation): remove 10 tags restriction

### DIFF
--- a/extensions/elation/actions/updatePatientTags/lib/getTagsFromLLM/evaluateTags.ts
+++ b/extensions/elation/actions/updatePatientTags/lib/getTagsFromLLM/evaluateTags.ts
@@ -14,7 +14,7 @@
  *   - LANGSMITH_PROJECT=ai-actions-local
  *
  * Usage:
- * node getTagsFromLLM/evaluateTags.ts
+ *  * yarn ts-node extensions/elation/actions/updatePatientTags/lib/getTagsFromLLM/evaluateTags.ts
  *
  * Results can be viewed in LangSmith dashboard:
  * https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/745cea13-3379-463f-9a8a-c6b10e29b8f6
@@ -61,7 +61,7 @@ const fetchTestExamples = async (): Promise<Example[]> => {
   try {
     const testExamples = langsmith.listExamples({
       datasetName,
-      splits: ['test'],
+      splits: ['test'], // change to ['validation'] to run on validation set
     })
     const examples: Example[] = []
     for await (const example of testExamples) {
@@ -82,12 +82,8 @@ const tagsMatchEvaluator = async ({
   outputs,
   referenceOutputs,
 }: EvaluatorInput): Promise<EvaluatorOutput> => {
-  console.log('Evaluator received:', { outputs, referenceOutputs }) // Debug log
-
   const generatedTags = outputs?.validatedTags as string[]
   const expectedTags = referenceOutputs?.expected_updated_tags as string[]
-
-  // console.log('Comparing tags:', { generatedTags, expectedTags }); // Debug log
 
   const isEqual =
     Array.isArray(generatedTags) &&
@@ -160,7 +156,8 @@ const runEvaluation = async (): Promise<void> => {
       data: testExamples,
       evaluators: [tagsMatchEvaluator],
       experimentPrefix: 'GetTagsFromLLM Evaluation',
-      maxConcurrency: 4,
+      maxConcurrency: 16,
+      numRepetitions: 3,
     })
 
     const resultsArray = Array.isArray(results) ? results : [results]

--- a/extensions/elation/actions/updatePatientTags/lib/getTagsFromLLM/prompt.ts
+++ b/extensions/elation/actions/updatePatientTags/lib/getTagsFromLLM/prompt.ts
@@ -21,7 +21,10 @@ export const systemPrompt = ChatPromptTemplate.fromTemplate(`
 
     - **Adding Tags:**
       - Use the exact wording and formatting provided in the instruction for new tags. Do not modify, reformat, or adjust them in any way. This is critical.
-      - Ensure that the final list does not exceed **10 tags**. If adding a tag would exceed this limit, do not add it and clarify this in the "explanation".
+      - When extracting tag names from instructions:
+        - If the tag is in quotes: use exactly what's in the quotes, but if the quoted text contains the word "tag" (e.g., 'MH-T tag', "CCM 2 tag"), remove the word "tag" and keep only the tag name ('MH-T', "CCM 2")
+        - If there are no quotes but the word "tag" follows the intended tag name (e.g., "add MH-T tag"), extract only the tag name ("MH-T") without the word "tag"
+        - Always preserve all spaces, punctuation, and capitalization exactly as specified
       - If a tag exceeds **100 characters**, do not add it and state this in the "explanation".
       - Ensure all tags remain **unique** (no duplicates).
       - The updated list should first retain all unchanged tags, followed by any new additions.
@@ -32,7 +35,7 @@ export const systemPrompt = ChatPromptTemplate.fromTemplate(`
   3. **Generate Output**
     - Return a JSON object containing:
       - "updatedTags": The final array of tags after modifications.
-      - "explanation": A single, concise sentence summarizing all tag modifications, including the reasoning behind changes or lack thereof. Do not include statements about the total number of tags.
+      - "explanation": A single, concise sentence summarizing all tag modifications, including the reasoning behind changes or lack thereof. Refrain from including statements about the total number of tags.
 
   ### Input
   existingTags: {existingTags}


### PR DESCRIPTION
[REV-159: Update Elation Patient Tags AI Action](https://linear.app/awell/issue/REV-159/update-elation-patient-tags-ai-action)

- Updated the Update Elation Tags prompt to remove the 10-tag restriction, based on confirmation from the Elation team and my checks.
- Created a new real-world dataset for validation and testing.
- Validation and test set evaluations both show 100% correctness.

Links to LangSmith experiments runs:

[validation dataset](https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/1816708c-7d0d-4c9b-bf4f-86b2911d3bec/compare?selectedSessions=566e68a8-74f8-434e-bb56-f9269e6797ea&baseline=undefined)

[test dataset](https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/1816708c-7d0d-4c9b-bf4f-86b2911d3bec/compare?selectedSessions=3c91ae81-e25b-4051-8f7f-18d0f6c1fb4f&baseline=undefined)