### PR TITLE
fix(bland): support both fields.webhook and fields.otherData.webhook

### DIFF
--- a/extensions/bland/actions/sendCall/__tests__/sendCall.test.ts
+++ b/extensions/bland/actions/sendCall/__tests__/sendCall.test.ts
@@ -82,4 +82,104 @@ describe('Bland.ai - Send call', () => {
       }),
     )
   })
+
+  test('Should work with async completion via fields.webhook and completeExtensionActivityAsync', async () => {
+    await sendCall.onEvent({
+      payload: {
+        fields: {
+          phoneNumber: '1234567890',
+          task: 'Some task',
+          webhook: 'https://webhook.site/1234567890',
+          completeExtensionActivityAsync: true,
+        },
+        patient: { id: 'patient-id' },
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+          tenant_id: '123',
+        },
+        activity: { id: 'activity-id' },
+        settings: { apiKey: 'api-key' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(sendCallSpy).toHaveBeenCalled()
+    expect(sendCallSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook: 'https://webhook.site/1234567890?activity_id=activity-id',
+      }),
+    )
+    // Completion happens async via a Webhook from Bland
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  test('Should use otherData.webhook and call onComplete (no async)', async () => {
+    await sendCall.onEvent({
+      payload: {
+        fields: {
+          phoneNumber: '1234567890',
+          task: 'Some task',
+          otherData: JSON.stringify({
+            webhook: 'https://example.com/otherdata',
+          }),
+        },
+        patient: { id: 'patient-id' },
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+          tenant_id: '123',
+        },
+        activity: { id: 'activity-id' },
+        settings: { apiKey: 'api-key' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(sendCallSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ webhook: 'https://example.com/otherdata' }),
+    )
+    // Not async completion => onComplete should be called
+    expect(onComplete).toHaveBeenCalled()
+  })
+
+  test('Should override fields.webhook with otherData.webhook and call onComplete (no async)', async () => {
+    await sendCall.onEvent({
+      payload: {
+        fields: {
+          phoneNumber: '1234567890',
+          task: 'Some task',
+          webhook: 'https://webhook.site/fields',
+          otherData: JSON.stringify({
+            webhook: 'https://webhook.site/otherdata',
+          }),
+        },
+        patient: { id: 'patient-id' },
+        pathway: {
+          id: 'pathway-id',
+          definition_id: 'pathway-definition-id',
+          tenant_id: '123',
+        },
+        activity: { id: 'activity-id' },
+        settings: { apiKey: 'api-key' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    // otherData.webhook should override fields.webhook
+    expect(sendCallSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ webhook: 'https://webhook.site/otherdata' }),
+    )
+    // Not async completion => onComplete should be called
+    expect(onComplete).toHaveBeenCalled()
+  })
 })

--- a/extensions/bland/actions/sendCall/sendCall.ts
+++ b/extensions/bland/actions/sendCall/sendCall.ts
@@ -38,9 +38,9 @@ export const sendCall: Action<
     // otherData helps us to pass in fields that are not part of the SendCallInputSchema,
     // given bland's schema is updating quickly
     const sendCallInput = SendCallInputSchema.parse({
-      ...otherData,
       ...fields,
       webhook: getWebhookUrl(),
+      ...otherData, // there can be a 'webhook' field in this otherData object, it needs to be able to override the webhook from the fields object
       phone_number: fields.phoneNumber,
       request_data: fields.requestData,
       metadata: {

--- a/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
+++ b/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
@@ -36,9 +36,9 @@ export const sendCallWithPathway: Action<
 
     const { otherData, ...fields } = allFields
     const sendCallInput = SendCallInputSchema.parse({
-      ...otherData,
       ...fields,
       webhook: getWebhookUrl(),
+      ...otherData, // there was a 'webhook' field in this otherData object
       phone_number: fields.phoneNumber,
       pathway_id: fields.pathwayId,
       request_data: fields.requestData,


### PR DESCRIPTION
We need to support both sync and async extension actions.

otherData.webhook was used by a customer in order to use an enrollment trigger to start a new track with the callCompleted webhook.

fields.webhook and fields.completeExtensionAsync are used in order to send a call back to complete the activity and continue in-line.

New tests should validate both options are possible now.