### PR TITLE
feat(metriport): Add Remove Patient from Cohort action to Metriport extension

### DIFF
--- a/extensions/metriport/README.md
+++ b/extensions/metriport/README.md
@@ -67,6 +67,12 @@ Visit [endpoint docs](https://docs.metriport.com/medical-api/api-reference/docum
 
 **NOTE: This endpoint returns a URL which you can use to download the specified Document using the file name provided from the List Documents endpoint.**
 
+## Remove Patient from Cohort
+
+Removes the specified Patient from a cohort.
+
+Visit [endpoint docs](https://docs.metriport.com/medical-api/api-reference/cohort/remove-patients-from-cohort) for more info.
+
 ## More Info
 
 For more information on how to integrate with Metriport please visit our [Medical API docs](https://docs.metriport.com/medical-api/getting-started/quickstart)

--- a/extensions/metriport/actions/cohort/dataPoints.ts
+++ b/extensions/metriport/actions/cohort/dataPoints.ts
@@ -1,0 +1,12 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const removePatientFromCohortDataPoints = {
+  message: {
+    key: 'message',
+    valueType: 'string',
+  },
+  cohort: {
+    key: 'cohort',
+    valueType: 'json',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/metriport/actions/cohort/fields.ts
+++ b/extensions/metriport/actions/cohort/fields.ts
@@ -1,0 +1,18 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+
+export const removePatientFromCohortFields = {
+  cohortId: {
+    id: 'cohortId',
+    label: 'Cohort ID',
+    description: 'The ID of the cohort to remove the Patient from',
+    type: FieldType.STRING,
+    required: true,
+  },
+  patientId: {
+    id: 'patientId',
+    label: 'Patient ID',
+    description: 'The Metriport ID of the Patient to remove from the cohort',
+    type: FieldType.STRING,
+    required: true,
+  },
+} satisfies Record<string, Field>

--- a/extensions/metriport/actions/cohort/removePatientFromCohort.ts
+++ b/extensions/metriport/actions/cohort/removePatientFromCohort.ts
@@ -18,6 +18,7 @@ export const removePatientFromCohort: Action<
   description: 'Removes the specified Patient from a cohort.',
   fields: removePatientFromCohortFields,
   previewable: true,
+  supports_automated_retries: true,
   dataPoints,
   onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
     try {

--- a/extensions/metriport/actions/cohort/removePatientFromCohort.ts
+++ b/extensions/metriport/actions/cohort/removePatientFromCohort.ts
@@ -20,7 +20,7 @@ export const removePatientFromCohort: Action<
   previewable: true,
   supports_automated_retries: true,
   dataPoints,
-  onEvent: async ({ payload, onComplete, onError }): Promise<void> => {
+  onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
     try {
       const cohortId = stringId.parse(payload.fields.cohortId)
       const patientId = stringId.parse(payload.fields.patientId)

--- a/extensions/metriport/actions/cohort/removePatientFromCohort.ts
+++ b/extensions/metriport/actions/cohort/removePatientFromCohort.ts
@@ -20,7 +20,7 @@ export const removePatientFromCohort: Action<
   previewable: true,
   supports_automated_retries: true,
   dataPoints,
-  onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
+  onEvent: async ({ payload, onComplete, onError }): Promise<void> => {
     try {
       const cohortId = stringId.parse(payload.fields.cohortId)
       const patientId = stringId.parse(payload.fields.patientId)

--- a/extensions/metriport/actions/cohort/removePatientFromCohort.ts
+++ b/extensions/metriport/actions/cohort/removePatientFromCohort.ts
@@ -1,0 +1,43 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { createMetriportApi } from '../../client'
+import { handleErrorMessage } from '../../shared/errorHandler'
+import { stringId } from '../../validation/generic.zod'
+import { removePatientFromCohortFields } from './fields'
+import { removePatientFromCohortDataPoints as dataPoints } from './dataPoints'
+
+export const removePatientFromCohort: Action<
+  typeof removePatientFromCohortFields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'removePatientFromCohort',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Remove Patient from Cohort',
+  description: 'Removes the specified Patient from a cohort.',
+  fields: removePatientFromCohortFields,
+  previewable: true,
+  dataPoints,
+  onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
+    try {
+      const cohortId = stringId.parse(payload.fields.cohortId)
+      const patientId = stringId.parse(payload.fields.patientId)
+
+      const api = createMetriportApi(payload.settings)
+      const { message, cohort } = await api.removePatientsFromCohort({
+        cohortId,
+        patientIds: [patientId],
+      })
+
+      await onComplete({
+        data_points: {
+          message,
+          cohort: JSON.stringify(cohort),
+        },
+      })
+    } catch (err) {
+      await handleErrorMessage(err, onError)
+    }
+  },
+}

--- a/extensions/metriport/actions/index.ts
+++ b/extensions/metriport/actions/index.ts
@@ -8,6 +8,7 @@ import { getUrl } from './document/getUrl'
 import { startNetworkQuery } from './network/startNetworkQuery'
 import { startConsolidatedQuery } from './consolidated/startConsolidatedQuery'
 import { getConsolidatedQueryStatus } from './consolidated/getConsolidatedQueryStatus'
+import { removePatientFromCohort } from './cohort/removePatientFromCohort'
 
 export const actions = {
   getPatient,
@@ -20,4 +21,5 @@ export const actions = {
   startNetworkQuery,
   startConsolidatedQuery,
   getConsolidatedQueryStatus,
+  removePatientFromCohort,
 }


### PR DESCRIPTION
Closes: [AWL-4253](https://linear.app/awell/issue/AWL-4253/add-enrollunenroll-to-metriport-extension)

## Summary
This PR adds a new action to the Metriport extension that enables removing a patient from a cohort via the Metriport Medical API.

## Key Changes
- **New Action**: `removePatientFromCohort` - Removes a specified patient from a cohort
  - Accepts `cohortId` and `patientId` as required string inputs
  - Returns the API response message and updated cohort data as JSON
  - Supports automated retries and is previewable
  - Includes proper error handling via the shared error handler

- **New Files**:
  - `extensions/metriport/actions/cohort/removePatientFromCohort.ts` - Main action implementation
  - `extensions/metriport/actions/cohort/fields.ts` - Field definitions for cohort ID and patient ID inputs
  - `extensions/metriport/actions/cohort/dataPoints.ts` - Data point definitions for message and cohort outputs

- **Updated Files**:
  - `extensions/metriport/actions/index.ts` - Exported the new action
  - `extensions/metriport/README.md` - Added documentation for the new action with link to Metriport API docs

## Implementation Details
- The action validates inputs using the existing `stringId` validation schema
- Leverages the existing `createMetriportApi` client to call the `removePatientsFromCohort` endpoint
- Follows the established pattern used by other actions in the extension for consistency
- Returns both a success message and the updated cohort object for downstream workflow use

https://claude.ai/code/session_01TCe95oEW5ANDAXtoWKMiYc