### PR TITLE
VIS-110: Add Language Detection to SUmmarize Form AI Actions

### DIFF
--- a/extensions/shelly/actions/summarizeFormsInStep/summarizeFormsInStepRealOpenAI.test.ts
+++ b/extensions/shelly/actions/summarizeFormsInStep/summarizeFormsInStepRealOpenAI.test.ts
@@ -5,6 +5,16 @@ import { TestHelpers } from '@awell-health/extensions-core'
 import { generateTestPayload } from '@/tests'
 import { summarizeFormsInStep } from '.'
 import { DISCLAIMER_MSG_FORM } from '../../lib/constants'
+import { detectLanguageWithLLM } from '../../lib/detectLanguageWithLLM'
+
+// Spy on detectLanguageWithLLM to verify it's called
+jest.mock('../../lib/detectLanguageWithLLM', () => {
+  const originalModule = jest.requireActual('../../lib/detectLanguageWithLLM');
+  return {
+    ...originalModule,
+    detectLanguageWithLLM: jest.fn(originalModule.detectLanguageWithLLM)
+  };
+});
 
 jest.setTimeout(30000) // Increase timeout for real LLM calls
 
@@ -118,6 +128,8 @@ describe.skip('summarizeFormsInStep - Real OpenAI calls', () => {
 
     expect(helpers.awellSdk).toHaveBeenCalled()
     expect(mockQuery).toHaveBeenCalledTimes(4)
+    // Verify that detectLanguageWithLLM was called because language is 'Default'
+    expect(detectLanguageWithLLM).toHaveBeenCalled()
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         summary: expect.stringContaining(DISCLAIMER_MSG_FORM)
@@ -221,9 +233,119 @@ describe.skip('summarizeFormsInStep - Real OpenAI calls', () => {
 
     expect(helpers.awellSdk).toHaveBeenCalled()
     expect(mockQuery).toHaveBeenCalledTimes(4)
+    // Verify that detectLanguageWithLLM was NOT called because a specific language (French) was provided
+    expect(detectLanguageWithLLM).not.toHaveBeenCalled()
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         summary: expect.stringContaining('Avis Important')
+      },
+    })
+    expect(onError).not.toHaveBeenCalled()
+  }, 30000)
+
+  it('Should detect Spanish language from Spanish form content', async () => {
+    const payload = generateTestPayload({
+      pathway: {
+        id: 'ai4rZaYEocjB',
+        definition_id: 'whatever',
+      },
+      activity: { id: 'X74HeDQ4N0gtdaSEuzF8s' },
+      fields: {
+        summaryFormat: 'Bullet-points',
+        language: 'Default', // Set to Default to trigger language detection
+      },
+      settings: {}
+    })
+
+    const mockQuery = jest.fn()
+      .mockResolvedValueOnce({
+        activity: {
+          success: true,
+          activity: {
+            id: 'X74HeDQ4N0gtdaSEuzF8s',
+            date: '2024-09-11T22:56:59.607Z',
+            context: {
+              step_id: 'Xkn5dkyPA5uW'
+            }
+          }
+        }
+      })
+      .mockResolvedValueOnce({
+        pathwayStepActivities: {
+          success: true,
+          activities: [{
+            id: 'X74HeDQ4N0gtdaSEuzF8s',
+            status: 'DONE',
+            date: '2024-09-11T22:56:58.607Z',
+            object: {
+              id: 'OGhjJKF5LRmo',
+              name: 'Formulario de Evaluación de Salud',
+              type: 'FORM'
+            },
+            context: {
+              step_id: 'Xkn5dkyPA5uW'
+            }
+          }]
+        }
+      })
+      .mockResolvedValueOnce({
+        form: {
+          success: true,
+          form: {
+            id: 'OGhjJKF5LRmo',
+            title: 'Formulario de Evaluación de Salud',
+            questions: [
+              {
+                id: 'q1',
+                title: '¿Cómo calificaría su salud general?',
+                type: 'SELECT',
+                options: [
+                  { value: 'excelente', label: 'Excelente' },
+                  { value: 'bueno', label: 'Bueno' }
+                ]
+              }
+            ]
+          }
+        }
+      })
+      .mockResolvedValueOnce({
+        formResponse: {
+          success: true,
+          response: {
+            form_id: 'OGhjJKF5LRmo',
+            answers: [
+              {
+                question_id: 'q1',
+                value: 'bueno'
+              }
+            ]
+          }
+        }
+      })
+
+    helpers.awellSdk = jest.fn().mockReturnValue({
+      orchestration: {
+        query: mockQuery
+      }
+    })
+
+    await extensionAction.onEvent({
+      payload,
+      onComplete,
+      onError,
+      helpers,
+    })
+
+    expect(helpers.awellSdk).toHaveBeenCalled()
+    expect(mockQuery).toHaveBeenCalledTimes(4)
+    
+    // Verify detectLanguageWithLLM was called
+    expect(detectLanguageWithLLM).toHaveBeenCalled()
+    
+    // The summary should contain Spanish disclaimer
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        summary: expect.stringContaining('Aviso Importante')
       },
     })
     expect(onError).not.toHaveBeenCalled()

