### PR TITLE
feat(shelly): use TEXT field type for multi-line prompt fields

### DIFF
--- a/extensions/shelly/actions/generateMessage/config/fields.ts
+++ b/extensions/shelly/actions/generateMessage/config/fields.ts
@@ -10,7 +10,7 @@ export const fields = {
     label: 'Communication Objective',
     description:
       'Provide the main purpose of the message. Add any important message context.',
-    type: FieldType.STRING,
+    type: FieldType.TEXT,
     required: true,
   },
   personalizationInput: {
@@ -18,7 +18,7 @@ export const fields = {
     label: 'Personalization Input',
     description:
       '[Optional] Specify the personalization input for the message (name, age, gender, date of the last checkup, etc). This is used to personalize the message to the recipient.',
-    type: FieldType.STRING,
+    type: FieldType.TEXT,
     required: false,
   },
   stakeholder: {

--- a/extensions/shelly/actions/summarizeCareFlow/config/fields.ts
+++ b/extensions/shelly/actions/summarizeCareFlow/config/fields.ts
@@ -7,7 +7,7 @@ export const fields = {
     label: 'Additional instructions',
     description:
       'Specify additional instructions for summarization, for example format, length, what to focus on etc. If not specified, default instructions will be used.',
-    type: FieldType.STRING,
+    type: FieldType.TEXT,
     required: false,
   },
   stakeholder: {


### PR DESCRIPTION
## Summary

- Switches `communicationObjective` and `personalizationInput` in `generateMessage` from `FieldType.STRING` → `FieldType.TEXT` so they render as textareas in the care flow builder
- Same change for `additionalInstructions` in `summarizeCareFlow`

## Backwards compatibility

`FieldType.TEXT` and `FieldType.STRING` both store plain strings — the only difference is the UI widget (textarea vs single-line input). Any values already entered in existing care flows will display unchanged in the larger text box. No migration needed.

## Test plan

- [ ] Open the Generate Message action in the care flow builder — Communication Objective and Personalization Input should now render as multi-line textareas
- [ ] Open the Summarize Care Flow action — Additional Instructions should render as a textarea
- [ ] Confirm existing care flows with values already set in those fields still display the values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)