### PR TITLE
fix(shelly): prevent Summarize Form timeouts on gpt-5-mini

### DIFF
--- a/extensions/shelly/actions/summarizeForm/summarizeForm.ts
+++ b/extensions/shelly/actions/summarizeForm/summarizeForm.ts
@@ -60,6 +60,10 @@ export const summarizeForm: Action<
       payload,
       modelType: OPENAI_MODELS.GPT5Mini,
       hideDataForTracing: true, // Hide input and output data when tracing
+      // Summarizing a form is a low-complexity task, so we cap reasoning effort
+      // to keep gpt-5-mini latency well under the request timeout. Scoped to this
+      // action so other extensions keep the model's default reasoning quality.
+      modelConfigOverrides: { reasoning: { effort: 'low' } },
     })
 
     const awellSdk = await helpers.awellSdk()

--- a/extensions/shelly/lib/summarizeFormWithLLM/summarizeFormWithLLM.ts
+++ b/extensions/shelly/lib/summarizeFormWithLLM/summarizeFormWithLLM.ts
@@ -1,7 +1,7 @@
 import { systemPromptBulletPoints, systemPromptTextParagraph } from './prompt'
 import { type ChatOpenAI } from '@langchain/openai'
 import { type AIActionMetadata } from '../../../../src/lib/llm/openai/types'