--- a/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.evaluate.ts
+++ b/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.evaluate.ts
@@ -1,0 +1,175 @@
+/**
+ * LangSmith Evaluation Script for detectLanguageWithLLM
+ *
+ * Evaluates the function by:
+ * - Running test cases from LangSmith dataset
+ * - Checking if a language is detected
+ * - Generating evaluation reports
+ *
+ * Requirements:
+ * - Set environment variables in .env:
+ *   - OPENAI_API_KEY
+ *   - LANGSMITH_API_KEY
+ *   - LANGSMITH_TRACING=true
+ *   - LANGSMITH_PROJECT=ai-actions-local
+ *
+ * Usage:
+ * yarn ts-node extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.evaluate.ts
+ *
+ * Results can be viewed in LangSmith dashboard
+ *
+ * ⚠️ **Note:** This script does NOT run in CI/CD. It is meant for **manual evaluation** before merging PRs (for now)
+ */
+import { Client, type Example } from 'langsmith'
+import { evaluate } from 'langsmith/evaluation'
+import { createOpenAIModel } from '../../../../src/lib/llm/openai/createOpenAIModel'
+import { detectLanguageWithLLM } from './detectLanguageWithLLM'
+import { OPENAI_MODELS } from '../../../../src/lib/llm/openai/constants'
+import { isNil } from 'lodash'
+
+import dotenv from 'dotenv'
+dotenv.config()
+
+const langsmith = new Client({
+  apiKey: process.env.LANGSMITH_API_KEY,
+  apiUrl: process.env.LANGSMITH_ENDPOINT,
+})
+
+// Define the dataset name
+const datasetName = 'ai-actions-detect-language-shelly'
+
+interface EvaluatorInput {
+  outputs: Record<string, unknown>
+}
+
+interface EvaluatorOutput {
+  key: string
+  score: number
+  metadata?: Record<string, unknown>
+}
+
+interface DatasetExample {
+  text: string
+  expected_language: string
+}
+
+// Fetch the 'test' split examples from the dataset
+const fetchTestExamples = async (): Promise<Example[]> => {
+  try {
+    const testExamples = langsmith.listExamples({
+      datasetName,
+      splits: ['test'],
+    })
+    const examples: Example[] = []
+    for await (const example of testExamples) {
+      if (!isNil(example.inputs)) {
+        // Explicit null check
+        examples.push(example)
+      }
+    }
+    return examples
+  } catch (error) {
+    console.error('❌ Error fetching test examples:', error)
+    throw error
+  }
+}
+
+// Custom evaluator to check if language detection is accurate
+const languageDetectionEvaluator = async ({
+  outputs,
+}: EvaluatorInput): Promise<EvaluatorOutput> => {
+  const detectedLanguage = outputs?.detectedLanguage as string
+  
+  // Check if language is detected and not empty
+  const isDetected = typeof detectedLanguage === 'string' && detectedLanguage.trim().length > 0
+  
+  return { 
+    key: 'language_detected', 
+    score: isDetected ? 1 : 0,
+    metadata: {
+      detectedLanguage,
+      isDetected
+    }
+  }
+}
+
+// Wrapper function to adapt detectLanguageWithLLM for evaluation
+const detectLanguageWithLLMWrapper = async (
+  input: DatasetExample,
+): Promise<{ detectedLanguage: string }> => {
+  const payload = {
+    activity: {
+      id: 'test-activity-id',
+    },
+    pathway: {
+      tenant_id: 'test-tenant',
+      definition_id: 'test-definition',
+      id: 'test-pathway',
+      org_slug: 'test-org',
+      org_id: 'test-org-id',
+    },
+    fields: {
+      text: input.text,
+    },
+    settings: {
+      openAiApiKey: process.env.OPENAI_API_KEY,
+    },
+  }
+
+  const helpers = {
+    getOpenAIConfig: () => {
+      const apiKey = process.env.OPENAI_API_KEY
+      if (isNil(apiKey) || apiKey.trim() === '') {
+        throw new Error('OPENAI_API_KEY is required but not set')
+      }
+      return { apiKey }
+    },
+  }
+
+  const { model, metadata, callbacks } = await createOpenAIModel({
+    settings: payload.settings,
+    helpers,
+    payload,
+    modelType: OPENAI_MODELS.GPT4o,
+  })
+
+  const detectedLanguage = await detectLanguageWithLLM({
+    model,
+    text: input.text,
+    metadata,
+    callbacks,
+  })
+
+  return { detectedLanguage }
+}
+
+// Main function to run the evaluation and print results
+const runEvaluation = async (): Promise<void> => {
+  try {
+    console.log('📡 Fetching test dataset from LangSmith...')
+    const testExamples = await fetchTestExamples()
+    console.log(`✅ Loaded ${testExamples.length} test examples\n`)
+
+    console.log('🚀 Running evaluation...\n')
+    const results = await evaluate(detectLanguageWithLLMWrapper, {
+      data: testExamples,
+      evaluators: [languageDetectionEvaluator],
+      experimentPrefix: 'DetectLanguageWithLLM Evaluation',
+      maxConcurrency: 8,
+      numRepetitions: 1,
+    })
+
+    const resultsArray = Array.isArray(results) ? results : [results]
+    const experimentId = resultsArray[0]?.run?.run_id as string
+
+    console.log('\n✨ Experiment Run Complete! Actual evaluation is running in LangSmith via custom evaluator.')
+    console.log('View detailed results in LangSmith:')
+    console.log(`https://smith.langchain.com/runs/${experimentId}`)
+  } catch (error) {
+    console.error('❌ Error during evaluation:', error)
+    throw error
+  }
+}
+
+// Execute the evaluation
+void runEvaluation() 

