### PR TITLE
fix(bland): return early from callCompleted webhook when call_id is missing

### DIFF
--- a/extensions/bland/webhooks/CallCompleted/callCompleted.test.ts
+++ b/extensions/bland/webhooks/CallCompleted/callCompleted.test.ts
@@ -10,6 +10,32 @@ describe('Webhook - Call completed', () => {
     clearMocks()
   })
 
+  describe('When call_id is missing', () => {
+    test('Should call onError and not call onSuccess', async () => {
+      const { call_id, ...payloadWithoutCallId } = callCompletedPayload
+
+      await extensionWebhook.onEvent!({
+        payload: {
+          payload: payloadWithoutCallId as any,
+          settings: { apiKey: 'api-key' },
+          rawBody: Buffer.from(''),
+          headers: {},
+        },
+        onSuccess,
+        onError,
+        helpers,
+      })
+
+      expect(onError).toHaveBeenCalledWith({
+        response: {
+          statusCode: 400,
+          message: 'Missing call_id in payload',
+        },
+      })
+      expect(onSuccess).not.toHaveBeenCalled()
+    })
+  })
+
   describe('When payload is valid', () => {
     test('Should call onSuccess, which starts the care flow', async () => {
       await extensionWebhook.onEvent!({

--- a/extensions/bland/webhooks/CallCompleted/callCompleted.ts
+++ b/extensions/bland/webhooks/CallCompleted/callCompleted.ts
@@ -51,7 +51,7 @@ export const callCompleted: Webhook<
       payload?.metadata?.awell_patient_id
 
     if (isNil(callId)) {
-      await onError({
+      return await onError({
         response: {
           statusCode: 400,
           message: 'Missing call_id in payload',


### PR DESCRIPTION
## Summary
- `callCompleted` webhook was calling `onError` when `call_id` was missing but not returning, causing execution to fall through and also call `onSuccess`
- Added `return` before `onError` to properly short-circuit
- Added a test covering this case (missing `call_id` → `onError` called, `onSuccess` not called)

## Test plan
- [ ] New test `When call_id is missing > Should call onError and not call onSuccess` passes
- [ ] Existing valid-payload test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)