### PR TITLE
feat(bland): add sendSms timeout fields and Completed Bland Text webhook

### DIFF
--- a/extensions/bland/CHANGELOG.md
+++ b/extensions/bland/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 - Added `sendSms` action: send an SMS immediately via Bland `POST /v1/sms/send`. The agent message is optional; when omitted, the pathway configured on the agent number generates the message.
 - Added `createSmsConversation` action: seed an SMS conversation positioned at pathway state via Bland `POST /v1/sms/create` without sending a message.
+- Added optional timeout fields to `sendSms` (`time_out`, `timeout_message`, `warning_time`, `warning_message`): per-conversation overrides for Bland's silence-timeout flow.
+- Added `completedBlandText` webhook: triggered when a Bland SMS conversation ends. Maps conversation data (status, reason, transcript, pathway variables) to data points and resolves the patient via the `awell_patient_id` echoed back in metadata.

--- a/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
+++ b/extensions/bland/actions/sendSms/__tests__/sendSms.test.ts
@@ -89,6 +89,44 @@ describe('Bland.ai - Send SMS', () => {
     expect(onComplete).toHaveBeenCalled()
   })
 
+  test('Should pass timeout configuration to Bland', async () => {
+    await sendSms.onEvent({
+      payload: {
+        fields: {
+          userNumber: '+12223334444',
+          agentNumber: '+18162392019',
+          agentMessage: 'Hello from Awell',
+          timeOut: 3600,
+          timeoutMessage: 'This conversation has ended.',
+          warningTime: 1800,
+          warningMessage: 'Are you still there?',
+        },
+        settings: {
+          apiKey: 'api-key',
+        },
+        patient: { id: 'patient-id' },
+        pathway: { id: 'pathway-id', definition_id: 'definition-id' },
+        activity: { id: 'activity-id' },
+      } as any,
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    const sdkInstance =
+      mockedSdk.mock.results[mockedSdk.mock.results.length - 1].value
+    expect(sdkInstance.sendSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        time_out: 3600,
+        timeout_message: 'This conversation has ended.',
+        warning_time: 1800,
+        warning_message: 'Are you still there?',
+      }),
+    )
+    expect(onComplete).toHaveBeenCalled()
+  })
+
   test('Should append activity_id to the webhook URL', async () => {
     await sendSms.onEvent({
       payload: {

--- a/extensions/bland/actions/sendSms/config/fields.ts
+++ b/extensions/bland/actions/sendSms/config/fields.ts
@@ -64,6 +64,38 @@ export const fields = {
     stringType: StringType.URL,
     required: false,
   },
+  timeOut: {
+    id: 'timeOut',
+    label: 'Timeout (seconds)',
+    description:
+      'Seconds of user silence (after an agent message) before the timeout flow fires (warning message and/or conversation end). Overrides the time_out on the agent number\u2019s SMS config and persists on the conversation.',
+    type: FieldType.NUMERIC,
+    required: false,
+  },
+  timeoutMessage: {
+    id: 'timeoutMessage',
+    label: 'Timeout message',
+    description:
+      'The message sent to the user when the timeout fires. Overrides the timeout_message on the agent number\u2019s SMS config.',
+    type: FieldType.TEXT,
+    required: false,
+  },
+  warningTime: {
+    id: 'warningTime',
+    label: 'Warning time (seconds)',
+    description:
+      'Seconds of user silence before sending the warning message. Must be less than the timeout. Overrides the warning_time on the agent number\u2019s SMS config.',
+    type: FieldType.NUMERIC,
+    required: false,
+  },
+  warningMessage: {
+    id: 'warningMessage',
+    label: 'Warning message',
+    description:
+      'The warning message sent to the user at the warning time. Overrides the warning_message on the agent number\u2019s SMS config.',
+    type: FieldType.TEXT,
+    required: false,
+  },
   requestData: {
     id: 'requestData',
     label: 'Request data',
@@ -89,6 +121,10 @@ export const FieldsValidationSchema = z.object({
   pathwayId: z.string().optional(),
   newConversation: dropdownOptionsBooleanSchema.optional(),
   webhook: z.string().optional(),
+  timeOut: z.number().optional(),
+  timeoutMessage: z.string().optional(),
+  warningTime: z.number().optional(),
+  warningMessage: z.string().optional(),
   requestData: JsonObjectSchema.optional(),
   metadata: JsonObjectSchema.optional(),
 } satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/bland/actions/sendSms/sendSms.ts
+++ b/extensions/bland/actions/sendSms/sendSms.ts
@@ -42,6 +42,14 @@ export const sendSms: Action<
       pathway_id: isEmpty(fields.pathwayId) ? undefined : fields.pathwayId,
       new_conversation: fields.newConversation,
       webhook: getWebhookUrl(),
+      time_out: fields.timeOut,
+      timeout_message: isEmpty(fields.timeoutMessage)
+        ? undefined
+        : fields.timeoutMessage,
+      warning_time: fields.warningTime,
+      warning_message: isEmpty(fields.warningMessage)
+        ? undefined
+        : fields.warningMessage,
       request_data: isEmpty(fields.requestData) ? undefined : fields.requestData,
       metadata: {
         ...fields.metadata,

--- a/extensions/bland/api/schema/SendSms.schema.ts
+++ b/extensions/bland/api/schema/SendSms.schema.ts
@@ -9,6 +9,10 @@ export const SendSmsInputSchema = z
     new_conversation: z.boolean().optional(),
     request_data: z.record(z.string(), z.any()).optional(),
     webhook: z.string().optional(),
+    time_out: z.number().optional(), // Seconds of user silence before the timeout flow fires. Persists on the conversation.
+    timeout_message: z.string().optional(), // Message sent when the timeout fires.
+    warning_time: z.number().optional(), // Seconds before sending the warning message. Must be less than time_out.
+    warning_message: z.string().optional(), // Warning message sent at warning_time.
     metadata: z.record(z.string(), z.any()).optional(),
   })
   .passthrough()

--- a/extensions/bland/webhooks/CompletedBlandText/completedBlandText.test.ts
+++ b/extensions/bland/webhooks/CompletedBlandText/completedBlandText.test.ts
@@ -1,0 +1,105 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { completedBlandText } from './completedBlandText'
+
+describe('Bland.ai - Completed Bland Text webhook', () => {
+  const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
+    TestHelpers.fromWebhook(completedBlandText)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  describe('when conversation_id is missing', () => {
+    test('Should call onError and not call onSuccess', async () => {
+      await extensionWebhook.onEvent({
+        payload: {
+          payload: { type: 'status', status: 'ended' },
+          rawBody: Buffer.from(''),
+          headers: {},
+          settings: { apiKey: 'api-key' },
+        } as any,
+        onSuccess,
+        onError,
+        helpers,
+      })
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response: expect.objectContaining({ statusCode: 400 }),
+        }),
+      )
+      expect(onSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a valid SMS status payload is received', () => {
+    test('Should map data points and resolve the patient from metadata', async () => {
+      const payload = {
+        type: 'status',
+        conversation_id: 'b1c68c2b-e01a-4e0f-b21b-a064f2ef57b9',
+        status: 'ended',
+        channel: 'sms',
+        phone_number: '+12223334444',
+        agent_number: '+15556667777',
+        conversation_history: [
+          {
+            sender: 'AGENT',
+            message: 'Hi!',
+            status: 'delivered',
+            timestamp: '2026-07-22T15:17:24.149Z',
+          },
+          {
+            sender: 'USER',
+            message: 'Ok thanks',
+            timestamp: '2026-07-22T15:17:46.742Z',
+          },
+        ],
+        pathway_id: 'pathway-uuid',
+        message_count: 2,
+        ended_at: '2026-07-22T15:17:50.929Z',
+        reason: 'Conversation ended at End Call or Transfer Call node',
+        variables: {
+          opted_out: false,
+          patient_reply: 'Ok thanks',
+          wants_to_schedule: true,
+        },
+        metadata: {
+          awell_patient_id: 'patient-id',
+          awell_activity_id: 'activity-id',
+          awell_care_flow_id: 'care-flow-id',
+          awell_care_flow_definition_id: 'definition-id',
+        },
+        concatenated_transcript: 'AGENT: Hi!\nUSER: Ok thanks',
+      }
+
+      await extensionWebhook.onEvent({
+        payload: {
+          payload,
+          rawBody: Buffer.from(JSON.stringify(payload)),
+          headers: {},
+          settings: { apiKey: 'api-key' },
+        } as any,
+        onSuccess,
+        onError,
+        helpers,
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledWith({
+        data_points: {
+          conversationId: 'b1c68c2b-e01a-4e0f-b21b-a064f2ef57b9',
+          status: 'ended',
+          reason: 'Conversation ended at End Call or Transfer Call node',
+          userNumber: '+12223334444',
+          agentNumber: '+15556667777',
+          pathwayId: 'pathway-uuid',
+          messageCount: '2',
+          transcript: 'AGENT: Hi!\nUSER: Ok thanks',
+          variables: JSON.stringify(payload.variables),
+          conversationObject: JSON.stringify(payload),
+        },
+        patient_id: 'patient-id',
+      })
+    })
+  })
+})

--- a/extensions/bland/webhooks/CompletedBlandText/completedBlandText.ts
+++ b/extensions/bland/webhooks/CompletedBlandText/completedBlandText.ts
@@ -1,0 +1,112 @@
+import { isNil } from 'lodash'
+import {
+  type DataPointDefinition,
+  type Webhook,
+} from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { type CompletedBlandTextWebhookPayload } from './types'
+
+const dataPoints = {
+  conversationId: {
+    key: 'conversationId',
+    valueType: 'string',
+  },
+  status: {
+    key: 'status',
+    valueType: 'string',
+  },
+  reason: {
+    key: 'reason',
+    valueType: 'string',
+  },
+  userNumber: {
+    key: 'userNumber',
+    valueType: 'string',
+  },
+  agentNumber: {
+    key: 'agentNumber',
+    valueType: 'string',
+  },
+  pathwayId: {
+    key: 'pathwayId',
+    valueType: 'string',
+  },
+  messageCount: {
+    key: 'messageCount',
+    valueType: 'number',
+  },
+  transcript: {
+    key: 'transcript',
+    valueType: 'string',
+  },
+  variables: {
+    key: 'variables',
+    valueType: 'json',
+  },
+  conversationObject: {
+    key: 'conversationObject',
+    valueType: 'json',
+  },
+} satisfies Record<string, DataPointDefinition>
+
+export const completedBlandText: Webhook<
+  keyof typeof dataPoints,
+  CompletedBlandTextWebhookPayload,
+  typeof settings
+> = {
+  key: 'completedBlandText',
+  description:
+    'Triggered when a Bland SMS conversation ends (status webhook with channel "sms").',
+  dataPoints,
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
+    const conversationId = payload?.conversation_id
+    const awellPatientId: string | undefined =
+      payload?.metadata?.awell_patient_id ??
+      (payload?.variables?.metadata as Record<string, string> | undefined)
+        ?.awell_patient_id
+
+    if (isNil(conversationId)) {
+      await onError({
+        response: {
+          statusCode: 400,
+          message: 'Missing conversation_id in payload',
+        },
+      }); return;
+    }
+
+    await onSuccess({
+      data_points: {
+        conversationId,
+        /**
+         * The status of the conversation, e.g. "ended".
+         */
+        status: payload?.status ?? '',
+        /**
+         * Why the conversation ended,
+         * e.g. "Conversation ended at End Call or Transfer Call node".
+         */
+        reason: payload?.reason ?? '',
+        userNumber: payload?.phone_number ?? '',
+        agentNumber: payload?.agent_number ?? '',
+        pathwayId: payload?.pathway_id ?? '',
+        messageCount: payload?.message_count?.toString() ?? '',
+        /**
+         * The full conversation as a single string
+         * ("AGENT: ...\nUSER: ...").
+         */
+        transcript: payload?.concatenated_transcript ?? '',
+        /**
+         * Pathway variables captured during the conversation
+         * (e.g. opted_out, patient_reply, or custom extraction variables).
+         */
+        variables: isNil(payload?.variables)
+          ? ''
+          : JSON.stringify(payload.variables),
+        conversationObject: JSON.stringify(payload),
+      },
+      ...(awellPatientId !== undefined && { patient_id: awellPatientId }),
+    })
+  },
+}
+
+export type CompletedBlandText = typeof completedBlandText

--- a/extensions/bland/webhooks/CompletedBlandText/types.ts
+++ b/extensions/bland/webhooks/CompletedBlandText/types.ts
@@ -1,0 +1,31 @@
+export interface SmsConversationHistoryEntry {
+  sender?: 'AGENT' | 'USER' | string
+  message?: string
+  status?: string
+  timestamp?: string
+}
+
+export interface CompletedBlandTextWebhookPayload {
+  type?: string
+  conversation_id?: string
+  status?: string
+  channel?: string
+  phone_number?: string
+  agent_number?: string
+  conversation_history?: SmsConversationHistoryEntry[]
+  pathway_id?: string
+  pathway_version?: string
+  message_count?: number
+  ended_at?: string
+  reason?: string
+  variables?: Record<string, unknown>
+  metadata?: {
+    awell_patient_id?: string
+    awell_activity_id?: string
+    awell_care_flow_id?: string
+    awell_care_flow_definition_id?: string
+    [key: string]: unknown
+  }
+  created_at?: string
+  concatenated_transcript?: string
+}

--- a/extensions/bland/webhooks/index.ts
+++ b/extensions/bland/webhooks/index.ts
@@ -1,3 +1,4 @@
 import { callCompleted } from './CallCompleted/callCompleted'
+import { completedBlandText } from './CompletedBlandText/completedBlandText'
 
-export const webhooks = [callCompleted]
+export const webhooks = [callCompleted, completedBlandText]


### PR DESCRIPTION
## What

Follow-up to #796 / #797 (both merged — thank you!). Two additions to the Bland SMS support:

### 1. Timeout fields on `sendSms`

Four new optional fields mapping to Bland's per-conversation silence-timeout overrides on `POST /v1/sms/send`:

- `timeOut` → `time_out` (seconds of user silence before the timeout flow fires; persists on the conversation)
- `timeoutMessage` → `timeout_message`
- `warningTime` → `warning_time` (must be < `time_out`, per Bland; rejected with `INVALID_TIMEOUT_CONFIG` otherwise)
- `warningMessage` → `warning_message`

All omitted from the request when blank, mirroring the existing field conventions.

### 2. `completedBlandText` webhook ("Completed Bland Text")

New extension webhook for Bland's SMS conversation-ended status event (`type: "status"`, `channel: "sms"`). Built against a real payload captured from a live sandbox conversation.

- Resolves the patient via the `awell_patient_id` echoed back in `metadata` (stamped on every SMS by `sendSms`), following the `callCompleted` convention.
- Data points: `conversationId`, `status`, `reason`, `userNumber`, `agentNumber`, `pathwayId`, `messageCount`, `transcript` (concatenated), `variables` (pathway variables as JSON — enables care flows to branch on conversation outcomes such as opt-outs or extracted answers), and the raw `conversationObject`.
- Returns 400 when `conversation_id` is missing.

## Testing

- `sendSms`: 4 unit tests passing (incl. new timeout-mapping test).
- `completedBlandText`: 2 unit tests passing, incl. one replaying the real captured sandbox payload shape (Awell metadata round-trip verified live).
- eslint clean.