-import type { BaseCallbackHandler } from "@langchain/core/callbacks/base"
+import type { BaseCallbackHandler } from '@langchain/core/callbacks/base'
 
 /**
  * Uses LLM to summarize form data in a specified format and language.
@@ -9,7 +9,7 @@ import type { BaseCallbackHandler } from "@langchain/core/callbacks/base"
  * 1. Formats prompt with form data and preferences
  * 2. Runs LLM with appropriate system prompt
  * 3. Returns formatted summary with disclaimer
- * 
+ *
  * @example
  * const result = await summarizeFormWithLLM({
  *   model,
@@ -40,29 +40,34 @@ export const summarizeFormWithLLM = async ({
   metadata: AIActionMetadata
   callbacks?: BaseCallbackHandler[]
 }): Promise<string> => {
-  const systemPrompt = summaryFormat === 'Bullet-points' ? systemPromptBulletPoints : 
-                      summaryFormat === 'Text paragraph' ? systemPromptTextParagraph :
-                      systemPromptBulletPoints // Default to bullet points if unknown format
+  const systemPrompt =
+    summaryFormat === 'Bullet-points'
+      ? systemPromptBulletPoints
+      : summaryFormat === 'Text paragraph'
+        ? systemPromptTextParagraph
+        : systemPromptBulletPoints // Default to bullet points if unknown format
 
   const prompt = await systemPrompt.format({
     language,
     input: formData,
     disclaimerMessage,
-    additionalInstructions: additionalInstructions ?? 'No additional instructions',
+    additionalInstructions:
+      additionalInstructions ?? 'No additional instructions',
   })
 
   try {
-    const result = await model.invoke(
-      prompt,
-      { 
-        metadata, 
-        runName: 'ShellySummarizeForm',
-        callbacks
-      }
-    )
+    const result = await model.invoke(prompt, {
+      metadata,
+      runName: 'ShellySummarizeForm',
+      callbacks,
+    })
 
     return result.content as string
   } catch (error) {
-    throw new Error('Failed to generate form summary')
+    // Preserve the underlying error (e.g. OpenAI TimeoutError) as the cause so it
+    // surfaces in logs/traces instead of being masked by the generic message.
+    const wrappedError = new Error('Failed to generate form summary')
+    ;(wrappedError as Error & { cause?: unknown }).cause = error
+    throw wrappedError
   }
 }

--- a/src/lib/llm/openai/constants.ts
+++ b/src/lib/llm/openai/constants.ts
@@ -9,13 +9,16 @@ export const getDefaultConfig = (
       return {
         temperature: 1,
         maxRetries: 3,
-        timeout: 30000,
+        // 60s per-request ceiling. gpt-5-mini is a reasoning model and a single
+        // generation can exceed the previous 30s limit, causing every retry to
+        // time out and the action to fail after ~2min. See summarizeForm.
+        timeout: 60000,
       }
     default:
       return {
         temperature: 0,
         maxRetries: 3,
-        timeout: 30000,
+        timeout: 60000,
       }
   }
 }

--- a/src/lib/llm/openai/createOpenAIModel.test.ts
+++ b/src/lib/llm/openai/createOpenAIModel.test.ts
@@ -1,0 +1,71 @@
+import { createOpenAIModel } from './createOpenAIModel'
+import { MODEL_VERSIONS, OPENAI_MODELS } from './constants'
+
+const buildArgs = (
+  overrides: Record<string, unknown> = {},
+): Parameters<typeof createOpenAIModel>[0] => ({
+  settings: {},
+  helpers: {
+    getOpenAIConfig: () => ({ apiKey: 'env-api-key' }),
+  },
+  payload: {
+    pathway: {
+      id: 'pathway-1',
+      definition_id: 'def-1',
+      tenant_id: 'tenant-1',
+      org_slug: 'org-slug',
+      org_id: 'org-1',
+    },
+    activity: { id: 'activity-1' },
+  },
+  ...overrides,
+})
+
+describe('createOpenAIModel', () => {
+  it('applies the model defaults from getDefaultConfig', async () => {
+    const { model } = await createOpenAIModel(buildArgs())
+
+    expect(model.model).toBe(MODEL_VERSIONS[OPENAI_MODELS.GPT5Mini])
+    // Raised from 30s to 60s to give gpt-5-mini reasoning latency headroom
+    expect(model.timeout).toBe(60000)
+    // No reasoning override by default -> preserves the model's default quality
+    expect(model.reasoning).toBeUndefined()
+  })
+
+  it('merges modelConfigOverrides on top of the defaults', async () => {
+    const { model } = await createOpenAIModel(
+      buildArgs({ modelConfigOverrides: { reasoning: { effort: 'low' } } }),
+    )
+
+    expect(model.reasoning).toEqual({ effort: 'low' })
+    // Untouched defaults still apply
+    expect(model.timeout).toBe(60000)
+  })
+
+  it('does not allow overrides to change the enforced model or apiKey', async () => {
+    const { model } = await createOpenAIModel(
+      buildArgs({
+        settings: { openAiApiKey: 'settings-api-key' },
+        modelConfigOverrides: {
+          model: 'gpt-4o',
+          apiKey: 'hijacked-key',
+          reasoning: { effort: 'low' },
+        },
+      }),
+    )
+
+    expect(model.model).toBe(MODEL_VERSIONS[OPENAI_MODELS.GPT5Mini])
+    expect(model.apiKey).toBe('settings-api-key')
+    expect(model.reasoning).toEqual({ effort: 'low' })
+  })
+
+  it('throws when no API key is available', async () => {
+    await expect(
+      createOpenAIModel(
+        buildArgs({
+          helpers: { getOpenAIConfig: () => ({ apiKey: undefined }) },
+        }),
+      ),
+    ).rejects.toThrow('No OpenAI API key available')
+  })
+})

--- a/src/lib/llm/openai/createOpenAIModel.ts
+++ b/src/lib/llm/openai/createOpenAIModel.ts
@@ -29,6 +29,7 @@ export const createOpenAIModel = async ({
   helpers,
   payload,
   modelType = OPENAI_MODELS.GPT5Mini,
+  modelConfigOverrides,
   hideDataForTracing = false,
 }: CreateOpenAIModelConfig & {
   hideDataForTracing?: boolean
@@ -42,9 +43,11 @@ export const createOpenAIModel = async ({
   }
 
   const model = new ChatOpenAI({
+    ...getDefaultConfig(modelType),
+    ...modelConfigOverrides,
+    // model and apiKey are enforced last so per-action overrides cannot change them
     model: MODEL_VERSIONS[modelType],
     apiKey,
-    ...getDefaultConfig(modelType),
   })
 
   let callbacks

--- a/src/lib/llm/openai/types.ts
+++ b/src/lib/llm/openai/types.ts
@@ -1,9 +1,9 @@
-import type { ChatOpenAI } from '@langchain/openai'
+import type { ChatOpenAI, ChatOpenAIFields } from '@langchain/openai'
 import type { OPENAI_MODELS } from './constants'
-import type { BaseCallbackHandler } from "@langchain/core/callbacks/base"
+import type { BaseCallbackHandler } from '@langchain/core/callbacks/base'
 
 // This ensures modelType only accepts the exact values from OPENAI_MODELS
-export type OpenAIModelType = typeof OPENAI_MODELS[keyof typeof OPENAI_MODELS]
+export type OpenAIModelType = (typeof OPENAI_MODELS)[keyof typeof OPENAI_MODELS]
 
 // Define the minimal structure we need from the pathway
 interface MinimalPathway {
@@ -36,9 +36,19 @@ export interface CreateOpenAIModelConfig {
     getOpenAIConfig: () => { apiKey: string }
   }
   /** Payload containing the minimal required information */
