### PR TITLE
feat(bland): expose answeredBy and errorMessage in Get call details

### DIFF
--- a/extensions/bland/actions/getCallDetails/__tests__/getCallDetails.test.ts
+++ b/extensions/bland/actions/getCallDetails/__tests__/getCallDetails.test.ts
@@ -140,6 +140,8 @@ describe('Bland.ai - Get call details', () => {
         concatenatedTranscript: callData.concatenated_transcript,
         transcripts: JSON.stringify(callData.transcripts),
         status: callData.status,
+        answeredBy: callData.answered_by,
+        errorMessage: '',
       },
     })
   })

--- a/extensions/bland/actions/getCallDetails/config/dataPoints.ts
+++ b/extensions/bland/actions/getCallDetails/config/dataPoints.ts
@@ -57,4 +57,12 @@ export const dataPoints = {
     key: 'status',
     valueType: 'string',
   },
+  answeredBy: {
+    key: 'answeredBy',
+    valueType: 'string',
+  },
+  errorMessage: {
+    key: 'errorMessage',
+    valueType: 'string',
+  },
 } satisfies Record<string, DataPointDefinition>

--- a/extensions/bland/actions/getCallDetails/getCallDetails.ts
+++ b/extensions/bland/actions/getCallDetails/getCallDetails.ts
@@ -55,6 +55,8 @@ export const getCallDetails: Action<
           ? undefined
           : JSON.stringify(data.transcripts),
         status: data.status,
+        answeredBy: data.answered_by ?? '',
+        errorMessage: data.error_message ?? '',
       },
     })
   },

--- a/extensions/bland/api/schema/GetCallDetails.schema.ts
+++ b/extensions/bland/api/schema/GetCallDetails.schema.ts
@@ -20,7 +20,7 @@ export const GetCallDetailsResponseSchema = z.object({
   max_duration: z.number(),
   error_message: z.string().nullable(),
   variables: z.record(z.string(), z.unknown()),
-  answered_by: z.string(),
+  answered_by: z.string().nullable(),
   record: z.boolean(),
   recording_url: z.string().nullable(),
   metadata: z.record(z.string(), z.unknown()),


### PR DESCRIPTION
## Summary

- Add `answeredBy` and `errorMessage` as first-class data points on the Bland **Get call details** action, mapped from the `answered_by` and `error_message` fields the [Bland Call Details API](https://docs.bland.ai/api-v1/get/calls-id) already returns.
- Make `answered_by` nullable in `GetCallDetailsResponseSchema` to reflect that Bland returns `null` when answered-by detection is disabled or still processing.
- This brings the action in line with the existing **Call Completed** webhook, which already exposes `status`, `answeredBy`, and `errorMessage`.

## Why

Previously the action only exposed `status` and `completed` as outcome-related data points; `answered_by` and `error_message` were only available buried inside the raw `callData` JSON. That made it awkward to branch on call outcome (human vs voicemail, failure reason) in Awell decision components. These fields are now usable directly.

Note: this surfaces data Bland already returns — it does not change detection accuracy. Reliable human/voicemail detection still depends on send-call configuration (`answered_by_enabled`, `wait_for_greeting`, a short `first_sentence`).

## Test plan

- [x] `Should work` test updated to assert the new `answeredBy` / `errorMessage` data points (covers `error_message: null -> ''`)
- [x] Existing getCallDetails test suite passes
- [ ] Verify in a care flow that the new data points appear and are selectable in decision components

Made with [Cursor](https://cursor.com)