--- a/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.test.ts
+++ b/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.test.ts
@@ -1,0 +1,152 @@
+import 'dotenv/config'
+import { detectLanguageWithLLM } from './detectLanguageWithLLM'
+import { ChatOpenAI } from '@langchain/openai'
+import { AIMessageChunk } from '@langchain/core/messages'
+
+describe('detectLanguageWithLLM', () => {
+  let mockModel: jest.Mocked<ChatOpenAI>
+
+  beforeEach(() => {
+    mockModel = {
+      invoke: jest.fn(),
+    } as unknown as jest.Mocked<ChatOpenAI>
+  })
+
+  it('should detect English text correctly', async () => {
+    const mockLanguage = 'English'
+    mockModel.invoke.mockResolvedValueOnce(
+      new AIMessageChunk(mockLanguage)
+    )
+
+    const text = 'Hello world! This is a sample text in English.'
+    const metadata = {
+      activity_id: 'test-activity-id',
+      care_flow_definition_id: 'test-def-id',
+      care_flow_id: 'test-pathway-id',
+      tenant_id: 'test-tenant-id',
+      org_slug: 'test-org-slug',
+      org_id: 'test-org-id'
+    }
+
+    const language = await detectLanguageWithLLM({
+      model: mockModel,
+      text,
+      metadata
+    })
+
+    expect(language).toBe(mockLanguage)
+    expect(mockModel.invoke).toHaveBeenCalledTimes(1)
+    expect(mockModel.invoke).toHaveBeenCalledWith(
+      expect.anything(),
+      { metadata, runName: 'ShellyDetectLanguage' }
+    )
+  })
+
+  it('should detect Croatian text correctly', async () => {
+    const mockLanguage = 'Croatian'
+    mockModel.invoke.mockResolvedValueOnce(
+      new AIMessageChunk(mockLanguage)
+    )
+
+    const text = 'Dobar dan! Ovo je primjer teksta na hrvatskom jeziku.'
+    const metadata = {
+      activity_id: 'test-activity-id',
+      care_flow_definition_id: 'test-def-id',
+      care_flow_id: 'test-pathway-id',
+      tenant_id: 'test-tenant-id',
+      org_slug: 'test-org-slug',
+      org_id: 'test-org-id'
+    }
+
+    const language = await detectLanguageWithLLM({
+      model: mockModel,
+      text,
+      metadata
+    })
+
+    expect(language).toBe(mockLanguage)
+    expect(mockModel.invoke).toHaveBeenCalledTimes(1)
+    expect(mockModel.invoke).toHaveBeenCalledWith(
+      expect.anything(),
+      { metadata, runName: 'ShellyDetectLanguage' }
+    )
+  })
+
+  it('should detect Spanish text correctly', async () => {
+    const mockLanguage = 'Spanish'
+    mockModel.invoke.mockResolvedValueOnce(
+      new AIMessageChunk(mockLanguage)
+    )
+
+    const text = '¡Hola mundo! Este es un ejemplo de texto en español.'
+    const metadata = {
+      activity_id: 'test-activity-id',
+      care_flow_definition_id: 'test-def-id',
+      care_flow_id: 'test-pathway-id',
+      tenant_id: 'test-tenant-id',
+      org_slug: 'test-org-slug',
+      org_id: 'test-org-id'
+    }
+
+    const language = await detectLanguageWithLLM({
+      model: mockModel,
+      text,
+      metadata
+    })
+
+    expect(language).toBe(mockLanguage)
+    expect(mockModel.invoke).toHaveBeenCalledTimes(1)
+    expect(mockModel.invoke).toHaveBeenCalledWith(
+      expect.anything(),
+      { metadata, runName: 'ShellyDetectLanguage' }
+    )
+  })
+
+  it('should handle empty text gracefully', async () => {
+    const mockLanguage = 'Unknown'
+    mockModel.invoke.mockResolvedValueOnce(
+      new AIMessageChunk(mockLanguage)
+    )
+
+    const text = ''
+    const metadata = {
+      activity_id: 'test-activity-id',
+      care_flow_definition_id: 'test-def-id',
+      care_flow_id: 'test-pathway-id',
+      tenant_id: 'test-tenant-id',
+      org_slug: 'test-org-slug',
+      org_id: 'test-org-id'
+    }
+
+    const language = await detectLanguageWithLLM({
+      model: mockModel,
+      text,
+      metadata
+    })
+
+    expect(language).toBe(mockLanguage)
+    expect(mockModel.invoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle errors gracefully', async () => {
+    mockModel.invoke.mockRejectedValueOnce(new Error('API Error'))
+
+    const text = 'Hello world'
+    const metadata = {
+      activity_id: 'test-activity-id',
+      care_flow_definition_id: 'test-def-id',
+      care_flow_id: 'test-pathway-id',
+      tenant_id: 'test-tenant-id',
+      org_slug: 'test-org-slug',
+      org_id: 'test-org-id'
+    }
+
+    await expect(
+      detectLanguageWithLLM({
+        model: mockModel,
+        text,
+        metadata
+      })
+    ).rejects.toThrow('Failed to detect language')
+  })
+}) 

--- a/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.ts
+++ b/extensions/shelly/lib/detectLanguageWithLLM/detectLanguageWithLLM.ts
@@ -1,0 +1,42 @@
+import { systemPrompt } from './prompt'
+import { type ChatOpenAI } from '@langchain/openai'
+import { type AIActionMetadata } from '../../../../src/lib/llm/openai/types'
+import type { BaseCallbackHandler } from "@langchain/core/callbacks/base"
+
+/**
+ * Uses LLM to detect the language of a given text.
+ * The function follows these steps:
+ * 1. Formats prompt with the input text
+ * 2. Runs LLM to identify the language
+ * 3. Returns the full language name (e.g., "English", "Croatian")
+ */
+export const detectLanguageWithLLM = async ({
+  model,
+  text,
+  metadata,
+  callbacks,
+}: {
+  model: ChatOpenAI
+  text: string
+  metadata: AIActionMetadata
+  callbacks?: BaseCallbackHandler[]
+}): Promise<string> => {
+  const prompt = await systemPrompt.format({
+    input: text,
+  })
+
+  try {
+    const result = await model.invoke(
+      prompt,
+      { 
+        metadata, 
+        runName: 'ShellyDetectLanguage',
+        callbacks
+      }
+    )
+
+    return result.content as string
+  } catch (error) {
+    throw new Error('Failed to detect language')
+  }
+} 

--- a/extensions/shelly/lib/detectLanguageWithLLM/index.ts
+++ b/extensions/shelly/lib/detectLanguageWithLLM/index.ts
@@ -1,0 +1,1 @@
+export { detectLanguageWithLLM } from './detectLanguageWithLLM' 

--- a/extensions/shelly/lib/detectLanguageWithLLM/prompt.ts
+++ b/extensions/shelly/lib/detectLanguageWithLLM/prompt.ts
@@ -1,0 +1,19 @@
+import { ChatPromptTemplate } from '@langchain/core/prompts'
+
+export const systemPrompt = ChatPromptTemplate.fromTemplate(`
+  You are a language expert tasked with identifying the language of a given text. 
+  Your goal is to analyze the input and return the name of the language it is written in.
+
+  ## Instructions:
+  - Return ONLY the full name of the language (e.g., "English", "Croatian", "Spanish", "French", etc.).
+  - Absolutely refrain from providing any explanation, additional information, punctuation, or formatting—just the language name.
+  - If the text appears to contain multiple languages, focus on the language that makes up the majority of the words.
+  - If the input is empty or contains no recognizable language patterns, return "Unknown".
+  - Make your best determination even for short phrases or single words.
+  - **Ignore any formatting, field labels, form metadata, or structural prefixes** (e.g., "Question:", "Answer:", "Form Title:", section dividers like "---", etc.). Focus only on the actual written words for questions and answers that carry meaning.
+
+  ---
+
+  ## Text to analyze:
+  {input}
+`)

--- a/extensions/shelly/lib/summarizeFormWithLLM/prompt.ts
+++ b/extensions/shelly/lib/summarizeFormWithLLM/prompt.ts
@@ -5,9 +5,9 @@ export const systemPromptBulletPoints = ChatPromptTemplate.fromTemplate(`
 
   First, write the disclaimer message "{disclaimerMessage}" in specified language: {language}, following these rules:
   - If specified language is Default or not specified: translate all parts of {disclaimerMessage} into the language of the form. If you cannot determine language use English.
-  - If specified language is other than Default (French, Spanish, bosnian, ...): translate all parts of {disclaimerMessage} into specified language: {language} It is critical that the entire disclaimer message is written in the same language as specified language: {language}.
-    For example if the disclaimer message is "Important Notice: The content provided is an AI-generated summary." and specified language is Spanish, the disclaimer message in Spanish would be "Aviso Importante: El contenido proporcionado es un resumen generado por IA de las respuestas del formulario".
-    If the specified language is French than the same disclaimer message should be: "Avis Important : Le contenu fourni est un résumé généré par IA des réponses du formulaire"
+  - If specified language is other than Default (French, Spanish, bosnian, ...): translate ALL parts of {disclaimerMessage} into specified language: {language}, including ANY heading text such as "Important Notice" which MUST be translated too. It is critical that the entire disclaimer message is written in the same language as specified language: {language} without any English words remaining.
+    For example if the disclaimer message is "**Important Notice:** The content provided is an AI-generated summary." and specified language is Spanish, the disclaimer message in Spanish would be "**Aviso Importante:** El contenido proporcionado es un resumen generado por IA de las respuestas del formulario".
+    If the specified language is French than the same disclaimer message should be: "**Avis Important :** Le contenu fourni est un résumé généré par IA des réponses du formulario".
   Then add two new lines after the disclaimer message.
 
   Then adhere strictly to these step-by-step instructions:
@@ -74,9 +74,9 @@ export const systemPromptTextParagraph = ChatPromptTemplate.fromTemplate(`
 
   First, write the disclaimer message "{disclaimerMessage}" in specified language: {language}, following these rules:
   - If specified language is Default or not specified: translate all parts of {disclaimerMessage} into the language of the form. If you cannot determine language use English.
-  - If specified language is other than Default (French, Spanish, bosnian, ...): translate all parts of {disclaimerMessage} into specified language: {language} It is critical that the entire disclaimer message is written in the same language as specified language: {language}.
-    For example if the disclaimer message is "Important Notice: The content provided is an AI-generated summary." and specified language is Spanish, the disclaimer message in Spanish would be "Aviso Importante: El contenido proporcionado es un resumen generado por IA de las respuestas del formulario".
-    If the specified language is French than the same disclaimer message should be: "Avis Important : Le contenu fourni est un résumé généré par IA des réponses du formulaire"
+  - If specified language is other than Default (French, Spanish, bosnian, ...): translate ALL parts of {disclaimerMessage} into specified language: {language}, including ANY heading text such as "Important Notice" which MUST be translated too. It is critical that the entire disclaimer message is written in the same language as specified language: {language} without any English words remaining.
+    For example if the disclaimer message is "**Important Notice:** The content provided is an AI-generated summary." and specified language is Spanish, the disclaimer message in Spanish would be "**Aviso Importante:** El contenido proporcionado es un resumen generado por IA de las respuestas del formulario".
+    If the specified language is French than the same disclaimer message should be: "**Avis Important :** Le contenu fourni est un résumé généré par IA des réponses du formulario".
   Then add two new lines after the disclaimer message.
   
   Then adhere strictly to these step-by-step instructions:
@@ -110,7 +110,7 @@ export const systemPromptTextParagraph = ChatPromptTemplate.fromTemplate(`
 
   **Language:**
 
-    - It is critical to summarize in the language specified below. If Default or not specified, use the language of the form.
+  - It is critical to summarize in the language specified below. If Default or not specified, use the language of the form.
 
   **Specified Language:**
 


### PR DESCRIPTION
[VIS-110: Spanish content issue in AI summary for Suvida](https://linear.app/awell/issue/VIS-110/spanish-content-issue-in-ai-summary-for-suvida)

Improved language detection and translation in form summarization:

- Added LLM-based language detection to reliably identify content language  
- Ensured translation covers all content, including headings and disclaimers  


**LangSmith experiments:**
- [Language Detection](https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/eae4ae59-fe19-411f-9856-f0998820981c) 
- [Summarize Form Evaluation](https://smith.langchain.com/o/3fffae83-70ff-4574-81ba-aaaedf0b4dc5/datasets/0d5083a4-0fc8-41d2-b3bd-30d7408e45a2)
