### PR TITLE
feat(medplum): add support for optional baseUrl - update README with …

### DIFF
--- a/extensions/medplum/README.md
+++ b/extensions/medplum/README.md
@@ -9,4 +9,8 @@ Medplum is the open source healthcare developer platform that helps you build, t
 
 ## Extension settings
 
-A client ID and client secret needs to be provided in order for the extension to authenticate with Medplum's API.
+The following settings are required to configure the Medplum extension:
+
+- **Client ID**: Used to authenticate with Medplum's API (required)
+- **Client Secret**: Used to authenticate with Medplum's API (required)
+- **Base URL**: Optional custom base URL for your Medplum server (e.g., `https://api.medplum.com/`). Leave empty to use the default Medplum server.

--- a/extensions/medplum/__mocks__/MedplumClient.ts
+++ b/extensions/medplum/__mocks__/MedplumClient.ts
@@ -13,6 +13,13 @@ import {
 } from '@medplum/fhirtypes'
 
 export class MedplumClient {
+  constructor(config?: { clientId?: string; baseUrl?: string }) {
+    // Store config for potential testing verification
+    this.config = config
+  }
+
+  config?: { clientId?: string; baseUrl?: string }
+
   startClientLogin = jest.fn()
 
   readResource = jest.fn(

--- a/extensions/medplum/__mocks__/index.ts
+++ b/extensions/medplum/__mocks__/index.ts
@@ -1,4 +1,4 @@
-export { mockSettings } from './mockSettings'
+export { mockSettings, mockSettingsWithoutBaseUrl } from './mockSettings'
 export {
   mockGetPatientResponse,
   mockCreatePatientResponse,

--- a/extensions/medplum/__mocks__/mockSettings.ts
+++ b/extensions/medplum/__mocks__/mockSettings.ts
@@ -1,4 +1,11 @@
 export const mockSettings = {
   clientId: 'clientId',
   clientSecret: 'clientSecret',
+  baseUrl: 'https://api.example.com/',
+}
+
+export const mockSettingsWithoutBaseUrl = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret',
+  baseUrl: '',
 }

--- a/extensions/medplum/settings.ts
+++ b/extensions/medplum/settings.ts
@@ -16,9 +16,17 @@ export const settings = {
     required: true,
     description: 'Used to authenticate with Medplum',
   },
+  baseUrl: {
+    key: 'baseUrl',
+    label: 'Base URL',
+    obfuscated: false,
+    required: false,
+    description: 'Optional custom base URL for Medplum server (e.g., https://api.medplum.com/). Leave empty to use default.',
+  },
 } satisfies Record<string, Setting>
 
 export const SettingsValidationSchema = z.object({
   clientId: z.string().min(1),
   clientSecret: z.string().min(1),
+  baseUrl: z.string().url().optional().or(z.literal('')),
 } satisfies Record<keyof typeof settings, ZodTypeAny>)

--- a/extensions/medplum/utils/validateAndCreateSdkClient.test.ts
+++ b/extensions/medplum/utils/validateAndCreateSdkClient.test.ts
@@ -1,0 +1,69 @@
+import { validateAndCreateSdkClient } from './validateAndCreateSdkClient'
+import { mockSettings, mockSettingsWithoutBaseUrl } from '../__mocks__'
+import { MedplumClient } from '@medplum/core'
+import z from 'zod'
+
+jest.mock('@medplum/core')
+
+const mockPayload = {
+  patient: { id: 'patient-id' },
+  pathway: { id: 'pathway-id' },
+  activity: { id: 'activity-id' },
+  settings: mockSettings,
+  fields: {},
+}
+
+const mockPayloadWithoutBaseUrl = {
+  ...mockPayload,
+  settings: mockSettingsWithoutBaseUrl,
+}
+
+describe('validateAndCreateSdkClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create MedplumClient with baseUrl when provided', async () => {
+    const fieldsSchema = z.object({})
+    
+    await validateAndCreateSdkClient({
+      fieldsSchema,
+      payload: mockPayload,
+    })
+
+    expect(MedplumClient).toHaveBeenCalledWith({
+      clientId: 'clientId',
+      baseUrl: 'https://api.example.com/',
+    })
+  })
+
+  it('should create MedplumClient without baseUrl when not provided', async () => {
+    const fieldsSchema = z.object({})
+    
+    await validateAndCreateSdkClient({
+      fieldsSchema,
+      payload: mockPayloadWithoutBaseUrl,
+    })
+
+    expect(MedplumClient).toHaveBeenCalledWith({
+      clientId: 'clientId',
+    })
+  })
+
+  it('should create MedplumClient without baseUrl when empty string provided', async () => {
+    const fieldsSchema = z.object({})
+    const payloadWithEmptyBaseUrl = {
+      ...mockPayload,
+      settings: { ...mockSettings, baseUrl: '' },
+    }
+    
+    await validateAndCreateSdkClient({
+      fieldsSchema,
+      payload: payloadWithEmptyBaseUrl,
+    })
+
+    expect(MedplumClient).toHaveBeenCalledWith({
+      clientId: 'clientId',
+    })
+  })
+})

