### PR TITLE
feat(awell): opt in all actions for automated retries

### DIFF
--- a/extensions/awell/v1/actions/addAdhocTrack/addAdhocTrack.ts
+++ b/extensions/awell/v1/actions/addAdhocTrack/addAdhocTrack.ts
@@ -16,6 +16,7 @@ export const addAdhocTrack: Action<typeof fields, typeof settings> = {
   description: 'Add a pre-configured ad hoc track to a patient care flow.',
   fields,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: { trackId },

--- a/extensions/awell/v1/actions/addIdentifierToPatient/addIdentifierToPatient.ts
+++ b/extensions/awell/v1/actions/addIdentifierToPatient/addIdentifierToPatient.ts
@@ -18,6 +18,7 @@ export const addIdentifierToPatient: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     // Validate and extract the `system` and `value` fields and `currentPatientId` from the payload
     const {

--- a/extensions/awell/v1/actions/createNaviSession/createNaviSession.ts
+++ b/extensions/awell/v1/actions/createNaviSession/createNaviSession.ts
@@ -13,6 +13,7 @@ export const createNaviSession: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError }): Promise<void> => {
     const {
       fields: { stakeholderId, exp },

--- a/extensions/awell/v1/actions/getCurrentCareflowId/getCurrentCareflowId.ts
+++ b/extensions/awell/v1/actions/getCurrentCareflowId/getCurrentCareflowId.ts
@@ -17,6 +17,7 @@ export const getCurrentCareflowId: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       pathway: { id: currentCareflowId, definition_id: currentCareflowDefinitionId },

--- a/extensions/awell/v1/actions/getDataPointValue/getDataPointValue.ts
+++ b/extensions/awell/v1/actions/getDataPointValue/getDataPointValue.ts
@@ -14,6 +14,7 @@ export const getDataPointValue: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const {
       fields: { careFlowId, dataPointDefinitionId },

--- a/extensions/awell/v1/actions/getPatientByIdentifier/getPatientByIdentifier.ts
+++ b/extensions/awell/v1/actions/getPatientByIdentifier/getPatientByIdentifier.ts
@@ -16,6 +16,7 @@ export const getPatientByIdentifier: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: true,
+  supports_automated_retries: true,
   onEvent: async ({
     payload,
     onComplete,

--- a/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/isPatientEnrolledInCareFlow.ts
+++ b/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/isPatientEnrolledInCareFlow.ts
@@ -37,6 +37,7 @@ export const isPatientEnrolledInCareFlow: Action<
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const {
       patient: { id: patientId },

--- a/extensions/awell/v1/actions/isPatientEnrolledInTrack/isPatientEnrolledInTrack.ts
+++ b/extensions/awell/v1/actions/isPatientEnrolledInTrack/isPatientEnrolledInTrack.ts
@@ -21,6 +21,7 @@ export const isPatientEnrolledInTrack: Action<typeof fields, typeof settings> =
     fields,
     dataPoints,
     previewable: false,
+    supports_automated_retries: true,
     onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
       const {
         fields: { trackDefinitionId },

--- a/extensions/awell/v1/actions/listFormAnswers/listFormAnswers.ts
+++ b/extensions/awell/v1/actions/listFormAnswers/listFormAnswers.ts
@@ -31,6 +31,7 @@ export const listFormAnswers: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const {
       fields: {

--- a/extensions/awell/v1/actions/searchPatientsByPatientCode/searchPatientsByPatientCode.ts
+++ b/extensions/awell/v1/actions/searchPatientsByPatientCode/searchPatientsByPatientCode.ts
@@ -18,6 +18,7 @@ export const searchPatientsByPatientCode: Action<
   fields,
   dataPoints,
   previewable: true,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       patient: {

--- a/extensions/awell/v1/actions/startCareFlow/startCareFlow.ts
+++ b/extensions/awell/v1/actions/startCareFlow/startCareFlow.ts
@@ -19,6 +19,7 @@ export const startCareFlow: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: { pathwayDefinitionId, baselineInfo },

--- a/extensions/awell/v1/actions/startCareFlowAndSession/startCareFlowAndSession.ts
+++ b/extensions/awell/v1/actions/startCareFlowAndSession/startCareFlowAndSession.ts
@@ -13,6 +13,7 @@ export const startCareFlowAndSession: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const {
       fields: { careFlowDefinitionId, stakeholderDefinitionId, baselineInfo },

--- a/extensions/awell/v1/actions/startHostedPagesSession/startHostedPagesSession.ts
+++ b/extensions/awell/v1/actions/startHostedPagesSession/startHostedPagesSession.ts
@@ -17,6 +17,7 @@ export const startHostedPagesSession: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const {
       fields: { careFlowId, stakeholder },

--- a/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
+++ b/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
@@ -16,6 +16,7 @@ export const stopCareFlow: Action<typeof fields, typeof settings> = {
   description: 'Stop the care flow the patient is currently enrolled.',
   fields,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: { careFlowIds, reason },

--- a/extensions/awell/v1/actions/stopTrack/stopTrack.ts
+++ b/extensions/awell/v1/actions/stopTrack/stopTrack.ts
@@ -15,6 +15,7 @@ export const stopTrack: Action<typeof fields, typeof settings> = {
   description: 'Stop a track in a patient care flow (pathway).',
   fields,
   previewable: false, // We don't have pathways in Preview, only cases.
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: { trackDefinitionId },

--- a/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
+++ b/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
@@ -18,6 +18,7 @@ export const updateBaselineInfo: Action<typeof fields, typeof settings> = {
   fields,
   dataPoints,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: { careflowId: externalCareflowId, baselineInfo },

--- a/extensions/awell/v1/actions/updatePatient/updatePatient.ts
+++ b/extensions/awell/v1/actions/updatePatient/updatePatient.ts
@@ -16,6 +16,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
   description: 'Update the current patient with new data.',
   fields,
   previewable: false,
+  supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, helpers }): Promise<void> => {
     const {
       fields: {


### PR DESCRIPTION
## Summary

- Sets `supports_automated_retries: true` on all 17 Awell Workflow extension actions
- Enables the automated retry option in Studio/design for actions such as **Update patient** and **Update Baseline Datapoints**
- Does not turn retries on by default; orchestration only retries when enabled per action in care flow design

## Test plan

- [x] `yarn compile` passes
- [ ] After release, confirm Studio shows the automated retry toggle for Awell Workflow actions
- [ ] When enabling retries on mutating actions (e.g. `updatePatient`, `startCareFlow`), verify idempotency expectations with your team


Made with [Cursor](https://cursor.com)