-  payload: RequiredPayloadProperties & Record<string, any>  // Changed to be more permissive
+  payload: RequiredPayloadProperties & Record<string, any> // Changed to be more permissive
   /** Which OpenAI model to use */
   modelType?: OpenAIModelType
+  /**
+   * Optional per-action overrides merged into the ChatOpenAI constructor on top
+   * of the model defaults from `getDefaultConfig`. Use this to tune behaviour for
+   * a single action (e.g. `{ reasoning: { effort: 'low' } }` to reduce latency)
+   * without affecting the shared defaults used by other extensions.
+   *
+   * Note: `model` and `apiKey` are always enforced by the factory and cannot be
+   * overridden here.
+   */
+  modelConfigOverrides?: Partial<ChatOpenAIFields>
 }
 
 /**
@@ -46,7 +56,7 @@ export interface CreateOpenAIModelConfig {
  * Used for LangSmith tracing and analytics
  */
 export interface AIActionMetadata {
-  activity_id: string,
+  activity_id: string
   care_flow_definition_id: string
   care_flow_id: string
   tenant_id: string
@@ -60,7 +70,7 @@ export interface OpenAIModelConfig {
   model: ChatOpenAI
   /** Tracing metadata for LangChain calls */
   metadata: {
-    activity_id: string,
+    activity_id: string
     care_flow_definition_id: string
     care_flow_id: string
     tenant_id: string


### PR DESCRIPTION
## Context

Surfaced from a ZAS demo-support Slack thread: the **Summarize Form** action (Shelly, `gpt-5-mini`) failed with `TimeoutError: Request timed out … wrapOpenAIClientError`. The LangSmith run `ShellySummarizeForm` ran **129.8s** and returned `null`. Earlier runs were "slow (1+ min) but worked."

## Root cause

The shared OpenAI factory configured `gpt-5-mini` with a **30s per-request `timeout`** and **`maxRetries: 3`**, and no reasoning-effort override — so the model ran at its default (medium) reasoning effort. `gpt-5-mini` is a reasoning model, so a single summary generation drifted past 30s. Each of the 1 + 3 = **4 attempts** blew the 30s ceiling, so the action failed after ~2 min (≈ 4 × 30s + backoff = the 129.8s in the trace). "Slow but worked earlier" = a run that happened to finish just under 30s. This is LLM latency/timeout, **not** a care-flow bug.

## Changes

1. **Raise the per-request timeout 30s → 60s** (`getDefaultConfig`) so a normal-but-slow reasoning generation completes instead of being killed and retried into a multi-minute failure.
2. **Cap reasoning effort for `summarizeForm` only** via a new optional `modelConfigOverrides` on `createOpenAIModel`, set to `{ reasoning: { effort: 'low' } }`. Summarization is low-complexity, so this cuts latency without changing the default reasoning quality other extensions (e.g. Elation) rely on. `model`/`apiKey` are enforced last in the constructor so overrides cannot change them.
3. **Preserve the underlying error** as `cause` in `summarizeFormWithLLM` instead of masking it behind the generic `"Failed to generate form summary"`, so future triage doesn't require digging into LangSmith.

`gpt-5-mini` is not in LangChain's "prefers Responses API" list and we don't set `reasoning.summary`, so `reasoning.effort` maps to `reasoning_effort` on the Chat Completions API — **no change** to output shape or tracing.

## Note / follow-up

`maxRetries` is intentionally left at 3 (per scoping of this fix). Worst-case failure path is now ~4 × 60s, but with `effort: 'low'` typical latency sits well under a single 60s attempt, so retries should rarely trigger. A future improvement could reduce retries for a tighter, more predictable failure ceiling.

## Testing

- `yarn compile` (typecheck) ✅
- `yarn jest` on `summarizeForm`, `summarizeFormWithLLM`, and a new `createOpenAIModel.test.ts` (asserts defaults, override merge, and that overrides cannot hijack `model`/`apiKey`) ✅
- eslint on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)