--- a/extensions/medplum/utils/validateAndCreateSdkClient.test.ts
+++ b/extensions/medplum/utils/validateAndCreateSdkClient.test.ts
@@ -11,12 +11,12 @@ const mockPayload = {
   activity: { id: 'activity-id' },
   settings: mockSettings,
   fields: {},
-}
+} as any
 
 const mockPayloadWithoutBaseUrl = {
   ...mockPayload,
   settings: mockSettingsWithoutBaseUrl,
-}
+} as any
 
 describe('validateAndCreateSdkClient', () => {
   beforeEach(() => {
@@ -55,7 +55,7 @@ describe('validateAndCreateSdkClient', () => {
     const payloadWithEmptyBaseUrl = {
       ...mockPayload,
       settings: { ...mockSettings, baseUrl: '' },
-    }
+    } as any
     
     await validateAndCreateSdkClient({
       fieldsSchema,

--- a/extensions/medplum/utils/validateAndCreateSdkClient.ts
+++ b/extensions/medplum/utils/validateAndCreateSdkClient.ts
@@ -29,7 +29,7 @@ export const validateAndCreateSdkClient: ValidateAndCreateSdkClient = async ({
   payload,
 }) => {
   const {
-    settings: { clientId, clientSecret },
+    settings: { clientId, clientSecret, baseUrl },
     fields,
     settings,
   } = validate({
@@ -44,9 +44,14 @@ export const validateAndCreateSdkClient: ValidateAndCreateSdkClient = async ({
 
   const { patient, pathway, activity } = payload
 
-  const medplumSdk = new MedplumClient({
-    clientId,
-  })
+  const clientConfig: { clientId: string; baseUrl?: string } = { clientId }
+
+  // Only add baseUrl if it's provided and not empty
+  if (baseUrl && baseUrl.trim() !== '') {
+    clientConfig.baseUrl = baseUrl
+  }
+
+  const medplumSdk = new MedplumClient(clientConfig)
 
   await medplumSdk.startClientLogin(clientId, clientSecret)
 

--- a/extensions/medplum/utils/validateAndCreateSdkClient.ts
+++ b/extensions/medplum/utils/validateAndCreateSdkClient.ts
@@ -48,7 +48,7 @@ export const validateAndCreateSdkClient: ValidateAndCreateSdkClient = async ({
 
   // Only add baseUrl if it's provided and not empty
   if (baseUrl && baseUrl.trim() !== '') {
-    clientConfig.baseUrl = baseUrl
+    clientConfig.baseUrl = baseUrl.trim()
   }
 
   const medplumSdk = new MedplumClient(clientConfig)


### PR DESCRIPTION
Dear Awell Team,

The current medplum extension doesn't provide an option to provide a custom base url which is required for self-hosted medplum deployments. 

This request is to surface and pass through this optional parameter in the extension settings. 

If not provided, the default is used. The default is the one provided in medplum/core. I've avoided providing a default as this is in medplum's gift.

Thank you!