### PR TITLE
feat(bland): add optional webhook field to sendSms

### DIFF
--- a/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
+++ b/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
@@ -88,4 +88,37 @@ describe('Bland.ai - Send SMS', () => {
 
     expect(onComplete).toHaveBeenCalled()
   })
+
+  test('Should append activity_id to the webhook URL', async () => {
+    await sendSms.onEvent({
+      payload: {
+        fields: {
+          userNumber: '+12223334444',
+          agentNumber: '+18162392019',
+          agentMessage: 'Hello from Awell',
+          webhook: 'https://example.com/webhooks/bland/sms',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+        patient: { id: 'patient-id' },
+        pathway: { id: 'pathway-id', definition_id: 'definition-id' },
+        activity: { id: 'activity-id' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    const sdkInstance =
+      mockedSdk.mock.results[mockedSdk.mock.results.length - 1].value
+    expect(sdkInstance.sendSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook:
+          'https://example.com/webhooks/bland/sms?activity_id=activity-id',
+      }),
+    )
+    expect(onComplete).toHaveBeenCalled()
+  })
 })

--- a/extensions/bland/actions/sendSms/config/fields.ts
+++ b/extensions/bland/actions/sendSms/config/fields.ts
@@ -55,6 +55,15 @@ export const fields = {
       dropdownOptions: dropdownOptionsBoolean,
     },
   },
+  webhook: {
+    id: 'webhook',
+    label: 'Webhook',
+    description:
+      'The webhook URL to send SMS conversation events to. The Awell activity ID is appended as an activity_id query parameter for correlation.',
+    type: FieldType.STRING,
+    stringType: StringType.URL,
+    required: false,
+  },
   requestData: {
     id: 'requestData',
     label: 'Request data',
@@ -79,6 +88,7 @@ export const FieldsValidationSchema = z.object({
   agentMessage: z.string().optional(),
   pathwayId: z.string().optional(),
   newConversation: dropdownOptionsBooleanSchema.optional(),
+  webhook: z.string().optional(),
   requestData: JsonObjectSchema.optional(),
   metadata: JsonObjectSchema.optional(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/sendSms/sendSms.ts
+++ b/extensions/bland/actions/sendSms/sendSms.ts
@@ -27,6 +27,12 @@ export const sendSms: Action<
       payload,
     })
 
+    const getWebhookUrl = (): string | undefined => {
+      if (isEmpty(fields.webhook)) return undefined
+      const separator = fields.webhook?.includes('?') === true ? '&' : '?'
+      return `${fields.webhook as string}${separator}activity_id=${payload.activity.id}`
+    }
+
     const sendSmsInput = SendSmsInputSchema.parse({
       user_number: fields.userNumber,
       agent_number: fields.agentNumber,
@@ -35,6 +41,7 @@ export const sendSms: Action<
         : fields.agentMessage,
       pathway_id: isEmpty(fields.pathwayId) ? undefined : fields.pathwayId,
       new_conversation: fields.newConversation,
+      webhook: getWebhookUrl(),
       request_data: isEmpty(fields.requestData) ? undefined : fields.requestData,
       metadata: {
         ...fields.metadata,


### PR DESCRIPTION
## What

Follow-up to the SMS actions PR (#796, merged): adds an optional **Webhook** field to the `sendSms` action so care-flow designers can receive SMS conversation events from Bland.

- New optional `webhook` field (URL) on `sendSms`, passed as the top-level `webhook` param on `POST /v1/sms/send` (already present in the Zod schema).
- The Awell activity ID is appended as an `activity_id` query parameter (`?activity_id=...` or `&activity_id=...` if the URL already has a query string), mirroring the `sendCall` convention, so webhook events can be correlated back to the originating activity.
- Omitted entirely when the field is blank.

## Testing

- New unit test asserts the `activity_id` is appended to the webhook URL sent to Bland.
- All `sendSms` tests pass; eslint clean.