### PR TITLE
feat(metriport): rate limit enrollment webhook on messageId

### DIFF
--- a/extensions/metriport/actions/webhookBundle/getWebhookBundle.test.ts
+++ b/extensions/metriport/actions/webhookBundle/getWebhookBundle.test.ts
@@ -7,7 +7,12 @@ jest.mock('./fetchBundle')
 
 const mockedFetchBundle = fetchBundle as jest.MockedFunction<typeof fetchBundle>
 
-const settings = { apiKey: 'test-api-key', baseUrl: '', webhookKey: '' }
+const settings = {
+  apiKey: 'test-api-key',
+  baseUrl: '',
+  webhookKey: '',
+  rateLimitDuration: '',
+}
 
 describe('Metriport - Get Webhook Bundle', () => {
   const onComplete = jest.fn()

--- a/extensions/metriport/settings.ts
+++ b/extensions/metriport/settings.ts
@@ -1,4 +1,8 @@
-import { type Setting } from '@awell-health/extensions-core'
+import type { RateLimitConfig, Setting } from '@awell-health/extensions-core'
+import { isEmpty, isFinite, isNil } from 'lodash'
+import { z } from 'zod'
+
+export const DEFAULT_DEDUPE_DURATION = '7 d'
 
 export const settings = {
   apiKey: {
@@ -23,4 +27,79 @@ export const settings = {
       'The Metriport webhook key used to verify incoming webhook requests. Metriport signs each request with an HMAC-SHA256 of the raw body using this key, sent in the `x-metriport-signature` header. Found in the Settings/Developers tab of the Metriport dashboard. When left empty, incoming webhook requests are not verified.',
     required: false,
   },
+  rateLimitDuration: {
+    key: 'rateLimitDuration',
+    label: 'Rate Limit Duration',
+    obfuscated: false,
+    description:
+      "Rate limit Metriport enrollment webhooks at a certain duration (e.g. only enroll once for a given webhook message every '30 s', '1 m', '12 h', '30 d'). Prevents duplicate deliveries of the same message from re-enrolling a patient. Value should be {number} {unit}. Defaults to seven days as '7 d'",
+    required: false,
+  },
 } satisfies Record<string, Setting>
+
+export const rateLimitDurationSchema = z.string().refine(
+  (val) => {
+    if (isNil(val) || isEmpty(val)) {
+      return true
+    }
+    try {
+      const [number, unit] = val.split(' ')
+      const parsedUnit = parseDurationUnit(unit)
+      return isFinite(Number(number)) && !isNil(parsedUnit)
+    } catch (error) {
+      return false
+    }
+  },
+  {
+    message:
+      'Duration must be in format {number} {unit} where unit is seconds, minutes, hours or days',
+  },
+)
+
+const parseDurationUnit = (
+  unit: string | undefined,
+): 'seconds' | 'minutes' | 'hours' | 'days' => {
+  if (isNil(unit) || isEmpty(unit))
+    throw new Error('Duration unit is required')
+
+  const normalized = unit.toLowerCase().trim()
+
+  switch (normalized) {
+    case 's':
+    case 'second':
+    case 'seconds':
+      return 'seconds'
+
+    case 'm':
+    case 'min':
+    case 'minute':
+    case 'minutes':
+      return 'minutes'
+
+    case 'h':
+    case 'hour':
+    case 'hours':
+      return 'hours'
+
+    case 'd':
+    case 'day':
+    case 'days':
+      return 'days'
+
+    default:
+      throw new Error(
+        `Invalid duration unit: ${unit}. Valid units are: s, m, h, d`,
+      )
+  }
+}
+
+export const transformRateLimitDuration = (
+  val: string,
+): RateLimitConfig['duration'] => {
+  const [number, unit] = val.split(' ')
+  const parsedUnit = parseDurationUnit(unit)
+  return {
+    value: Number(number),
+    unit: parsedUnit,
+  }
+}

--- a/extensions/metriport/validation/settings.zod.ts
+++ b/extensions/metriport/validation/settings.zod.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
+import { DEFAULT_DEDUPE_DURATION, rateLimitDurationSchema } from '../settings'
 
 export const settingsSchema = z.object({
   baseUrl: z
     .string({ errorMap: () => ({ message: 'Missing baseUrl' }) })
     .optional(),
   apiKey: z.string({ errorMap: () => ({ message: 'Missing apiKey' }) }).min(1),
+  rateLimitDuration: rateLimitDurationSchema.optional().default(DEFAULT_DEDUPE_DURATION),
 })

--- a/extensions/metriport/webhooks/enrollment.test.ts
+++ b/extensions/metriport/webhooks/enrollment.test.ts
@@ -293,6 +293,73 @@ describe('Metriport - Webhook - Enrollment', () => {
     })
   })
 
+  describe('When rate limiting is configured', () => {
+    const settingsWithRateLimit = { ...mockSettings, rateLimitDuration: '1 m' }
+
+    const invokeWithSettings = async (
+      payload: unknown,
+      settings: Record<string, string>,
+    ): Promise<void> => {
+      await extensionWebhook.onEvent!({
+        payload: {
+          payload,
+          settings,
+          rawBody: Buffer.from(''),
+          headers: {},
+        },
+        onSuccess,
+        onError,
+        helpers,
+      })
+    }
+
+    test('Should build the limiter from meta.type + endpoint and rate-limit on messageId, then enroll when not a duplicate', async () => {
+      const limit = jest
+        .fn()
+        .mockResolvedValue({ success: true, result: {} })
+      jest
+        .mocked(helpers.rateLimiter)
+        .mockReturnValueOnce({ limit, reset: jest.fn() })
+
+      await invokeWithSettings(admitPayload, settingsWithRateLimit)
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+      expect(helpers.rateLimiter).toHaveBeenCalledWith(
+        `metriport-enrollment-${MetriportWebhookType.PatientAdmit}-global`,
+        { requests: 1, duration: { value: 1, unit: 'minutes' } },
+      )
+      expect(limit).toHaveBeenCalledWith('msg-1')
+    })
+
+    test('Should acknowledge a duplicate delivery with 200 and not enroll', async () => {
+      const limit = jest
+        .fn()
+        .mockResolvedValue({ success: false, result: {} })
+      jest
+        .mocked(helpers.rateLimiter)
+        .mockReturnValueOnce({ limit, reset: jest.fn() })
+
+      await invokeWithSettings(admitPayload, settingsWithRateLimit)
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+      const call = onError.mock.calls[0][0]
+      expect(call.response.statusCode).toBe(200)
+      expect(call.response.message).toContain('Rate limit exceeded')
+      expect(call.response.message).toContain('msg-1')
+    })
+
+    test('Should enroll normally when rate limiting is not configured', async () => {
+      await invokeWithSettings(admitPayload, mockSettings)
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+      // With no rateLimitDuration set the limiter is never constructed.
+      expect(helpers.rateLimiter).not.toHaveBeenCalled()
+    })
+  })
+
   describe('When the payload is invalid', () => {
     test('Should call onError', async () => {
       await invoke({ meta: { type: 'not-a-real-type' } })

--- a/extensions/metriport/webhooks/enrollment.ts
+++ b/extensions/metriport/webhooks/enrollment.ts
@@ -5,7 +5,11 @@ import {
   type DataPointDefinition,
   type Webhook,
 } from '@awell-health/extensions-core'
-import { type settings } from '../settings'
+import {
+  rateLimitDurationSchema,
+  transformRateLimitDuration,
+  type settings,
+} from '../settings'
 import { isWebhookRequestAuthorized } from '../shared/verifyWebhookSignature'
 import {
   MetriportWebhookType,
@@ -80,9 +84,10 @@ export const enrollment: Webhook<
     'Enrolls a patient when Metriport sends a real-time notification. The `eventType` data point carries the Metriport webhook type (`patient.admit` or `medical.discharge-summary`) so it can be distinguished on. The FHIR bundle is not fetched here — the pre-signed URL is passed on the `bundleUrl` data point and can be retrieved later with the "Get Webhook Bundle" action.',
   dataPoints,
   onEvent: async ({
-    payload: { payload, rawBody, headers, settings },
+    payload: { payload, rawBody, headers, settings, endpoint },
     onSuccess,
     onError,
+    helpers: { rateLimiter },
   }) => {
     try {
       // Verify the Metriport webhook signature (HMAC-SHA256 over the raw body)
@@ -176,6 +181,35 @@ export const enrollment: Webhook<
           },
         })
         return
+      }
+
+      // rate limiting
+      //
+      // Keyed on the guaranteed-unique `meta.messageId`. Metriport reuses the
+      // same messageId on retries, so this acts as an idempotency/dedup guard:
+      // a duplicate delivery of the same message within the configured window is
+      // acknowledged with 200 OK (so Metriport stops retrying) but does not
+      // re-enroll the patient. Distinct messages always pass.
+      const { success, data: durationString } =
+        rateLimitDurationSchema.safeParse(settings.rateLimitDuration)
+      if (success && !isNil(durationString)) {
+        const duration = transformRateLimitDuration(durationString)
+        const limiterName = `metriport-enrollment-${webhook.meta.type}-${endpoint?.id ?? 'global'}`
+        const limiter = rateLimiter(limiterName, {
+          requests: 1,
+          duration,
+        })
+        const key = webhook.meta.messageId
+        const { success } = await limiter.limit(key)
+        if (!success) {
+          await onError({
+            response: {
+              statusCode: 200,
+              message: `Rate limit exceeded on limiter ${limiterName} for messageId ${key}. 200 OK response sent to Metriport to prevent re-enrolling patient ${patientId} for a duplicate delivery of this message on endpoint ${endpoint?.url ?? 'global'}.`,
+            },
+          })
+          return
+        }
       }
 
       await onSuccess({


### PR DESCRIPTION
Closes [AWL-4313](https://linear.app/awell/issue/AWL-4313/add-rate-limiting-to-metriport-webhook-handlers)


## What

Ports Elation's rate-limit pattern to the Metriport `enrollment` webhook, keyed on the guaranteed-unique `meta.messageId`.

Reference: `extensions/elation/webhooks/appointmentCreatedOrUpdated.ts:47-69` and `extensions/elation/settings.ts`.

## Why

The enrollment webhook enrolls a patient on every `patient.admit` / `medical.discharge-summary` notification. Metriport can deliver the same message multiple times (retries, duplicate deliveries), each triggering an enrollment. Because Metriport reuses the same `messageId` on retries, keying the limiter on `messageId` acts as an idempotency/dedup guard: a duplicate delivery within the configured window is acknowledged with `200 OK` (so Metriport stops retrying) but does **not** re-enroll. Genuinely distinct messages always pass.

Rate limiting is **fully opt-in** — when `rateLimitDuration` is unset, existing behavior is unchanged (the `safeParse` guard short-circuits).

## Changes

- **`settings.ts`** — new `rateLimitDuration` setting plus the `rateLimitDurationSchema`, `parseDurationUnit`, and `transformRateLimitDuration` helpers (mirroring Elation).
- **`validation/settings.zod.ts`** — wire `rateLimitDuration` into the settings schema as optional.
- **`webhooks/enrollment.ts`** — destructure `endpoint` and `helpers: { rateLimiter }`; insert the rate-limit block immediately before `onSuccess`. Limiter name is `metriport-enrollment-${meta.type}-${endpoint?.id ?? 'global'}` (event types get separate namespaces); key is `meta.messageId`.
- **`webhooks/enrollment.test.ts`** — tests for limiter construction + enroll on fresh message, 200-OK-no-enroll on duplicate, and normal enrollment when unconfigured.

## Verification

- ✅ All 14 enrollment tests pass (`jest extensions/metriport/webhooks/enrollment.test.ts`)
- ✅ `tsc --noEmit` — 0 type errors
- ✅ ESLint clean on all changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)