### PR TITLE
feat(bland): add sendSms and createSmsConversation actions

### DIFF
--- a/extensions/bland/CHANGELOG.md
+++ b/extensions/bland/CHANGELOG.md
@@ -1,1 +1,6 @@
 # CHANGELOG
+
+## Unreleased
+
+- Added `sendSms` action: send an SMS immediately via Bland `POST /v1/sms/send`. The agent message is optional; when omitted, the pathway configured on the agent number generates the message.
+- Added `createSmsConversation` action: seed an SMS conversation positioned at pathway state via Bland `POST /v1/sms/create` without sending a message. `message_sid` is required by the live API (despite being documented as optional) and is auto-generated as a UUID.

--- a/extensions/bland/CHANGELOG.md
+++ b/extensions/bland/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## Unreleased
 
 - Added `sendSms` action: send an SMS immediately via Bland `POST /v1/sms/send`. The agent message is optional; when omitted, the pathway configured on the agent number generates the message.
-- Added `createSmsConversation` action: seed an SMS conversation positioned at pathway state via Bland `POST /v1/sms/create` without sending a message. `message_sid` is required by the live API (despite being documented as optional) and is auto-generated as a UUID.
+- Added `createSmsConversation` action: seed an SMS conversation positioned at pathway state via Bland `POST /v1/sms/create` without sending a message.

