### PR TITLE
docs(bland): clarify language field format and default

### DIFF
--- a/extensions/bland/actions/sendCall/config/fields.ts
+++ b/extensions/bland/actions/sendCall/config/fields.ts
@@ -148,7 +148,7 @@ export const fields = {
     id: 'language',
     label: 'Language',
     description:
-      'Optimizes every part of our API for that language - transcription, speech, and other inner workings.',
+      'Optimizes transcription, speech, and other inner workings for the specified language. Enter a 2-letter ISO 639-1 code in lowercase, for example: en, es, fr. Defaults to English if not set.',
     type: FieldType.STRING,
     required: false,
   },

--- a/extensions/bland/actions/sendCallWithPathway/config/fields.ts
+++ b/extensions/bland/actions/sendCallWithPathway/config/fields.ts
@@ -155,7 +155,7 @@ export const fields = {
     id: 'language',
     label: 'Language',
     description:
-      'Optimizes every part of our API for that language - transcription, speech, and other inner workings.',
+      'Optimizes transcription, speech, and other inner workings for the specified language. Enter a 2-letter ISO 639-1 code in lowercase, for example: en, es, fr. Defaults to English if not set.',
     type: FieldType.STRING,
     required: false,
   },


### PR DESCRIPTION
## Summary

- Updates the `language` field description in `sendCall` and `sendCallWithPathway` to tell users the expected format (2-letter ISO 639-1 lowercase, e.g. en, es, fr) and that it defaults to English if omitted.
- Display string change only — no logic, schema, or test impact.

## Test plan

- [ ] Visual check: confirm updated description appears in the authoring UI for both actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)