--- a/extensions/bland/actions/createSmsConversation/__tests__/createSmsConversation.test.ts
+++ b/extensions/bland/actions/createSmsConversation/__tests__/createSmsConversation.test.ts
@@ -1,0 +1,76 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { BlandApiClient } from '../../../api/client'
+import { createSmsConversation as action } from '../createSmsConversation'
+
+const createResponse = {
+  data: {
+    conversation_id: 'conv-456',
+    status: 'created',
+  },
+  errors: null,
+}
+
+const createSmsConversationMock = jest.fn().mockResolvedValue({
+  data: createResponse,
+})
+
+jest.mock('../../../api/client', () => ({
+  BlandApiClient: jest.fn().mockImplementation(() => ({
+    createSmsConversation: createSmsConversationMock,
+  })),
+}))
+
+const mockedSdk = jest.mocked(BlandApiClient)
+
+describe('Bland.ai - Create SMS conversation', () => {
+  const {
+    extensionAction: createSmsConversation,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should create a conversation and auto-generate a message_sid', async () => {
+    await createSmsConversation.onEvent({
+      payload: {
+        fields: {
+          userNumber: '+12223334444',
+          agentNumber: '+18162392019',
+          message: 'Patient opted in to SMS reminders',
+          sender: 'USER',
+          currPathwayId: '0d726519-a4a3-47ba-9d55-c5a5181e29de',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+        patient: { id: 'patient-id' },
+        pathway: { id: 'pathway-id', definition_id: 'definition-id' },
+        activity: { id: 'activity-id' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(mockedSdk).toHaveBeenCalled()
+
+    const input = createSmsConversationMock.mock.calls[0][0]
+    expect(input.message_sid).toEqual(expect.any(String))
+    expect(input.message_sid.length).toBeGreaterThan(0)
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: {
+          conversationId: 'conv-456',
+          createResponse: JSON.stringify(createResponse),
+        },
+      }),
+    )
+  })
+})

--- a/extensions/bland/actions/createSmsConversation/config/dataPoints.ts
+++ b/extensions/bland/actions/createSmsConversation/config/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  conversationId: {
+    key: 'conversationId',
+    valueType: 'string',
+  },
+  createResponse: {
+    key: 'createResponse',
+    valueType: 'json',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/bland/actions/createSmsConversation/config/fields.ts
+++ b/extensions/bland/actions/createSmsConversation/config/fields.ts
@@ -1,0 +1,105 @@
+import {
+  FieldType,
+  StringType,
+  type Field,
+} from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+import {
+  dropdownOptionsBoolean,
+  dropdownOptionsBooleanSchema,
+  JsonObjectSchema,
+} from '../../../lib/sharedActionFields'
+
+export const fields = {
+  userNumber: {
+    id: 'userNumber',
+    label: 'User phone number',
+    description: 'The phone number of the user in the conversation (E.164 format).',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  agentNumber: {
+    id: 'agentNumber',
+    label: 'Agent phone number',
+    description:
+      'The Bland-owned, SMS-enabled phone number for the conversation (E.164 format).',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  message: {
+    id: 'message',
+    label: 'Message',
+    description:
+      'The message to seed the conversation with. It is recorded in the conversation but NOT sent to the user.',
+    type: FieldType.TEXT,
+    required: true,
+  },
+  sender: {
+    id: 'sender',
+    label: 'Sender',
+    description:
+      'Who the seeded message is attributed to. Defaults to USER when omitted.',
+    type: FieldType.STRING,
+    required: false,
+    options: {
+      dropdownOptions: [
+        { value: 'USER', label: 'User' },
+        { value: 'AGENT', label: 'Agent' },
+      ],
+    },
+  },
+  currPathwayId: {
+    id: 'currPathwayId',
+    label: 'Current pathway ID',
+    description: 'The pathway to position the conversation on.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  currPathwayVersion: {
+    id: 'currPathwayVersion',
+    label: 'Current pathway version',
+    description: 'The version of the pathway.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  currentNodeId: {
+    id: 'currentNodeId',
+    label: 'Current node ID',
+    description: 'The pathway node the conversation should be positioned at.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  newConversation: {
+    id: 'newConversation',
+    label: 'Start new conversation',
+    description:
+      'When enabled, starts a fresh conversation instead of continuing an existing one.',
+    type: FieldType.STRING,
+    required: false,
+    options: {
+      dropdownOptions: dropdownOptionsBoolean,
+    },
+  },
+  requestData: {
+    id: 'requestData',
+    label: 'Request data',
+    description:
+      'JSON object of variables made available to the pathway/agent during the conversation. Can be referenced with Prompt Variables.',
+    type: FieldType.JSON,
+    required: false,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  userNumber: z.string().trim().min(1),
+  agentNumber: z.string().trim().min(1),
+  message: z.string().trim().min(1),
+  sender: z.enum(['USER', 'AGENT']).optional(),
+  currPathwayId: z.string().optional(),
+  currPathwayVersion: z.string().optional(),
+  currentNodeId: z.string().optional(),
+  newConversation: dropdownOptionsBooleanSchema.optional(),
+  requestData: JsonObjectSchema.optional(),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/createSmsConversation/config/index.ts
+++ b/extensions/bland/actions/createSmsConversation/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/bland/actions/createSmsConversation/createSmsConversation.ts
+++ b/extensions/bland/actions/createSmsConversation/createSmsConversation.ts
@@ -1,0 +1,82 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { randomUUID } from 'crypto'
+import { isEmpty, isNil } from 'lodash'
+import { validatePayloadAndCreateSdk } from '../../lib/validatePayloadAndCreateSdk'
+import { type settings } from '../../settings'
+import { fields, FieldsValidationSchema, dataPoints } from './config'
+import { CreateSmsConversationInputSchema } from '../../api/schema'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+
+export const createSmsConversation: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'createSmsConversation',
+  category: Category.COMMUNICATION,
+  title: 'Create SMS conversation',
+  description:
+    'Create an SMS conversation seeded with pathway state, without sending a message immediately. The pathway then drives outbound texts.',
+  fields,
+  previewable: true,
+  dataPoints,
+  supports_automated_retries: true,
+  onEvent: async ({ payload, onComplete, helpers: { log } }): Promise<void> => {
+    const { fields, blandSdk } = await validatePayloadAndCreateSdk({
+      fieldsSchema: FieldsValidationSchema,
+      payload,
+    })
+
+    const createSmsConversationInput = CreateSmsConversationInputSchema.parse({
+      user_number: fields.userNumber,
+      agent_number: fields.agentNumber,
+      message: fields.message,
+      // Required by the live Bland API despite being documented as optional;
+      // it is only a correlation id so a generated UUID is sufficient.
+      message_sid: randomUUID(),
+      sender: fields.sender,
+      curr_pathway_id: isEmpty(fields.currPathwayId)
+        ? undefined
+        : fields.currPathwayId,
+      curr_pathway_version: isEmpty(fields.currPathwayVersion)
+        ? undefined
+        : fields.currPathwayVersion,
+      current_node_id: isEmpty(fields.currentNodeId)
+        ? undefined
+        : fields.currentNodeId,
+      new_conversation: fields.newConversation,
+      request_data: isEmpty(fields.requestData) ? undefined : fields.requestData,
+    })
+
+    try {
+      log(
+        { createSmsConversationInput },
+        'Creating SMS conversation via Bland',
+      )
+    } catch (err) {
+      console.error('unable to use new helpers.log')
+      console.error(JSON.stringify(err))
+    }
+
+    const { data } = await blandSdk.createSmsConversation(
+      createSmsConversationInput,
+    )
+
+    const conversationId = data?.data?.conversation_id
+
+    await onComplete({
+      data_points: {
+        conversationId: isNil(conversationId) ? undefined : conversationId,
+        createResponse: isNil(data) ? undefined : JSON.stringify(data),
+      },
+      events: [
+        addActivityEventLog({
+          message: `SMS conversation created in Bland.\nConversation ID: ${
+            conversationId ?? 'n/a'
+          }`,
+        }),
+      ],
+    })
+  },
+}

--- a/extensions/bland/actions/createSmsConversation/index.ts
+++ b/extensions/bland/actions/createSmsConversation/index.ts
@@ -1,0 +1,1 @@
+export { createSmsConversation } from './createSmsConversation'

--- a/extensions/bland/actions/index.ts
+++ b/extensions/bland/actions/index.ts
@@ -2,10 +2,14 @@ import { sendCall } from './sendCall'
 import { sendCallWithPathway } from './sendCallWithPathway'
 import { getCallDetails } from './getCallDetails'
 import { stopActiveCall } from './stopActiveCall'
+import { sendSms } from './sendSms'
+import { createSmsConversation } from './createSmsConversation'
 
 export const actions = {
   sendCallWithPathway,
   sendCall,
   getCallDetails,
   stopActiveCall,
+  sendSms,
+  createSmsConversation,
 }

--- a/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
+++ b/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
@@ -1,0 +1,91 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { BlandApiClient } from '../../../api/client'
+import { sendSms as action } from '../sendSms'
+
+const smsResponse = {
+  data: {
+    conversation_id: 'conv-123',
+    status: 'sent',
+  },
+  errors: null,
+}
+
+jest.mock('../../../api/client', () => ({
+  BlandApiClient: jest.fn().mockImplementation(() => ({
+    sendSms: jest.fn().mockResolvedValue({
+      data: smsResponse,
+    }),
+  })),
+}))
+
+const mockedSdk = jest.mocked(BlandApiClient)
+
+describe('Bland.ai - Send SMS', () => {
+  const {
+    extensionAction: sendSms,
+    onComplete,
+    onError,
+    helpers,
+    clearMocks,
+  } = TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  test('Should send an SMS with an explicit agent message', async () => {
+    await sendSms.onEvent({
+      payload: {
+        fields: {
+          userNumber: '+12223334444',
+          agentNumber: '+18162392019',
+          agentMessage: 'Hello from Awell',
+          requestData: '{"patient_name":"Jane"}',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+        patient: { id: 'patient-id' },
+        pathway: { id: 'pathway-id', definition_id: 'definition-id' },
+        activity: { id: 'activity-id' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(mockedSdk).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: {
+          conversationId: 'conv-123',
+          smsResponse: JSON.stringify(smsResponse),
+        },
+      }),
+    )
+  })
+
+  test('Should allow omitting the agent message (pathway-generated)', async () => {
+    await sendSms.onEvent({
+      payload: {
+        fields: {
+          userNumber: '+12223334444',
+          agentNumber: '+18162392019',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+        patient: { id: 'patient-id' },
+        pathway: { id: 'pathway-id', definition_id: 'definition-id' },
+        activity: { id: 'activity-id' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+})

--- a/extensions/bland/actions/sendSms/config/dataPoints.ts
+++ b/extensions/bland/actions/sendSms/config/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  conversationId: {
+    key: 'conversationId',
+    valueType: 'string',
+  },
+  smsResponse: {
+    key: 'smsResponse',
+    valueType: 'json',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/bland/actions/sendSms/config/fields.ts
+++ b/extensions/bland/actions/sendSms/config/fields.ts
@@ -1,0 +1,84 @@
+import {
+  FieldType,
+  StringType,
+  type Field,
+} from '@awell-health/extensions-core'
+import z, { type ZodTypeAny } from 'zod'
+import {
+  dropdownOptionsBoolean,
+  dropdownOptionsBooleanSchema,
+  JsonObjectSchema,
+} from '../../../lib/sharedActionFields'
+
+export const fields = {
+  userNumber: {
+    id: 'userNumber',
+    label: 'User phone number',
+    description: 'The phone number of the recipient (E.164 format).',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  agentNumber: {
+    id: 'agentNumber',
+    label: 'Agent phone number',
+    description:
+      'The Bland-owned, SMS-enabled phone number to send the message from (E.164 format).',
+    type: FieldType.STRING,
+    stringType: StringType.PHONE,
+    required: true,
+  },
+  agentMessage: {
+    id: 'agentMessage',
+    label: 'Agent message',
+    description:
+      'The message to send. When omitted and a pathway is configured on the agent number, the pathway generates the message.',
+    type: FieldType.TEXT,
+    required: false,
+  },
+  pathwayId: {
+    id: 'pathwayId',
+    label: 'Pathway ID',
+    description:
+      'The conversational pathway to drive the SMS conversation with.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  newConversation: {
+    id: 'newConversation',
+    label: 'Start new conversation',
+    description:
+      'When enabled, starts a fresh conversation instead of continuing an existing one.',
+    type: FieldType.STRING,
+    required: false,
+    options: {
+      dropdownOptions: dropdownOptionsBoolean,
+    },
+  },
+  requestData: {
+    id: 'requestData',
+    label: 'Request data',
+    description:
+      'JSON object of variables made available to the pathway/agent during the conversation. Can be referenced with Prompt Variables.',
+    type: FieldType.JSON,
+    required: false,
+  },
+  metadata: {
+    id: 'metadata',
+    label: 'Metadata',
+    description:
+      'Add any additional information you want to associate with the conversation.',
+    type: FieldType.JSON,
+    required: false,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  userNumber: z.string().trim().min(1),
+  agentNumber: z.string().trim().min(1),
+  agentMessage: z.string().optional(),
+  pathwayId: z.string().optional(),
+  newConversation: dropdownOptionsBooleanSchema.optional(),
+  requestData: JsonObjectSchema.optional(),
+  metadata: JsonObjectSchema.optional(),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/sendSms/config/index.ts
+++ b/extensions/bland/actions/sendSms/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/bland/actions/sendSms/index.ts
+++ b/extensions/bland/actions/sendSms/index.ts
@@ -1,0 +1,1 @@
+export { sendSms } from './sendSms'

--- a/extensions/bland/actions/sendSms/sendSms.ts
+++ b/extensions/bland/actions/sendSms/sendSms.ts
@@ -1,0 +1,73 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { isEmpty, isNil } from 'lodash'
+import { validatePayloadAndCreateSdk } from '../../lib/validatePayloadAndCreateSdk'
+import { type settings } from '../../settings'
+import { fields, FieldsValidationSchema, dataPoints } from './config'
+import { SendSmsInputSchema } from '../../api/schema'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+
+export const sendSms: Action<
+  typeof fields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'sendSms',
+  category: Category.COMMUNICATION,
+  title: 'Send SMS',
+  description:
+    'Send an SMS message immediately. The agent message is optional when a pathway drives the conversation.',
+  fields,
+  previewable: true,
+  dataPoints,
+  supports_automated_retries: true,
+  onEvent: async ({ payload, onComplete, helpers: { log } }): Promise<void> => {
+    const { fields, blandSdk } = await validatePayloadAndCreateSdk({
+      fieldsSchema: FieldsValidationSchema,
+      payload,
+    })
+
+    const sendSmsInput = SendSmsInputSchema.parse({
+      user_number: fields.userNumber,
+      agent_number: fields.agentNumber,
+      agent_message: isEmpty(fields.agentMessage)
+        ? undefined
+        : fields.agentMessage,
+      pathway_id: isEmpty(fields.pathwayId) ? undefined : fields.pathwayId,
+      new_conversation: fields.newConversation,
+      request_data: isEmpty(fields.requestData) ? undefined : fields.requestData,
+      metadata: {
+        ...fields.metadata,
+        awell_patient_id: payload.patient.id,
+        awell_care_flow_definition_id: payload.pathway.definition_id,
+        awell_care_flow_id: payload.pathway.id,
+        awell_activity_id: payload.activity.id,
+      },
+    })
+
+    try {
+      log({ sendSmsInput }, 'Sending SMS via Bland')
+    } catch (err) {
+      console.error('unable to use new helpers.log')
+      console.error(JSON.stringify(err))
+    }
+
+    const { data } = await blandSdk.sendSms(sendSmsInput)
+
+    const conversationId = data?.data?.conversation_id
+
+    await onComplete({
+      data_points: {
+        conversationId: isNil(conversationId) ? undefined : conversationId,
+        smsResponse: isNil(data) ? undefined : JSON.stringify(data),
+      },
+      events: [
+        addActivityEventLog({
+          message: `SMS request sent to Bland.\nConversation ID: ${
+            conversationId ?? 'n/a'
+          }`,
+        }),
+      ],
+    })
+  },
+}

--- a/extensions/bland/api/client.ts
+++ b/extensions/bland/api/client.ts
@@ -6,6 +6,10 @@ import {
   type GetCallDetailsResponseType,
   type StopActiveCallInputType,
   type StopActiveCallResponseType,
+  type SendSmsInputType,
+  type SendSmsResponseType,
+  type CreateSmsConversationInputType,
+  type CreateSmsConversationResponseType,
 } from './schema'
 
 export class BlandApiClient {
@@ -37,6 +41,28 @@ export class BlandApiClient {
   ): Promise<AxiosResponse<GetCallDetailsResponseType>> {
     const response = await this.client.get<GetCallDetailsResponseType>(
       `/calls/${input.call_id}`
+    )
+
+    return response
+  }
+
+  async sendSms(
+    input: SendSmsInputType
+  ): Promise<AxiosResponse<SendSmsResponseType>> {
+    const response = await this.client.post<SendSmsResponseType>(
+      `/sms/send`,
+      input
+    )
+
+    return response
+  }
+
+  async createSmsConversation(
+    input: CreateSmsConversationInputType
+  ): Promise<AxiosResponse<CreateSmsConversationResponseType>> {
+    const response = await this.client.post<CreateSmsConversationResponseType>(
+      `/sms/create`,
+      input
     )
 
     return response

--- a/extensions/bland/api/schema/CreateSmsConversation.schema.ts
+++ b/extensions/bland/api/schema/CreateSmsConversation.schema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+export const CreateSmsConversationInputSchema = z
+  .object({
+    user_number: z.string().min(1), // For best results, use the E.164 format.
+    agent_number: z.string().min(1), // Must be a Bland-owned SMS-enabled number.
+    message: z.string().min(1), // The message seeded into the conversation (recorded, not sent).
+    /**
+     * Required by the live API even though Bland docs mark it optional
+     * (omitting it returns 400 MISSING_REQUIRED_FIELDS). It is a Twilio
+     * correlation id; a generated UUID is acceptable.
+     */
+    message_sid: z.string().min(1),
+    curr_pathway_id: z.string().optional(),
+    curr_pathway_version: z.string().optional(),
+    current_node_id: z.string().optional(),
+    sender: z.enum(['USER', 'AGENT']).optional(),
+    new_conversation: z.boolean().optional(),
+    request_data: z.record(z.string(), z.any()).optional(),
+  })
+  .passthrough()
+
+export type CreateSmsConversationInputType = z.infer<
+  typeof CreateSmsConversationInputSchema
+>
+
+export const CreateSmsConversationResponseSchema = z
+  .object({
+    data: z
+      .object({
+        conversation_id: z.string().optional(),
+        status: z.string().optional(),
+      })
+      .passthrough()
+      .nullish(),
+    errors: z.array(z.any()).nullish(),
+  })
+  .passthrough()
+
+export type CreateSmsConversationResponseType = z.infer<
+  typeof CreateSmsConversationResponseSchema
+>

--- a/extensions/bland/api/schema/SendSms.schema.ts
+++ b/extensions/bland/api/schema/SendSms.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const SendSmsInputSchema = z
+  .object({
+    user_number: z.string().min(1), // For best results, use the E.164 format.
+    agent_number: z.string().min(1), // Must be a Bland-owned SMS-enabled number.
+    agent_message: z.string().optional(), // When omitted, the pathway generates the message.
+    pathway_id: z.string().optional(),
+    new_conversation: z.boolean().optional(),
+    request_data: z.record(z.string(), z.any()).optional(),
+    webhook: z.string().optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
+  })
+  .passthrough()
+
+export type SendSmsInputType = z.infer<typeof SendSmsInputSchema>
+
+export const SendSmsResponseSchema = z
+  .object({
+    data: z
+      .object({
+        conversation_id: z.string().optional(),
+        message_id: z.string().optional(),
+        status: z.string().optional(),
+      })
+      .passthrough()
+      .nullish(),
+    errors: z.array(z.any()).nullish(),
+  })
+  .passthrough()
+
+export type SendSmsResponseType = z.infer<typeof SendSmsResponseSchema>

--- a/extensions/bland/api/schema/index.ts
+++ b/extensions/bland/api/schema/index.ts
@@ -1,3 +1,5 @@
 export * from './SendCall.schema'
 export * from './GetCallDetails.schema'
 export * from './StopActiveCall.schema'
+export * from './SendSms.schema'
+export * from './CreateSmsConversation.schema'


### PR DESCRIPTION
## What

Adds SMS support to the Bland.ai extension with two new actions, following the existing action patterns (`sendCall` / `getCallDetails`):

- **`sendSms`** — sends an SMS immediately via `POST /v1/sms/send`. `agent_message` is optional: when omitted and a pathway is configured on the agent number, the pathway generates the message. Awell metadata (patient id, care flow definition id, care flow id, activity id) is stamped into the request metadata, mirroring `sendCall`. Data points: `conversationId`, `smsResponse`.
- **`createSmsConversation`** — seeds an SMS conversation positioned at pathway state via `POST /v1/sms/create` **without** sending a message; the pathway then drives outbound texts. Data points: `conversationId`, `createResponse`.

## Implementation notes

- New Zod schemas in `api/schema/` (`SendSms.schema.ts`, `CreateSmsConversation.schema.ts`) and matching `BlandApiClient` methods.
- **`message_sid` gotcha:** the live Bland API requires `message_sid` on `/sms/create` even though Bland's docs mark it optional (omitting it returns `400 MISSING_REQUIRED_FIELDS`). It is only a Twilio correlation id, so the action auto-generates a UUID — care-flow designers never have to think about it.
- SMS endpoints are flagged Enterprise on Bland's side; tested with an Enterprise-enabled key.

## Testing

- Unit tests for both actions (mocked client) — passing, alongside the existing 16 Bland extension tests.
- Verified live against the real Bland API using the extension actions themselves (real payload shape incl. patient/pathway/activity context):
  - `createSmsConversation` returned a real conversation id and `"SMS conversation created successfully"`.
  - `sendSms` delivered a real text (status `processing`, message id returned) continuing that same conversation.

## Changelog

- `extensions/bland/CHANGELOG.md` updated.