### PR TITLE
fix: remove redundant action log metadata

### DIFF
--- a/extensions/airtop/actions/queryPage/queryPage.ts
+++ b/extensions/airtop/actions/queryPage/queryPage.ts
@@ -18,13 +18,7 @@ export const queryPage: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing queryPage')
+    helpers.log({ fields: payload.fields }, 'Processing queryPage')
 
     try {
       const { fields, airtopSdk } = await validatePayloadAndCreateSdk({
@@ -39,7 +33,7 @@ export const queryPage: Action<
       const createWindowRequest = {
         url: fields.pageUrl,
       }
-      helpers.log({ meta, createWindowRequest }, 'Creating Airtop window')
+      helpers.log({ createWindowRequest }, 'Creating Airtop window')
       const window = await airtopSdk.windows.create(
         session.data.id,
         createWindowRequest,
@@ -52,7 +46,7 @@ export const queryPage: Action<
           outputSchema: fields.jsonSchema,
         },
       }
-      helpers.log({ meta, pageQueryRequest }, 'Querying Airtop page')
+      helpers.log({ pageQueryRequest }, 'Querying Airtop page')
       const result = await airtopSdk.windows.pageQuery(
         session.data.id,
         window.data.windowId,
@@ -73,7 +67,7 @@ export const queryPage: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/airtop/actions/smartScrape/smartScrape.ts
+++ b/extensions/airtop/actions/smartScrape/smartScrape.ts
@@ -17,13 +17,7 @@ export const smartScrape: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing smartScrape')
+    helpers.log({ fields: payload.fields }, 'Processing smartScrape')
 
     try {
       const { fields, airtopSdk } = await validatePayloadAndCreateSdk({
@@ -57,7 +51,7 @@ export const smartScrape: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/athenahealth/actions/addClinicalDocument/addClinicalDocument.ts
+++ b/extensions/athenahealth/actions/addClinicalDocument/addClinicalDocument.ts
@@ -17,16 +17,7 @@ export const addClinicalDocument: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing addClinicalDocument',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing addClinicalDocument')
 
     const {
       fields: input,

--- a/extensions/athenahealth/actions/createAppointmentNote/createAppointmentNote.ts
+++ b/extensions/athenahealth/actions/createAppointmentNote/createAppointmentNote.ts
@@ -17,16 +17,7 @@ export const createAppointmentNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createAppointmentNote',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createAppointmentNote')
 
     const {
       fields: input,

--- a/extensions/athenahealth/actions/createPatient/createPatient.ts
+++ b/extensions/athenahealth/actions/createPatient/createPatient.ts
@@ -16,13 +16,7 @@ export const createPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createPatient')
+    helpers.log({ fields: payload.fields }, 'Processing createPatient')
 
     try {
       const {
@@ -45,7 +39,7 @@ export const createPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/athenahealth/actions/getAppointment/getAppointment.ts
+++ b/extensions/athenahealth/actions/getAppointment/getAppointment.ts
@@ -17,13 +17,7 @@ export const getAppointment: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getAppointment')
+    helpers.log({ fields: payload.fields }, 'Processing getAppointment')
 
     try {
       const {
@@ -52,7 +46,7 @@ export const getAppointment: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/athenahealth/actions/getPatient/getPatient.ts
+++ b/extensions/athenahealth/actions/getPatient/getPatient.ts
@@ -17,13 +17,7 @@ export const getPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       const {
@@ -49,7 +43,7 @@ export const getPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/availity/actions/getInsuranceVerificationDemo/getInsuranceVerificationDemo.ts
+++ b/extensions/availity/actions/getInsuranceVerificationDemo/getInsuranceVerificationDemo.ts
@@ -18,14 +18,8 @@ export const getInsuranceVerificationDemo: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing getInsuranceVerificationDemo',
     )
 
@@ -39,7 +33,7 @@ export const getInsuranceVerificationDemo: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/addAdhocTrack/addAdhocTrack.ts
+++ b/extensions/awell/v1/actions/addAdhocTrack/addAdhocTrack.ts
@@ -18,13 +18,7 @@ export const addAdhocTrack: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addAdhocTrack')
+    helpers.log({ fields: payload.fields }, 'Processing addAdhocTrack')
 
     try {
       const {
@@ -60,7 +54,7 @@ export const addAdhocTrack: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/createNaviSession/createNaviSession.ts
+++ b/extensions/awell/v1/actions/createNaviSession/createNaviSession.ts
@@ -28,11 +28,6 @@ export const createNaviSession: Action<typeof fields, typeof settings> = {
     const orgId = payload.pathway.org_id
     const tenantId = payload.pathway.tenant_id
     const environment = process.env.AWELL_ENVIRONMENT ?? 'test'
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const body = {
       orgId,
@@ -45,7 +40,7 @@ export const createNaviSession: Action<typeof fields, typeof settings> = {
     }
 
     try {
-      helpers.log({ meta, body }, 'Creating Navi session')
+      helpers.log({ body }, 'Creating Navi session')
       const response = await fetch(
         'https://navi-portal.awellhealth.com/api/session/create',
         {

--- a/extensions/awell/v1/actions/getCurrentCareflowId/getCurrentCareflowId.ts
+++ b/extensions/awell/v1/actions/getCurrentCareflowId/getCurrentCareflowId.ts
@@ -14,16 +14,7 @@ export const getCurrentCareflowId: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getCurrentCareflowId',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getCurrentCareflowId')
 
     try {
       const {
@@ -45,7 +36,7 @@ export const getCurrentCareflowId: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/getPatientByIdentifier/getPatientByIdentifier.ts
+++ b/extensions/awell/v1/actions/getPatientByIdentifier/getPatientByIdentifier.ts
@@ -18,16 +18,7 @@ export const getPatientByIdentifier: Action<typeof fields, typeof settings> = {
   previewable: true,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getPatientByIdentifier',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getPatientByIdentifier')
 
     try {
       const {
@@ -73,7 +64,7 @@ export const getPatientByIdentifier: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/isPatientEnrolledInCareFlow.ts
+++ b/extensions/awell/v1/actions/isPatientEnrolledInCareFlow/isPatientEnrolledInCareFlow.ts
@@ -39,14 +39,8 @@ export const isPatientEnrolledInCareFlow: Action<
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing isPatientEnrolledInCareFlow',
     )
 
@@ -138,7 +132,7 @@ export const isPatientEnrolledInCareFlow: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/isPatientEnrolledInTrack/isPatientEnrolledInTrack.ts
+++ b/extensions/awell/v1/actions/isPatientEnrolledInTrack/isPatientEnrolledInTrack.ts
@@ -27,14 +27,8 @@ export const isPatientEnrolledInTrack: Action<typeof fields, typeof settings> =
       onError,
       helpers,
     }): Promise<void> => {
-      const meta = {
-        tenant_id: payload.pathway.tenant_id,
-        careflow_id: payload.pathway.id,
-        activity_id: payload.activity.id,
-      }
-
       helpers.log(
-        { meta, fields: payload.fields },
+        { fields: payload.fields },
         'Processing isPatientEnrolledInTrack',
       )
 
@@ -128,7 +122,7 @@ export const isPatientEnrolledInTrack: Action<typeof fields, typeof settings> =
           },
         })
       } catch (err) {
-        helpers.log({ meta, err }, 'error', err as Error)
+        helpers.log({ err }, 'error', err as Error)
         const error = err as Error
         await onError({
           events: [

--- a/extensions/awell/v1/actions/searchPatientsByPatientCode/searchPatientsByPatientCode.ts
+++ b/extensions/awell/v1/actions/searchPatientsByPatientCode/searchPatientsByPatientCode.ts
@@ -20,14 +20,8 @@ export const searchPatientsByPatientCode: Action<
   previewable: true,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing searchPatientsByPatientCode',
     )
 
@@ -84,7 +78,7 @@ export const searchPatientsByPatientCode: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/startCareFlow/startCareFlow.ts
+++ b/extensions/awell/v1/actions/startCareFlow/startCareFlow.ts
@@ -21,13 +21,7 @@ export const startCareFlow: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing startCareFlow')
+    helpers.log({ fields: payload.fields }, 'Processing startCareFlow')
 
     try {
       const {
@@ -67,7 +61,7 @@ export const startCareFlow: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/startCareFlowAndSession/startCareFlowAndSession.ts
+++ b/extensions/awell/v1/actions/startCareFlowAndSession/startCareFlowAndSession.ts
@@ -15,14 +15,8 @@ export const startCareFlowAndSession: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing startCareFlowAndSession',
     )
 
@@ -74,7 +68,7 @@ export const startCareFlowAndSession: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/startHostedPagesSession/startHostedPagesSession.ts
+++ b/extensions/awell/v1/actions/startHostedPagesSession/startHostedPagesSession.ts
@@ -19,14 +19,8 @@ export const startHostedPagesSession: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing startHostedPagesSession',
     )
 
@@ -81,7 +75,7 @@ export const startHostedPagesSession: Action<typeof fields, typeof settings> = {
         })
 
         helpers.log(
-          { meta, careFlowId, stakeholdersInRelease },
+          { careFlowId, stakeholdersInRelease },
           'stakeholdersInRelease',
         )
 
@@ -125,7 +119,7 @@ export const startHostedPagesSession: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
+++ b/extensions/awell/v1/actions/stopCareFlow/stopCareFlow.ts
@@ -18,13 +18,7 @@ export const stopCareFlow: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing stopCareFlow')
+    helpers.log({ fields: payload.fields }, 'Processing stopCareFlow')
 
     try {
       const {
@@ -86,7 +80,7 @@ export const stopCareFlow: Action<typeof fields, typeof settings> = {
         events,
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/stopTrack/stopTrack.ts
+++ b/extensions/awell/v1/actions/stopTrack/stopTrack.ts
@@ -17,13 +17,7 @@ export const stopTrack: Action<typeof fields, typeof settings> = {
   previewable: false, // We don't have pathways in Preview, only cases.
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing stopTrack')
+    helpers.log({ fields: payload.fields }, 'Processing stopTrack')
 
     try {
       const {
@@ -93,7 +87,7 @@ export const stopTrack: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
+++ b/extensions/awell/v1/actions/updateBaselineInfo/updateBaselineInfo.ts
@@ -20,16 +20,7 @@ export const updateBaselineInfo: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing updateBaselineInfo',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing updateBaselineInfo')
 
     try {
       const {
@@ -64,7 +55,7 @@ export const updateBaselineInfo: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awell/v1/actions/updatePatient/updatePatient.ts
+++ b/extensions/awell/v1/actions/updatePatient/updatePatient.ts
@@ -18,13 +18,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
   previewable: false,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updatePatient')
+    helpers.log({ fields: payload.fields }, 'Processing updatePatient')
 
     try {
       const {
@@ -116,7 +110,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/awellTasks/actions/getComments/getComments.ts
+++ b/extensions/awellTasks/actions/getComments/getComments.ts
@@ -19,13 +19,7 @@ export const getComments: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getComments')
+    helpers.log({ fields: payload.fields }, 'Processing getComments')
 
     try {
       const { taskSdk, pathway } = await validatePayloadAndCreateSdk({
@@ -66,7 +60,7 @@ export const getComments: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/createSmsConversation/createSmsConversation.ts
+++ b/extensions/bland/actions/createSmsConversation/createSmsConversation.ts
@@ -23,16 +23,7 @@ export const createSmsConversation: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createSmsConversation',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createSmsConversation')
 
     try {
       const { fields, blandSdk } = await validatePayloadAndCreateSdk({
@@ -67,7 +58,7 @@ export const createSmsConversation: Action<
 
       try {
         helpers.log(
-          { meta, createSmsConversationInput },
+          { createSmsConversationInput },
           'Creating SMS conversation via Bland',
         )
       } catch (err) {
@@ -95,7 +86,7 @@ export const createSmsConversation: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/getCallDetails/getCallDetails.ts
+++ b/extensions/bland/actions/getCallDetails/getCallDetails.ts
@@ -20,13 +20,7 @@ export const getCallDetails: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getCallDetails')
+    helpers.log({ fields: payload.fields }, 'Processing getCallDetails')
 
     try {
       const { fields, blandSdk } = await validatePayloadAndCreateSdk({
@@ -69,7 +63,7 @@ export const getCallDetails: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/sendCall/sendCall.ts
+++ b/extensions/bland/actions/sendCall/sendCall.ts
@@ -20,13 +20,7 @@ export const sendCall: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendCall')
+    helpers.log({ fields: payload.fields }, 'Processing sendCall')
 
     try {
       const { fields: allFields, blandSdk } = await validatePayloadAndCreateSdk(
@@ -66,7 +60,7 @@ export const sendCall: Action<
       })
 
       try {
-        helpers.log({ meta, sendCallInput }, 'Sending call to Bland')
+        helpers.log({ sendCallInput }, 'Sending call to Bland')
       } catch (err) {
         console.error('unable to use new helpers.log')
         console.error(JSON.stringify(err))
@@ -92,7 +86,7 @@ export const sendCall: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
+++ b/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
@@ -20,16 +20,7 @@ export const sendCallWithPathway: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendCallWithPathway',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendCallWithPathway')
 
     try {
       const { fields: allFields, blandSdk } = await validatePayloadAndCreateSdk(
@@ -89,7 +80,7 @@ export const sendCallWithPathway: Action<
 
       // TODO: remove this once we validate helpers.log in production
       try {
-        helpers.log({ meta, sendCallInput }, 'Sending call to Bland')
+        helpers.log({ sendCallInput }, 'Sending call to Bland')
       } catch (err) {
         console.error('unable to use new helpers.log')
         console.error(JSON.stringify(err))
@@ -115,7 +106,7 @@ export const sendCallWithPathway: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
+++ b/extensions/bland/actions/sendCallWithPathway/sendCallWithPathway.ts
@@ -53,7 +53,6 @@ export const sendCallWithPathway: Action<
       if (resolvedPathwayId !== fields.pathwayId) {
         helpers.log(
           {
-            meta,
             originalPathwayId: fields.pathwayId,
             resolvedPathwayId,
           },

--- a/extensions/bland/actions/sendSms/sendSms.ts
+++ b/extensions/bland/actions/sendSms/sendSms.ts
@@ -22,13 +22,7 @@ export const sendSms: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     try {
       const { fields, blandSdk } = await validatePayloadAndCreateSdk({
@@ -72,7 +66,7 @@ export const sendSms: Action<
       })
 
       try {
-        helpers.log({ meta, sendSmsInput }, 'Sending SMS via Bland')
+        helpers.log({ sendSmsInput }, 'Sending SMS via Bland')
       } catch (err) {
         console.error('unable to use new helpers.log')
         console.error(JSON.stringify(err))
@@ -96,7 +90,7 @@ export const sendSms: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/bland/actions/stopActiveCall/stopActiveCall.ts
+++ b/extensions/bland/actions/stopActiveCall/stopActiveCall.ts
@@ -19,13 +19,7 @@ export const stopActiveCall: Action<
   dataPoints,
   supports_automated_retries: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing stopActiveCall')
+    helpers.log({ fields: payload.fields }, 'Processing stopActiveCall')
 
     try {
       const { fields, blandSdk } = await validatePayloadAndCreateSdk({
@@ -37,10 +31,7 @@ export const stopActiveCall: Action<
         call_id: fields.callId,
       }
 
-      helpers.log(
-        { meta, stopActiveCallInput },
-        'Stopping active call via Bland',
-      )
+      helpers.log({ stopActiveCallInput }, 'Stopping active call via Bland')
       const { data } = await blandSdk.stopActiveCall(stopActiveCallInput)
 
       await onComplete({
@@ -55,7 +46,7 @@ export const stopActiveCall: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/scheduleEmail/scheduleEmail.ts
+++ b/extensions/braze/actions/scheduleEmail/scheduleEmail.ts
@@ -15,13 +15,7 @@ export const scheduleEmail = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing scheduleEmail')
+    helpers.log({ fields: payload.fields }, 'Processing scheduleEmail')
 
     try {
       const {
@@ -78,7 +72,7 @@ export const scheduleEmail = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Scheduling email via Braze')
+      helpers.log({ requestBody }, 'Scheduling email via Braze')
       const resp = await brazeClient.scheduleMessage(requestBody)
 
       await onComplete({
@@ -93,7 +87,7 @@ export const scheduleEmail = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/scheduleSMS/scheduleSMS.ts
+++ b/extensions/braze/actions/scheduleSMS/scheduleSMS.ts
@@ -15,13 +15,7 @@ export const scheduleSMS = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing scheduleSMS')
+    helpers.log({ fields: payload.fields }, 'Processing scheduleSMS')
 
     try {
       const {
@@ -70,7 +64,7 @@ export const scheduleSMS = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Scheduling SMS via Braze')
+      helpers.log({ requestBody }, 'Scheduling SMS via Braze')
       const resp = await brazeClient.scheduleMessage(requestBody)
 
       await onComplete({
@@ -86,7 +80,7 @@ export const scheduleSMS = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/sendCampaign/sendCampaign.ts
+++ b/extensions/braze/actions/sendCampaign/sendCampaign.ts
@@ -14,13 +14,7 @@ export const sendCampaign = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendCampaign')
+    helpers.log({ fields: payload.fields }, 'Processing sendCampaign')
 
     try {
       const {
@@ -66,7 +60,7 @@ export const sendCampaign = {
         }),
       }
 
-      helpers.log({ meta, requestBody }, 'Sending campaign via Braze')
+      helpers.log({ requestBody }, 'Sending campaign via Braze')
       const resp = await brazeClient.sendCampaign(requestBody)
 
       await onComplete({
@@ -81,7 +75,7 @@ export const sendCampaign = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/sendEmail/sendEmail.ts
+++ b/extensions/braze/actions/sendEmail/sendEmail.ts
@@ -14,13 +14,7 @@ export const sendEmail = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendEmail')
+    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
 
     try {
       const {
@@ -73,7 +67,7 @@ export const sendEmail = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Sending email via Braze')
+      helpers.log({ requestBody }, 'Sending email via Braze')
       const resp = await brazeClient.sendMessageImmediately(requestBody)
 
       await onComplete({
@@ -88,7 +82,7 @@ export const sendEmail = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/sendEmailUsingTemplate/sendEmailUsingTemplate.ts
+++ b/extensions/braze/actions/sendEmailUsingTemplate/sendEmailUsingTemplate.ts
@@ -16,16 +16,7 @@ export const sendEmailUsingTemplate = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendEmailUsingTemplate',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendEmailUsingTemplate')
 
     try {
       const {
@@ -81,10 +72,7 @@ export const sendEmailUsingTemplate = {
         },
       }
 
-      helpers.log(
-        { meta, requestBody },
-        'Sending email using template via Braze',
-      )
+      helpers.log({ requestBody }, 'Sending email using template via Braze')
       const resp = isNil(time)
         ? await brazeClient.sendMessageImmediately(requestBody)
         : await brazeClient.scheduleMessage(requestBody)
@@ -105,7 +93,7 @@ export const sendEmailUsingTemplate = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/braze/actions/sendSMS/sendSMS.ts
+++ b/extensions/braze/actions/sendSMS/sendSMS.ts
@@ -14,13 +14,7 @@ export const sendSMS = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSMS')
+    helpers.log({ fields: payload.fields }, 'Processing sendSMS')
 
     try {
       const {
@@ -67,7 +61,7 @@ export const sendSMS = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Sending SMS via Braze')
+      helpers.log({ requestBody }, 'Sending SMS via Braze')
       const resp = await brazeClient.sendMessageImmediately(requestBody)
 
       await onComplete({
@@ -82,7 +76,7 @@ export const sendSMS = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/calDotCom/actions/createBooking/createBooking.test.ts
+++ b/extensions/calDotCom/actions/createBooking/createBooking.test.ts
@@ -65,11 +65,6 @@ describe('Create booking', () => {
     })
     expect(helpers.log).toHaveBeenCalledWith(
       {
-        meta: {
-          tenant_id: basePayload.pathway.tenant_id,
-          careflow_id: basePayload.pathway.id,
-          activity_id: basePayload.activity.id,
-        },
         createBookingRequest: {
           eventTypeId: sampleBooking.eventTypeId,
           start: sampleBooking.startTime,

--- a/extensions/calDotCom/actions/createBooking/createBooking.ts
+++ b/extensions/calDotCom/actions/createBooking/createBooking.ts
@@ -15,12 +15,6 @@ export const createBooking: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings: { apiKey },
@@ -60,7 +54,7 @@ export const createBooking: Action<typeof fields, typeof settings> = {
         status,
       }
 
-      helpers.log({ meta, createBookingRequest }, 'Creating Cal.com booking')
+      helpers.log({ createBookingRequest }, 'Creating Cal.com booking')
 
       const booking = await calComApi.createBooking(createBookingRequest)
 
@@ -70,7 +64,7 @@ export const createBooking: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/calDotCom/actions/deleteBooking/deleteBooking.test.ts
+++ b/extensions/calDotCom/actions/deleteBooking/deleteBooking.test.ts
@@ -44,11 +44,6 @@ describe('Delete booking', () => {
     expect(onComplete).toHaveBeenCalledWith()
     expect(helpers.log).toHaveBeenCalledWith(
       {
-        meta: {
-          tenant_id: basePayload.pathway.tenant_id,
-          careflow_id: basePayload.pathway.id,
-          activity_id: basePayload.activity.id,
-        },
         bookingId: String(sampleBooking.id),
         deleteBookingRequest: {
           allRemainingBookings: undefined,

--- a/extensions/calDotCom/actions/deleteBooking/deleteBooking.ts
+++ b/extensions/calDotCom/actions/deleteBooking/deleteBooking.ts
@@ -14,12 +14,6 @@ export const deleteBooking: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings: { apiKey },
@@ -39,7 +33,7 @@ export const deleteBooking: Action<typeof fields, typeof settings> = {
       }
 
       helpers.log(
-        { meta, bookingId, deleteBookingRequest },
+        { bookingId, deleteBookingRequest },
         'Deleting Cal.com booking',
       )
 
@@ -47,7 +41,7 @@ export const deleteBooking: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/calDotCom/actions/getBooking/v1/getBooking.test.ts
+++ b/extensions/calDotCom/actions/getBooking/v1/getBooking.test.ts
@@ -160,11 +160,6 @@ describe('Cal.com GetBooking action', () => {
 
       expect(helpers.log).toHaveBeenCalledWith(
         {
-          meta: {
-            tenant_id: payload.pathway.tenant_id,
-            careflow_id: payload.pathway.id,
-            activity_id: payload.activity.id,
-          },
           bookingId: payload.fields.bookingId,
         },
         'Getting Cal.com booking',

--- a/extensions/calDotCom/actions/getBooking/v1/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking/v1/getBooking.ts
@@ -14,12 +14,6 @@ export const getBooking: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { bookingId },
@@ -32,7 +26,7 @@ export const getBooking: Action<typeof fields, typeof settings> = {
         payload,
       })
       const calComApi = new CalComApi(apiKey)
-      helpers.log({ meta, bookingId }, 'Getting Cal.com booking')
+      helpers.log({ bookingId }, 'Getting Cal.com booking')
       const booking = await calComApi.getBooking(bookingId)
 
       await onComplete({
@@ -54,7 +48,7 @@ export const getBooking: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (error instanceof ZodError) {
         const err = fromZodError(error)
         await onError({

--- a/extensions/calDotCom/actions/getBooking/v2/getBooking.test.ts
+++ b/extensions/calDotCom/actions/getBooking/v2/getBooking.test.ts
@@ -55,11 +55,6 @@ describe('Cal.com - Get booking (v2 api)', () => {
       expect(onError).not.toHaveBeenCalled()
       expect(helpers.log).toHaveBeenCalledWith(
         {
-          meta: {
-            tenant_id: payload.pathway.tenant_id,
-            careflow_id: payload.pathway.id,
-            activity_id: payload.activity.id,
-          },
           getBookingRequest: {
             bookingUid: 'booking_uid_123',
           },

--- a/extensions/calDotCom/actions/getBooking/v2/getBooking.ts
+++ b/extensions/calDotCom/actions/getBooking/v2/getBooking.ts
@@ -14,12 +14,6 @@ export const getBookingv2: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const {
       fields: { bookingUid },
       calv2Client,
@@ -32,13 +26,13 @@ export const getBookingv2: Action<typeof fields, typeof settings> = {
       bookingUid,
     }
 
-    helpers.log({ meta, getBookingRequest }, 'Getting Cal.com booking')
+    helpers.log({ getBookingRequest }, 'Getting Cal.com booking')
 
     const response = await calv2Client.getBooking(getBookingRequest)
 
     if (response.data.status === 'error') {
       helpers.log(
-        { meta, getBookingRequest, responseData: response.data },
+        { getBookingRequest, responseData: response.data },
         'Cal.com get booking returned an error',
       )
       await onError({

--- a/extensions/calDotCom/actions/updateBooking/updateBooking.test.ts
+++ b/extensions/calDotCom/actions/updateBooking/updateBooking.test.ts
@@ -58,11 +58,6 @@ describe('Update booking', () => {
     })
     expect(helpers.log).toHaveBeenCalledWith(
       {
-        meta: {
-          tenant_id: basePayload.pathway.tenant_id,
-          careflow_id: basePayload.pathway.id,
-          activity_id: basePayload.activity.id,
-        },
         bookingId: String(sampleBooking.id),
         updateBookingRequest: {
           title: sampleBooking.title,

--- a/extensions/calDotCom/actions/updateBooking/updateBooking.ts
+++ b/extensions/calDotCom/actions/updateBooking/updateBooking.ts
@@ -15,12 +15,6 @@ export const updateBooking: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings: { apiKey },
@@ -43,7 +37,7 @@ export const updateBooking: Action<typeof fields, typeof settings> = {
       }
 
       helpers.log(
-        { meta, bookingId, updateBookingRequest },
+        { bookingId, updateBookingRequest },
         'Updating Cal.com booking',
       )
 
@@ -59,7 +53,7 @@ export const updateBooking: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/canvasMedical/v1/actions/createAppointment/createAppointment.ts
+++ b/extensions/canvasMedical/v1/actions/createAppointment/createAppointment.ts
@@ -23,16 +23,7 @@ export const createAppointment: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createAppointment',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createAppointment')
 
     try {
       validate({
@@ -55,7 +46,7 @@ export const createAppointment: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/createClaim/createClaim.ts
+++ b/extensions/canvasMedical/v1/actions/createClaim/createClaim.ts
@@ -23,12 +23,6 @@ export const createClaim: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: {
@@ -66,7 +60,7 @@ export const createClaim: Action<typeof fields, typeof settings> = {
         item,
       } satisfies Claim
 
-      helpers.log({ meta, claimData }, '[createClaim] Creating Canvas claim')
+      helpers.log({ claimData }, '[createClaim] Creating Canvas claim')
 
       const claimId = await api.createClaim(claimData)
 
@@ -76,7 +70,7 @@ export const createClaim: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/createCoverage/createCoverage.ts
+++ b/extensions/canvasMedical/v1/actions/createCoverage/createCoverage.ts
@@ -22,13 +22,7 @@ export const createCoverage: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createCoverage')
+    helpers.log({ fields: payload.fields }, 'Processing createCoverage')
 
     try {
       const {
@@ -80,7 +74,7 @@ export const createCoverage: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/createPatient/createPatient.ts
+++ b/extensions/canvasMedical/v1/actions/createPatient/createPatient.ts
@@ -23,13 +23,7 @@ export const createPatient: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createPatient')
+    helpers.log({ fields: payload.fields }, 'Processing createPatient')
 
     try {
       validate({
@@ -52,7 +46,7 @@ export const createPatient: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/createQuestionnaireResponses/createQuestionnaireResponses.ts
+++ b/extensions/canvasMedical/v1/actions/createQuestionnaireResponses/createQuestionnaireResponses.ts
@@ -26,14 +26,8 @@ export const createQuestionnaireResponses: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing createQuestionnaireResponses',
     )
 
@@ -69,7 +63,7 @@ export const createQuestionnaireResponses: Action<
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/createTask/createTask.ts
+++ b/extensions/canvasMedical/v1/actions/createTask/createTask.ts
@@ -23,13 +23,7 @@ export const createTask: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTask')
+    helpers.log({ fields: payload.fields }, 'Processing createTask')
 
     try {
       validate({
@@ -52,7 +46,7 @@ export const createTask: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/extractPatientInfo/extractPatientInfo.ts
+++ b/extensions/canvasMedical/v1/actions/extractPatientInfo/extractPatientInfo.ts
@@ -15,16 +15,7 @@ export const extractPatientInfo: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing extractPatientInfo',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing extractPatientInfo')
 
     try {
       validate({
@@ -64,7 +55,7 @@ export const extractPatientInfo: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/getAppointment/getAppointment.ts
+++ b/extensions/canvasMedical/v1/actions/getAppointment/getAppointment.ts
@@ -23,13 +23,7 @@ export const getAppointment: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getAppointment')
+    helpers.log({ fields: payload.fields }, 'Processing getAppointment')
 
     try {
       validate({
@@ -50,7 +44,7 @@ export const getAppointment: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/getPatient/getPatient.ts
+++ b/extensions/canvasMedical/v1/actions/getPatient/getPatient.ts
@@ -23,13 +23,7 @@ export const getPatient: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       validate({
@@ -50,7 +44,7 @@ export const getPatient: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/getQuestionnaireResponse/getQuestionnaireResponse.ts
+++ b/extensions/canvasMedical/v1/actions/getQuestionnaireResponse/getQuestionnaireResponse.ts
@@ -24,14 +24,8 @@ export const getQuestionnaireResponse: Action<typeof fields, typeof settings> =
     dataPoints,
     previewable: true,
     onEvent: async ({ payload, onComplete, onError, helpers }) => {
-      const meta = {
-        tenant_id: payload.pathway.tenant_id,
-        careflow_id: payload.pathway.id,
-        activity_id: payload.activity.id,
-      }
-
       helpers.log(
-        { meta, fields: payload.fields },
+        { fields: payload.fields },
         'Processing getQuestionnaireResponse',
       )
 
@@ -60,7 +54,7 @@ export const getQuestionnaireResponse: Action<typeof fields, typeof settings> =
           },
         })
       } catch (error) {
-        helpers.log({ meta, error }, 'error', error as Error)
+        helpers.log({ error }, 'error', error as Error)
         let parsedError
 
         if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/getTask/getTask.ts
+++ b/extensions/canvasMedical/v1/actions/getTask/getTask.ts
@@ -23,13 +23,7 @@ export const getTask: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getTask')
+    helpers.log({ fields: payload.fields }, 'Processing getTask')
 
     try {
       validate({
@@ -50,7 +44,7 @@ export const getTask: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/updateAppointment/updateAppointment.ts
+++ b/extensions/canvasMedical/v1/actions/updateAppointment/updateAppointment.ts
@@ -23,16 +23,7 @@ export const updateAppointment: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing updateAppointment',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing updateAppointment')
 
     try {
       validate({
@@ -53,7 +44,7 @@ export const updateAppointment: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/updateCoverage/updateCoverage.ts
+++ b/extensions/canvasMedical/v1/actions/updateCoverage/updateCoverage.ts
@@ -23,12 +23,6 @@ export const updateCoverage: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: {
@@ -75,10 +69,7 @@ export const updateCoverage: Action<typeof fields, typeof settings> = {
         class: classCoverage,
       } satisfies CoverageWithId
 
-      helpers.log(
-        { meta, coverageData },
-        '[updateCoverage] Updating Canvas coverage',
-      )
+      helpers.log({ coverageData }, '[updateCoverage] Updating Canvas coverage')
 
       const coverageId = await api.updateCoverage(coverageData)
 
@@ -88,7 +79,7 @@ export const updateCoverage: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/updatePatient/updatePatient.ts
+++ b/extensions/canvasMedical/v1/actions/updatePatient/updatePatient.ts
@@ -23,13 +23,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updatePatient')
+    helpers.log({ fields: payload.fields }, 'Processing updatePatient')
 
     try {
       validate({
@@ -51,7 +45,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/canvasMedical/v1/actions/updateTask/updateTask.ts
+++ b/extensions/canvasMedical/v1/actions/updateTask/updateTask.ts
@@ -23,13 +23,7 @@ export const updateTask: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updateTask')
+    helpers.log({ fields: payload.fields }, 'Processing updateTask')
 
     try {
       validate({
@@ -50,7 +44,7 @@ export const updateTask: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       let parsedError
 
       if (isZodError(error)) {

--- a/extensions/cerner/actions/createDocument/createDocument.ts
+++ b/extensions/cerner/actions/createDocument/createDocument.ts
@@ -20,11 +20,6 @@ export const createDocument: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
     const {
       cernerFhirR4Sdk,
       fields: { patientResourceId, encounterResourceId, type, note },
@@ -75,7 +70,7 @@ export const createDocument: Action<
 
     try {
       helpers.log(
-        { meta, DocumentReferenceInput },
+        { DocumentReferenceInput },
         '[createDocument] Creating Cerner document reference',
       )
 

--- a/extensions/cerner/actions/createPatient/createPatient.ts
+++ b/extensions/cerner/actions/createPatient/createPatient.ts
@@ -21,11 +21,6 @@ export const createPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
     const {
       cernerFhirR4Sdk,
       fields: {
@@ -95,7 +90,7 @@ export const createPatient: Action<
 
     try {
       helpers.log(
-        { meta, PatientResource },
+        { PatientResource },
         '[createPatient] Creating Cerner patient',
       )
 

--- a/extensions/cloudinary/actions/uploadFiles/uploadFiles.ts
+++ b/extensions/cloudinary/actions/uploadFiles/uploadFiles.ts
@@ -21,13 +21,7 @@ export const uploadFiles: Action<typeof fields, typeof settings> = {
   },
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing uploadFiles')
+    helpers.log({ fields: payload.fields }, 'Processing uploadFiles')
 
     try {
       validate({
@@ -42,7 +36,7 @@ export const uploadFiles: Action<typeof fields, typeof settings> = {
        * Completion happens in Awell Hosted Pages
        */
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/cloudinary/actions/uploadSingleFile/uploadSingleFile.ts
+++ b/extensions/cloudinary/actions/uploadSingleFile/uploadSingleFile.ts
@@ -20,13 +20,7 @@ export const uploadSingleFile: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing uploadSingleFile')
+    helpers.log({ fields: payload.fields }, 'Processing uploadSingleFile')
 
     try {
       validate({
@@ -41,7 +35,7 @@ export const uploadSingleFile: Action<typeof fields, typeof settings> = {
        * Completion happens in Awell Hosted Pages
        */
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/cmDotCom/v1/actions/sendSms/sendSms.ts
+++ b/extensions/cmDotCom/v1/actions/sendSms/sendSms.ts
@@ -16,13 +16,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     try {
       const {
@@ -68,7 +62,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/collectData/v1/actions/arrayTest/arrayTest.ts
+++ b/extensions/collectData/v1/actions/arrayTest/arrayTest.ts
@@ -15,12 +15,6 @@ export const arrayTest: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         stringArray,
@@ -30,9 +24,9 @@ export const arrayTest: Action<typeof fields, typeof settings> = {
       } = validateActionFields(payload.fields)
 
       const strings = [...stringArray, ...anotherStringArray]
-      helpers.log({ meta, strings }, '🚀 ~ onActivityCreated: ~ strings:')
+      helpers.log({ strings }, '🚀 ~ onActivityCreated: ~ strings:')
       const numbers = [...numericArray, ...anotherNumericArray]
-      helpers.log({ meta, numbers }, '🚀 ~ onActivityCreated: ~ numbers:')
+      helpers.log({ numbers }, '🚀 ~ onActivityCreated: ~ numbers:')
 
       await onComplete({
         data_points: {
@@ -41,7 +35,7 @@ export const arrayTest: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/customerIo/actions/trackPersonEvent/trackPersonEvent.ts
+++ b/extensions/customerIo/actions/trackPersonEvent/trackPersonEvent.ts
@@ -17,13 +17,7 @@ export const trackPersonEvent: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing trackPersonEvent')
+    helpers.log({ fields: payload.fields }, 'Processing trackPersonEvent')
 
     try {
       const { customerIoTrackClient, fields, pathway, patient, activity } =
@@ -62,7 +56,7 @@ export const trackPersonEvent: Action<
       }
 
       helpers.log(
-        { meta, trackPersonEventWithPatientIdentifiersInput },
+        { trackPersonEventWithPatientIdentifiersInput },
         'Tracking Customer.io person event',
       )
       await customerIoTrackClient.trackPersonEvent(
@@ -86,14 +80,14 @@ export const trackPersonEvent: Action<
       }
 
       helpers.log(
-        { meta, trackPersonEventInput },
+        { trackPersonEventInput },
         'Tracking Customer.io person event',
       )
       await customerIoTrackClient.trackPersonEvent(trackPersonEventInput)
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/dateHelpers/actions/checkWorkingHours/checkWorkingHours.ts
+++ b/extensions/dateHelpers/actions/checkWorkingHours/checkWorkingHours.ts
@@ -19,12 +19,6 @@ export const checkWorkingHours: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { workingHoursStart, workingHoursEnd, timezone } =
       FieldsValidationSchema.parse(payload.fields)
 
@@ -44,7 +38,7 @@ export const checkWorkingHours: Action<
 
     if (endTotalMinutes <= startTotalMinutes) {
       helpers.log(
-        { meta, workingHoursStart, workingHoursEnd, timezone },
+        { workingHoursStart, workingHoursEnd, timezone },
         'Invalid working hours',
       )
       await onError({

--- a/extensions/dateHelpers/actions/checkWorkingHours/checkWorkingHours.ts
+++ b/extensions/dateHelpers/actions/checkWorkingHours/checkWorkingHours.ts
@@ -102,7 +102,6 @@ export const checkWorkingHours: Action<
 
     helpers.log(
       {
-        meta,
         workingHoursStart,
         workingHoursEnd,
         timezone,

--- a/extensions/dateHelpers/actions/getNextDateOccurrence/getNextDateOccurrence.ts
+++ b/extensions/dateHelpers/actions/getNextDateOccurrence/getNextDateOccurrence.ts
@@ -16,16 +16,7 @@ export const getNextDateOccurrence: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getNextDateOccurrence',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getNextDateOccurrence')
 
     try {
       const { referenceDate: referenceDateInput } =
@@ -78,7 +69,7 @@ export const getNextDateOccurrence: Action<
       const nextOccurrence = findNextOccurrence(anchorDate)
 
       helpers.log(
-        { meta, referenceDate: referenceDateInput, nextOccurrence },
+        { referenceDate: referenceDateInput, nextOccurrence },
         'Calculated next date occurrence',
       )
 
@@ -88,7 +79,7 @@ export const getNextDateOccurrence: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/dateHelpers/actions/getNextWorkday/getNextWorkday.ts
+++ b/extensions/dateHelpers/actions/getNextWorkday/getNextWorkday.ts
@@ -17,13 +17,7 @@ export const getNextWorkday: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getNextWorkday')
+    helpers.log({ fields: payload.fields }, 'Processing getNextWorkday')
 
     try {
       const { referenceDate: referenceDateInput, includeReferenceDate } =
@@ -183,7 +177,7 @@ export const getNextWorkday: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/dateHelpers/actions/getNextWorkday/getNextWorkday.ts
+++ b/extensions/dateHelpers/actions/getNextWorkday/getNextWorkday.ts
@@ -161,7 +161,6 @@ export const getNextWorkday: Action<
 
       helpers.log(
         {
-          meta,
           referenceDate: referenceDateInput,
           includeReferenceDate,
           nextWorkday,

--- a/extensions/dockHealth/actions/createTask/createTask.ts
+++ b/extensions/dockHealth/actions/createTask/createTask.ts
@@ -17,13 +17,7 @@ export const createTask: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTask')
+    helpers.log({ fields: payload.fields }, 'Processing createTask')
 
     try {
       const { fields, dockClient } = await validatePayloadAndCreateClient({
@@ -66,7 +60,7 @@ export const createTask: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/dockHealth/actions/getPatient/getPatient.ts
+++ b/extensions/dockHealth/actions/getPatient/getPatient.ts
@@ -16,13 +16,7 @@ export const getPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       const { fields, dockClient } = await validatePayloadAndCreateClient({
@@ -39,7 +33,7 @@ export const getPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/docuSign/actions/createSequentialEmbeddedSignatureRequest/createSequentialEmbeddedSignatureRequest.ts
+++ b/extensions/docuSign/actions/createSequentialEmbeddedSignatureRequest/createSequentialEmbeddedSignatureRequest.ts
@@ -26,11 +26,6 @@ export const createSequentialEmbeddedSignatureRequest: Action<
       pathway: { id: pathwayId },
       activity: { id: activityId, sessionId },
     } = payload
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const {
       settings: {
@@ -98,7 +93,7 @@ export const createSequentialEmbeddedSignatureRequest: Action<
       const createEnvelopeRequest = {
         envelopeDefinition: envelope,
       }
-      helpers.log({ meta, createEnvelopeRequest }, 'Creating DocuSign envelope')
+      helpers.log({ createEnvelopeRequest }, 'Creating DocuSign envelope')
       const envelopeResult = await envelopesApi.createEnvelope(
         accountId,
         createEnvelopeRequest,
@@ -122,7 +117,7 @@ export const createSequentialEmbeddedSignatureRequest: Action<
       }
 
       helpers.log(
-        { meta, createRecipientViewRequest },
+        { createRecipientViewRequest },
         'Creating DocuSign recipient view',
       )
       const recipient1ViewResult = await envelopesApi.createRecipientView(

--- a/extensions/docuSign/actions/generateSignUrlForExistingEnvelope/generateSignUrlForExistingEnvelope.ts
+++ b/extensions/docuSign/actions/generateSignUrlForExistingEnvelope/generateSignUrlForExistingEnvelope.ts
@@ -25,11 +25,6 @@ export const generateSignUrlForExistingEnvelope: Action<
       pathway: { id: pathwayId },
       activity: { id: activityId, sessionId },
     } = payload
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const {
       settings: {
@@ -76,7 +71,7 @@ export const generateSignUrlForExistingEnvelope: Action<
       }
 
       helpers.log(
-        { meta, createRecipientViewRequest },
+        { createRecipientViewRequest },
         'Creating DocuSign recipient view',
       )
       const viewResult = await envelopesApi.createRecipientView(

--- a/extensions/dropboxSign/v1/actions/cancelSignatureRequest/cancelSignatureRequest.ts
+++ b/extensions/dropboxSign/v1/actions/cancelSignatureRequest/cancelSignatureRequest.ts
@@ -17,16 +17,7 @@ export const cancelSignatureRequest: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing cancelSignatureRequest',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing cancelSignatureRequest')
 
     try {
       const { signatureRequestId } = validateActionFields(payload.fields)
@@ -39,7 +30,7 @@ export const cancelSignatureRequest: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/dropboxSign/v1/actions/getSignatureRequest/getSignatureRequest.ts
+++ b/extensions/dropboxSign/v1/actions/getSignatureRequest/getSignatureRequest.ts
@@ -17,16 +17,7 @@ export const getSignatureRequest: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getSignatureRequest',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getSignatureRequest')
 
     try {
       const { signatureRequestId } = validateActionFields(payload.fields)
@@ -61,7 +52,7 @@ export const getSignatureRequest: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/dropboxSign/v1/actions/sendRequestReminder/sendRequestReminder.ts
+++ b/extensions/dropboxSign/v1/actions/sendRequestReminder/sendRequestReminder.ts
@@ -17,16 +17,7 @@ export const sendRequestReminder: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendRequestReminder',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendRequestReminder')
 
     try {
       const { signatureRequestId, signerEmailAddress } = validateActionFields(
@@ -45,7 +36,7 @@ export const sendRequestReminder: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/sendSignatureRequestWithTemplate.ts
+++ b/extensions/dropboxSign/v1/actions/sendSignatureRequestWithTemplate/sendSignatureRequestWithTemplate.ts
@@ -20,14 +20,8 @@ export const sendSignatureRequestWithTemplate: Action<
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing sendSignatureRequestWithTemplate',
     )
 
@@ -92,7 +86,7 @@ export const sendSignatureRequestWithTemplate: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/addAllergy/addAllergy.ts
+++ b/extensions/elation/actions/addAllergy/addAllergy.ts
@@ -18,13 +18,7 @@ export const addAllergy: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addAllergy')
+    helpers.log({ fields: payload.fields }, 'Processing addAllergy')
 
     try {
       const { fields, settings } = validate({
@@ -45,10 +39,7 @@ export const addAllergy: Action<
         severity: fields.severity,
       }
 
-      helpers.log(
-        { meta, addAllergyInput },
-        '[addAllergy] Adding Elation allergy',
-      )
+      helpers.log({ addAllergyInput }, '[addAllergy] Adding Elation allergy')
 
       const { id } = await api.addAllergy(addAllergyInput)
 
@@ -58,7 +49,7 @@ export const addAllergy: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/addHistory/addHistory.ts
+++ b/extensions/elation/actions/addHistory/addHistory.ts
@@ -13,13 +13,7 @@ export const addHistory: Action<typeof elationFields, typeof settings> = {
   fields: elationFields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addHistory')
+    helpers.log({ fields: payload.fields }, 'Processing addHistory')
 
     try {
       const { fields, settings } = validate({
@@ -38,16 +32,13 @@ export const addHistory: Action<typeof elationFields, typeof settings> = {
         text: fields.text,
       }
 
-      helpers.log(
-        { meta, addHistoryInput },
-        '[addHistory] Adding Elation history',
-      )
+      helpers.log({ addHistoryInput }, '[addHistory] Adding Elation history')
 
       await api.addHistory(addHistoryInput)
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/addMessageToThread/addMessageToThread.ts
+++ b/extensions/elation/actions/addMessageToThread/addMessageToThread.ts
@@ -17,16 +17,7 @@ export const addMessageToThread: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing addMessageToThread',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing addMessageToThread')
 
     try {
       const { fields, settings } = validate({
@@ -47,7 +38,7 @@ export const addMessageToThread: Action<
       }
 
       helpers.log(
-        { meta, addMessageToThreadInput },
+        { addMessageToThreadInput },
         '[addMessageToThread] Adding Elation thread message',
       )
 
@@ -59,7 +50,7 @@ export const addMessageToThread: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/addVitals/addVitals.ts
+++ b/extensions/elation/actions/addVitals/addVitals.ts
@@ -48,13 +48,7 @@ export const addVitals: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addVitals')
+    helpers.log({ fields: payload.fields }, 'Processing addVitals')
 
     try {
       const { fields, settings } = validate({
@@ -90,7 +84,7 @@ export const addVitals: Action<
         wc: createMeasurement(fields.wc, fields.wcNote),
       }
 
-      helpers.log({ meta, body }, '[addVitals] Adding Elation vitals')
+      helpers.log({ body }, '[addVitals] Adding Elation vitals')
 
       const { id } = await api.addVitals(body)
 
@@ -100,7 +94,7 @@ export const addVitals: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/cancelAppointments/cancelAppointments.ts
+++ b/extensions/elation/actions/cancelAppointments/cancelAppointments.ts
@@ -24,12 +24,6 @@ export const cancelAppointments: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { prompt, patientId } = FieldsValidationSchema.parse(payload.fields)
     const api = makeAPIClient(payload.settings)
 
@@ -146,7 +140,7 @@ export const cancelAppointments: Action<
             }
 
             helpers.log(
-              { meta, updateData },
+              { updateData },
               '[cancelAppointments] Cancelling Elation appointment',
             )
 

--- a/extensions/elation/actions/checkPatientTags/checkPatientTags.ts
+++ b/extensions/elation/actions/checkPatientTags/checkPatientTags.ts
@@ -29,13 +29,7 @@ export const checkPatientTags: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing checkPatientTags')
+    helpers.log({ fields: payload.fields }, 'Processing checkPatientTags')
 
     try {
       // 1. Validate input and initialize API client
@@ -78,7 +72,7 @@ export const checkPatientTags: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/closeCareGap/closeCareGap.ts
+++ b/extensions/elation/actions/closeCareGap/closeCareGap.ts
@@ -17,12 +17,6 @@ export const closeCareGap: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { quality_program, caregap_id },
@@ -52,14 +46,14 @@ export const closeCareGap: Action<
         status: 'closed' as const,
       }
 
-      helpers.log({ meta, closeCareGapRequest }, 'Closing Elation care gap')
+      helpers.log({ closeCareGapRequest }, 'Closing Elation care gap')
 
       await api.closeCareGap(closeCareGapRequest)
 
       await onComplete()
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/createAppointment.ts
+++ b/extensions/elation/actions/createAppointment.ts
@@ -96,12 +96,6 @@ export const createAppointment: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         scheduledDate,
@@ -124,16 +118,16 @@ export const createAppointment: Action<
 
       // API Call should produce AuthError or something dif.
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, appointment }, 'Creating Elation appointment')
+      helpers.log({ appointment }, 'Creating Elation appointment')
       const { id } = await api.createAppointment(appointment)
-      helpers.log({ meta, appointmentId: id }, 'Created Elation appointment')
+      helpers.log({ appointmentId: id }, 'Created Elation appointment')
       await onComplete({
         data_points: {
           appointmentId: String(id),
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/createCareGap/createCareGap.ts
+++ b/extensions/elation/actions/createCareGap/createCareGap.ts
@@ -17,12 +17,6 @@ export const createCareGap: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: {
@@ -64,11 +58,11 @@ export const createCareGap: Action<
         detail: detail ?? '',
       }
 
-      helpers.log({ meta, createCareGapRequest }, 'Creating Elation care gap')
+      helpers.log({ createCareGapRequest }, 'Creating Elation care gap')
 
       const careGap = await api.createCareGap(createCareGapRequest)
 
-      helpers.log({ meta, careGapId: careGap.id }, 'Created Elation care gap')
+      helpers.log({ careGapId: careGap.id }, 'Created Elation care gap')
 
       await onComplete({
         data_points: {
@@ -77,7 +71,7 @@ export const createCareGap: Action<
       })
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/createLabOrder.ts
+++ b/extensions/elation/actions/createLabOrder.ts
@@ -102,12 +102,6 @@ export const createLabOrder: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patientId,
@@ -132,9 +126,9 @@ export const createLabOrder: Action<
       })
 
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, labOrder }, 'Creating Elation lab order')
+      helpers.log({ labOrder }, 'Creating Elation lab order')
       const { id, printable_view } = await api.createLabOrder(labOrder)
-      helpers.log({ meta, labOrderId: id }, 'Created Elation lab order')
+      helpers.log({ labOrderId: id }, 'Created Elation lab order')
       await onComplete({
         data_points: {
           labOrderId: String(id),
@@ -142,7 +136,7 @@ export const createLabOrder: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/createMessageThread/createMessageThread.ts
+++ b/extensions/elation/actions/createMessageThread/createMessageThread.ts
@@ -19,16 +19,7 @@ export const createMessageThread: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createMessageThread',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createMessageThread')
 
     try {
       const {
@@ -78,7 +69,7 @@ export const createMessageThread: Action<
 
       const api = makeAPIClient(payload.settings)
       helpers.log(
-        { meta, messageThread },
+        { messageThread },
         '[createMessageThread] Creating Elation message thread',
       )
 
@@ -90,7 +81,7 @@ export const createMessageThread: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/createNonVisitNote/createNonVisitNote.ts
+++ b/extensions/elation/actions/createNonVisitNote/createNonVisitNote.ts
@@ -19,12 +19,6 @@ export const createNonVisitNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { patientId, authorId, tags, text, category } =
       FieldsValidationSchema.parse(payload.fields)
 
@@ -51,7 +45,7 @@ export const createNonVisitNote: Action<
 
     try {
       helpers.log(
-        { meta, note },
+        { note },
         '[createNonVisitNote] Creating Elation non-visit note',
       )
 

--- a/extensions/elation/actions/createPatient/createPatient.ts
+++ b/extensions/elation/actions/createPatient/createPatient.ts
@@ -21,13 +21,7 @@ export const createPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createPatient')
+    helpers.log({ fields: payload.fields }, 'Processing createPatient')
 
     try {
       const {
@@ -90,10 +84,7 @@ export const createPatient: Action<
       })
 
       try {
-        helpers.log(
-          { meta, patient },
-          '[createPatient] Creating Elation patient',
-        )
+        helpers.log({ patient }, '[createPatient] Creating Elation patient')
 
         const { data } = await api.createPatient(patient)
 
@@ -122,7 +113,7 @@ export const createPatient: Action<
         throw err
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/createReferralOrder/createReferralOrder.ts
+++ b/extensions/elation/actions/createReferralOrder/createReferralOrder.ts
@@ -23,12 +23,6 @@ export const createReferralOrder: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patient,
@@ -66,7 +60,7 @@ export const createReferralOrder: Action<
       }
 
       helpers.log(
-        { meta, createReferralOrderRequest },
+        { createReferralOrderRequest },
         'Creating Elation referral order',
       )
 
@@ -84,7 +78,7 @@ export const createReferralOrder: Action<
       }
 
       helpers.log(
-        { meta, postLetterRequest },
+        { postLetterRequest },
         'Posting Elation referral order letter',
       )
 
@@ -96,7 +90,7 @@ export const createReferralOrder: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof AxiosError) {
         const responseData = (err as AxiosError).response?.data
         await onError({

--- a/extensions/elation/actions/createVisitNote/createVisitNote.ts
+++ b/extensions/elation/actions/createVisitNote/createVisitNote.ts
@@ -18,13 +18,7 @@ export const createVisitNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createVisitNote')
+    helpers.log({ fields: payload.fields }, 'Processing createVisitNote')
 
     try {
       const { fields, settings } = validate({
@@ -55,7 +49,7 @@ export const createVisitNote: Action<
       }
 
       helpers.log(
-        { meta, createVisitNoteInput },
+        { createVisitNoteInput },
         '[createVisitNote] Creating Elation visit note',
       )
 
@@ -67,7 +61,7 @@ export const createVisitNote: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/deleteNonVisitNote.ts
+++ b/extensions/elation/actions/deleteNonVisitNote.ts
@@ -30,23 +30,17 @@ export const deleteNonVisitNote: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const { nonVisitNoteId } = payload.fields
       const noteId = NumericIdSchema.parse(nonVisitNoteId)
 
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, noteId }, 'Deleting Elation non-visit note')
+      helpers.log({ noteId }, 'Deleting Elation non-visit note')
       await api.deleteNonVisitNote(noteId)
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/findAppointments/findAppointments.ts
+++ b/extensions/elation/actions/findAppointments/findAppointments.ts
@@ -20,13 +20,7 @@ export const findAppointments: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing findAppointment')
+    helpers.log({ fields: payload.fields }, 'Processing findAppointment')
 
     try {
       const { fields, settings } = validate({
@@ -49,7 +43,7 @@ export const findAppointments: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/findFutureAppointment/findFutureAppointment.ts
+++ b/extensions/elation/actions/findFutureAppointment/findFutureAppointment.ts
@@ -26,16 +26,7 @@ export const findFutureAppointment: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing findFutureAppointment',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing findFutureAppointment')
 
     try {
       // 1. Validate input
@@ -141,7 +132,7 @@ export const findFutureAppointment: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/findPhysician.ts
+++ b/extensions/elation/actions/findPhysician.ts
@@ -84,12 +84,6 @@ export const findPhysician: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const { firstName, lastName, npi } = payload.fields
 
@@ -102,13 +96,13 @@ export const findPhysician: Action<
         },
       }
 
-      helpers.log({ meta, findPhysiciansRequest }, 'Finding Elation physicians')
+      helpers.log({ findPhysiciansRequest }, 'Finding Elation physicians')
 
       const physiciansList = await api.findPhysicians(findPhysiciansRequest)
 
       if (physiciansList.count !== 1) {
         helpers.log(
-          { meta, findPhysiciansRequest, count: physiciansList.count },
+          { findPhysiciansRequest, count: physiciansList.count },
           'Elation physician search returned unexpected result count',
         )
         await onError({
@@ -129,17 +123,14 @@ export const findPhysician: Action<
       }
 
       const physician = physiciansList.results[0]
-      helpers.log(
-        { meta, physicianId: physician.id },
-        'Found Elation physician',
-      )
+      helpers.log({ physicianId: physician.id }, 'Found Elation physician')
       await onComplete({
         data_points: {
           physicianId: String(physician.id),
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/getAppointment.ts
+++ b/extensions/elation/actions/getAppointment.ts
@@ -85,20 +85,14 @@ export const getAppointment: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const appointmentId = NumericIdSchema.parse(payload.fields.appointmentId)
 
       // API Call should produce AuthError or something dif.
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, appointmentId }, 'Getting Elation appointment')
+      helpers.log({ appointmentId }, 'Getting Elation appointment')
       const appointment = await api.getAppointment(appointmentId)
-      helpers.log({ meta, appointmentId }, 'Got Elation appointment')
+      helpers.log({ appointmentId }, 'Got Elation appointment')
       await onComplete({
         data_points: {
           scheduledDate: appointment.scheduled_date,
@@ -117,7 +111,7 @@ export const getAppointment: Action<
       })
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/getLetter/getLetter.ts
+++ b/extensions/elation/actions/getLetter/getLetter.ts
@@ -17,20 +17,14 @@ export const getLetter: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const { letterId } = FieldsValidationSchema.parse(payload.fields)
       const api = makeAPIClient(payload.settings)
 
-      helpers.log({ meta, letterId }, 'Getting Elation letter')
+      helpers.log({ letterId }, 'Getting Elation letter')
       const res = await api.getLetter(letterId)
 
-      helpers.log({ meta, letterId }, 'Got Elation letter')
+      helpers.log({ letterId }, 'Got Elation letter')
 
       await onComplete({
         data_points: {
@@ -43,7 +37,7 @@ export const getLetter: Action<
       })
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/getNonVisitNote.ts
+++ b/extensions/elation/actions/getNonVisitNote.ts
@@ -69,23 +69,17 @@ export const getNonVisitNote: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const { nonVisitNoteId } = payload.fields
       const noteId = NumericIdSchema.parse(nonVisitNoteId)
 
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, noteId }, 'Getting Elation non-visit note')
+      helpers.log({ noteId }, 'Getting Elation non-visit note')
       const { bullets, chart_date, document_date, patient, practice, tags } =
         await api.getNonVisitNote(noteId)
 
       helpers.log(
-        { meta, noteId, patient, practice, document_date, chart_date },
+        { noteId, patient, practice, document_date, chart_date },
         'Got Elation non-visit note',
       )
 
@@ -105,7 +99,7 @@ export const getNonVisitNote: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/getPatient/getPatient.ts
+++ b/extensions/elation/actions/getPatient/getPatient.ts
@@ -19,13 +19,7 @@ export const getPatient: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       const fields = FieldsValidationSchema.parse(payload.fields)
@@ -70,7 +64,7 @@ export const getPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/getPharmacy/getPharmacy.ts
+++ b/extensions/elation/actions/getPharmacy/getPharmacy.ts
@@ -19,13 +19,7 @@ export const getPharmacy: Action<typeof elationFields, typeof settings> = {
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPharmacy')
+    helpers.log({ fields: payload.fields }, 'Processing getPharmacy')
 
     try {
       const { fields, settings } = validate({
@@ -53,7 +47,7 @@ export const getPharmacy: Action<typeof elationFields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/getPhysician/getPhysician.ts
+++ b/extensions/elation/actions/getPhysician/getPhysician.ts
@@ -20,24 +20,18 @@ export const getPhysician: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const validatedFields = FieldsValidationSchema.parse(payload.fields)
 
       const api = makeAPIClient(payload.settings)
       helpers.log(
-        { meta, physicianId: validatedFields.physicianId },
+        { physicianId: validatedFields.physicianId },
         'Getting Elation physician',
       )
       const physician = await api.getPhysician(validatedFields.physicianId)
 
       helpers.log(
-        { meta, physicianId: validatedFields.physicianId },
+        { physicianId: validatedFields.physicianId },
         'Got Elation physician',
       )
 
@@ -53,7 +47,7 @@ export const getPhysician: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/getReferralOrder/getReferralOrder.ts
+++ b/extensions/elation/actions/getReferralOrder/getReferralOrder.ts
@@ -17,13 +17,7 @@ export const getReferralOrder: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getReferralOrder')
+    helpers.log({ fields: payload.fields }, 'Processing getReferralOrder')
 
     try {
       const { referralOrderId } = FieldsValidationSchema.parse(payload.fields)
@@ -46,7 +40,7 @@ export const getReferralOrder: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/postLetter.ts
+++ b/extensions/elation/actions/postLetter.ts
@@ -86,12 +86,6 @@ export const postLetter: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patientId,
@@ -132,17 +126,17 @@ export const postLetter: Action<
         },
       })
 
-      helpers.log({ meta, letter }, 'Posting Elation letter')
+      helpers.log({ letter }, 'Posting Elation letter')
 
       const { id } = await api.postNewLetter(letter)
-      helpers.log({ meta, letterId: id }, 'Posted Elation letter')
+      helpers.log({ letterId: id }, 'Posted Elation letter')
       await onComplete({
         data_points: {
           letterId: String(id),
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/elation/actions/signNonVisitNote/signNonVisitNote.ts
+++ b/extensions/elation/actions/signNonVisitNote/signNonVisitNote.ts
@@ -18,12 +18,6 @@ export const signNonVisitNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { nonVisitNoteId, signedBy } = FieldsValidationSchema.parse(
       payload.fields,
     )
@@ -34,7 +28,7 @@ export const signNonVisitNote: Action<
 
     try {
       helpers.log(
-        { meta, signNonVisitNoteInput },
+        { signNonVisitNoteInput },
         '[signNonVisitNote] Signing Elation non-visit note',
       )
 

--- a/extensions/elation/actions/signVisitNote/signVisitNote.ts
+++ b/extensions/elation/actions/signVisitNote/signVisitNote.ts
@@ -18,12 +18,6 @@ export const signVisitNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { visitNoteId, signedBy } = FieldsValidationSchema.parse(
       payload.fields,
     )
@@ -34,7 +28,7 @@ export const signVisitNote: Action<
 
     try {
       helpers.log(
-        { meta, signVisitNoteInput },
+        { signVisitNoteInput },
         '[signVisitNote] Signing Elation visit note',
       )
 

--- a/extensions/elation/actions/updateNonVisitNote.ts
+++ b/extensions/elation/actions/updateNonVisitNote.ts
@@ -106,12 +106,6 @@ export const updateNonVisitNote: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         nonVisitNoteId,
@@ -144,12 +138,12 @@ export const updateNonVisitNote: Action<typeof fields, typeof settings> = {
       })
 
       const api = makeAPIClient(payload.settings)
-      helpers.log({ meta, noteId, note }, 'Updating Elation non-visit note')
+      helpers.log({ noteId, note }, 'Updating Elation non-visit note')
       await api.updateNonVisitNote(noteId, note)
       await onComplete()
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/updatePatient.ts
+++ b/extensions/elation/actions/updatePatient.ts
@@ -176,12 +176,6 @@ export const updatePatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patientId,
@@ -256,7 +250,7 @@ export const updatePatient: Action<
       }
 
       helpers.log(
-        { meta, patientId: id, updatedPatientFields },
+        { patientId: id, updatedPatientFields },
         'Updating Elation patient',
       )
 
@@ -264,7 +258,7 @@ export const updatePatient: Action<
       await onComplete()
     } catch (err) {
       const message = (err as Error).message
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await onError({
         events: [
           {

--- a/extensions/elation/actions/updatePatientTags/updatePatientTags.ts
+++ b/extensions/elation/actions/updatePatientTags/updatePatientTags.ts
@@ -28,16 +28,7 @@ export const updatePatientTags: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing updatePatientTags',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing updatePatientTags')
 
     try {
       // 1. Validate input and initialize API client
@@ -74,7 +65,7 @@ export const updatePatientTags: Action<
       }
 
       helpers.log(
-        { meta, updatePatientTagsInput },
+        { updatePatientTagsInput },
         '[updatePatientTags] Updating Elation patient tags',
       )
 
@@ -93,7 +84,7 @@ export const updatePatientTags: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/elation/actions/updateReferralOrderResolution/updateReferralOrderResolution.ts
+++ b/extensions/elation/actions/updateReferralOrderResolution/updateReferralOrderResolution.ts
@@ -18,12 +18,6 @@ export const updateReferralOrderResolution: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { referralOrderId, resolutionState, resolvingDocument } =
       FieldsValidationSchema.parse(payload.fields)
     const api = makeAPIClient(payload.settings)
@@ -36,7 +30,7 @@ export const updateReferralOrderResolution: Action<
 
     try {
       helpers.log(
-        { meta, updateReferralOrderInput },
+        { updateReferralOrderInput },
         '[updateReferralOrderResolution] Updating Elation referral order',
       )
 

--- a/extensions/epic/actions/createClinicalNote/createClinicalNote.ts
+++ b/extensions/epic/actions/createClinicalNote/createClinicalNote.ts
@@ -20,11 +20,6 @@ export const createClinicalNote: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
     const {
       epicFhirR4Sdk,
       fields: { patientResourceId, encounterResourceId, status, type, note },
@@ -68,7 +63,7 @@ export const createClinicalNote: Action<
 
     try {
       helpers.log(
-        { meta, DocumentReferenceInput },
+        { DocumentReferenceInput },
         '[createClinicalNote] Creating Epic document reference',
       )
 

--- a/extensions/epic/actions/createPatient/createPatient.ts
+++ b/extensions/epic/actions/createPatient/createPatient.ts
@@ -20,11 +20,6 @@ export const createPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
     const {
       epicFhirR4Sdk,
       fields: { familyName, givenName, email, gender, birthDate, ssn },
@@ -62,10 +57,7 @@ export const createPatient: Action<
     } satisfies Patient
 
     try {
-      helpers.log(
-        { meta, PatientResource },
-        '[createPatient] Creating Epic patient',
-      )
+      helpers.log({ PatientResource }, '[createPatient] Creating Epic patient')
 
       const res = await epicFhirR4Sdk.createPatient(PatientResource)
       const resourceReference =

--- a/extensions/external-server/v1/actions/mtls.ts
+++ b/extensions/external-server/v1/actions/mtls.ts
@@ -56,16 +56,12 @@ export const mtls: Action<
     }
     const { fields, settings } = PayloadSchema.parse(payload)
     const clientPayload = fields.payload ?? {}
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-    helpers.log({ meta, fields: payload.fields }, 'Processing response')
+
+    helpers.log({ fields: payload.fields }, 'Processing response')
 
     try {
       const requestBody = { data: clientPayload }
-      helpers.log({ meta, requestBody }, 'Sending mTLS request')
+      helpers.log({ requestBody }, 'Sending mTLS request')
       const { data, status } = await axios.post<{
         data_points: any
         events: any
@@ -82,7 +78,7 @@ export const mtls: Action<
         throw new Error(`Error: ${JSON.stringify(data)}`)
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/freshdesk/actions/addNoteToTicket/addNoteToTicket.ts
+++ b/extensions/freshdesk/actions/addNoteToTicket/addNoteToTicket.ts
@@ -19,12 +19,6 @@ export const addNoteToTicket: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { fields, freshdeskSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -42,7 +36,7 @@ export const addNoteToTicket: Action<
         },
       }
 
-      helpers.log({ meta, addNoteInput }, 'Adding note to Freshdesk ticket')
+      helpers.log({ addNoteInput }, 'Adding note to Freshdesk ticket')
       await freshdeskSdk.addNote(addNoteInput)
 
       await onComplete()

--- a/extensions/freshdesk/actions/getContact/getContact.ts
+++ b/extensions/freshdesk/actions/getContact/getContact.ts
@@ -20,12 +20,6 @@ export const getContact: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { fields, freshdeskSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -33,7 +27,7 @@ export const getContact: Action<
 
     try {
       const { data } = await freshdeskSdk.getContact(fields.contactId)
-      helpers.log({ meta, data }, 'data')
+      helpers.log({ data }, 'data')
 
       await onComplete({
         data_points: {

--- a/extensions/freshdesk/actions/updateTicket/updateTicket.ts
+++ b/extensions/freshdesk/actions/updateTicket/updateTicket.ts
@@ -19,12 +19,6 @@ export const updateTicket: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { fields, freshdeskSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -49,7 +43,7 @@ export const updateTicket: Action<
         input: requestBody,
       }
 
-      helpers.log({ meta, updateTicketInput }, 'Updating Freshdesk ticket')
+      helpers.log({ updateTicketInput }, 'Updating Freshdesk ticket')
       await freshdeskSdk.updateTicket(updateTicketInput)
 
       await onComplete({

--- a/extensions/gridspace/actions/callWithGrace/callWithGrace.ts
+++ b/extensions/gridspace/actions/callWithGrace/callWithGrace.ts
@@ -13,13 +13,7 @@ export const callWithGrace = {
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing callWithGrace')
+    helpers.log({ fields: payload.fields }, 'Processing callWithGrace')
 
     try {
       const { pathway, patient } = payload
@@ -40,7 +34,7 @@ export const callWithGrace = {
         pathway_definition_id: pathway.definition_id,
         activity_id: payload.activity.id,
       }
-      helpers.log({ meta, allData }, 'Calling with Grace via Gridspace')
+      helpers.log({ allData }, 'Calling with Grace via Gridspace')
       const resp = await client.callWithGrace(flowId, allData)
       await onComplete({
         events: [
@@ -52,7 +46,7 @@ export const callWithGrace = {
         data_points: {},
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
+++ b/extensions/gridspace/actions/uploadContactToCampaign/uploadContactToCampaign.ts
@@ -14,14 +14,8 @@ export const uploadContactToCampaign = {
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing uploadContactToCampaign',
     )
 
@@ -56,7 +50,7 @@ export const uploadContactToCampaign = {
         service_terms_reviewed: serviceTermsReviewed,
       }
 
-      helpers.log({ meta, requestBody }, 'Uploading contact via Gridspace')
+      helpers.log({ requestBody }, 'Uploading contact via Gridspace')
       const { num_uploaded_contacts = 0 } =
         await client.uploadContactsToCampaign(campaignId, requestBody)
 
@@ -77,7 +71,7 @@ export const uploadContactToCampaign = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/healthie/actions/applyTagToPatient/applyTagToPatient.ts
+++ b/extensions/healthie/actions/applyTagToPatient/applyTagToPatient.ts
@@ -18,16 +18,7 @@ export const applyTagToPatient: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing applyTagToPatient',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing applyTagToPatient')
 
     const { fields, settings } = payload
     const { id, patient_id } = fields
@@ -77,7 +68,7 @@ export const applyTagToPatient: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/archivePatient/archivePatient.ts
+++ b/extensions/healthie/actions/archivePatient/archivePatient.ts
@@ -18,13 +18,7 @@ export const archivePatient: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing archivePatient')
+    helpers.log({ fields: payload.fields }, 'Processing archivePatient')
 
     const { fields, settings } = payload
     const { id } = fields
@@ -71,7 +65,7 @@ export const archivePatient: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/assignPatientToGroup/assignPatientToGroup.ts
+++ b/extensions/healthie/actions/assignPatientToGroup/assignPatientToGroup.ts
@@ -18,16 +18,7 @@ export const assignPatientToGroup: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing assignPatientToGroup',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing assignPatientToGroup')
 
     const { fields, settings } = payload
     const { id, groupId } = fields
@@ -75,7 +66,7 @@ export const assignPatientToGroup: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/cancelAppointment/cancelAppointment.ts
+++ b/extensions/healthie/actions/cancelAppointment/cancelAppointment.ts
@@ -18,16 +18,7 @@ export const cancelAppointment: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing cancelAppointment',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing cancelAppointment')
 
     const { fields, settings } = payload
     const { id } = fields
@@ -74,7 +65,7 @@ export const cancelAppointment: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/checkPatientTag/checkPatientTag.ts
+++ b/extensions/healthie/actions/checkPatientTag/checkPatientTag.ts
@@ -23,13 +23,7 @@ export const checkPatientTag: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing checkPatientTag')
+    helpers.log({ fields: payload.fields }, 'Processing checkPatientTag')
 
     const { fields, settings } = payload
     const { id, patientId } = fields
@@ -60,7 +54,7 @@ export const checkPatientTag: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/checkScheduledAppointments/checkScheduledAppointments.ts
+++ b/extensions/healthie/actions/checkScheduledAppointments/checkScheduledAppointments.ts
@@ -23,14 +23,8 @@ export const checkScheduledAppointments: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing checkScheduledAppointments',
     )
 
@@ -66,7 +60,7 @@ export const checkScheduledAppointments: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/closeChatConversation/closeChatConversation.ts
+++ b/extensions/healthie/actions/closeChatConversation/closeChatConversation.ts
@@ -18,16 +18,7 @@ export const closeChatConversation: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing closeChatConversation',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing closeChatConversation')
 
     const { fields, settings } = payload
     const { id, provider_id } = fields
@@ -74,7 +65,7 @@ export const closeChatConversation: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/completeTask/completeTask.ts
+++ b/extensions/healthie/actions/completeTask/completeTask.ts
@@ -18,13 +18,7 @@ export const completeTask: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing completeTask')
+    helpers.log({ fields: payload.fields }, 'Processing completeTask')
 
     const { fields, settings } = payload
     const { id } = fields
@@ -68,7 +62,7 @@ export const completeTask: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/createAppointment/createAppointment.ts
+++ b/extensions/healthie/actions/createAppointment/createAppointment.ts
@@ -29,11 +29,6 @@ export const createAppointment: Action<
       fieldsSchema: FieldsValidationSchema,
       payload,
     })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     try {
       const createAppointmentInput = {
@@ -48,7 +43,7 @@ export const createAppointment: Action<
       }
 
       helpers.log(
-        { meta, createAppointmentInput },
+        { createAppointmentInput },
         '[createAppointment] Creating Healthie appointment',
       )
 

--- a/extensions/healthie/actions/createChartingNote/createChartingNote.ts
+++ b/extensions/healthie/actions/createChartingNote/createChartingNote.ts
@@ -19,16 +19,7 @@ export const createChartingNote: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createChartingNote',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createChartingNote')
 
     const { fields, settings } = payload
     const {
@@ -162,7 +153,7 @@ export const createChartingNote: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/createGoal/createGoal.ts
+++ b/extensions/healthie/actions/createGoal/createGoal.ts
@@ -13,13 +13,7 @@ export const createGoal: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createGoal')
+    helpers.log({ fields: payload.fields }, 'Processing createGoal')
 
     try {
       const { fields, healthieSdk } = await validatePayloadAndCreateSdk({
@@ -52,7 +46,7 @@ export const createGoal: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/healthie/actions/createJournalEntry/createJournalEntry.ts
+++ b/extensions/healthie/actions/createJournalEntry/createJournalEntry.ts
@@ -23,16 +23,7 @@ export const createJournalEntry: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createJournalEntry',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createJournalEntry')
 
     const { fields, settings } = payload
     const { id, type, percieved_hungriness } = fields
@@ -86,7 +77,7 @@ export const createJournalEntry: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/createLocation/createLocation.ts
+++ b/extensions/healthie/actions/createLocation/createLocation.ts
@@ -23,13 +23,7 @@ export const createLocation: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createLocation')
+    helpers.log({ fields: payload.fields }, 'Processing createLocation')
 
     const { fields, settings } = payload
     const { id, name, country, state, city, zip, line1, line2 } = fields
@@ -88,7 +82,7 @@ export const createLocation: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/createMetricEntry/createMetricEntry.ts
+++ b/extensions/healthie/actions/createMetricEntry/createMetricEntry.ts
@@ -19,16 +19,7 @@ export const createMetricEntry: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createMetricEntry',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createMetricEntry')
 
     try {
       const {
@@ -54,7 +45,7 @@ export const createMetricEntry: Action<typeof fields, typeof settings> = {
         await onComplete({})
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/healthie/actions/createPatient/createPatient.ts
+++ b/extensions/healthie/actions/createPatient/createPatient.ts
@@ -30,11 +30,6 @@ export const createPatient: Action<
       fieldsSchema: FieldsValidationSchema,
       payload,
     })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const dont_send_welcome = fields.send_invite !== true
     const dietitian_id =
@@ -59,7 +54,7 @@ export const createPatient: Action<
       }
 
       helpers.log(
-        { meta, createClientInput },
+        { createClientInput },
         '[createPatient] Creating Healthie client',
       )
 

--- a/extensions/healthie/actions/createTask/createTask.ts
+++ b/extensions/healthie/actions/createTask/createTask.ts
@@ -23,13 +23,7 @@ export const createTask: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTask')
+    helpers.log({ fields: payload.fields }, 'Processing createTask')
 
     const { fields, settings } = payload
 
@@ -56,7 +50,7 @@ export const createTask: Action<
         throw new Error('API Client is missing settings (api url or api key)')
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponseToHealthie/pushFormResponseToHealthie.ts
@@ -32,11 +32,6 @@ export const pushFormResponseToHealthie: Action<
         fieldsSchema: FieldsValidationSchema,
         payload,
       })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const awellSdk = await helpers.awellSdk()
 
@@ -80,7 +75,7 @@ export const pushFormResponseToHealthie: Action<
       }
 
       helpers.log(
-        { meta, createFormAnswerGroupInput },
+        { createFormAnswerGroupInput },
         '[pushFormResponseToHealthie] Creating Healthie form answer group',
       )
 
@@ -107,7 +102,7 @@ export const pushFormResponseToHealthie: Action<
         }
 
         helpers.log(
-          { meta, lockFormAnswerGroupInput },
+          { lockFormAnswerGroupInput },
           '[pushFormResponseToHealthie] Locking Healthie form answer group',
         )
 

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.test.ts
@@ -114,14 +114,9 @@ describe('pushFormResponsesToHealthie', () => {
      * two calls to GetFormResponse each form has a response
      */
     expect(awellSdkMock.orchestration.query).toHaveBeenCalledTimes(6)
-    const expectedMeta = {
-      tenant_id: '123',
-      careflow_id: '5eN4qWbxZGSA',
-      activity_id: 'X74HeDQ4N0gtdaSEuzF8s',
-    }
+
     expect(helpers.log).toHaveBeenCalledWith(
       expect.objectContaining({
-        meta: expectedMeta,
         status: mockCareflowActivitiesResponse.activities[0].status,
       }),
       '[getAllFormsInCurrentStep] Fetched current activity',
@@ -129,7 +124,6 @@ describe('pushFormResponsesToHealthie', () => {
     )
     expect(helpers.log).toHaveBeenCalledWith(
       expect.objectContaining({
-        meta: expectedMeta,
         formsData: expect.any(Array),
       }),
       '[pushFormResponsesToHealthie] Forms data',

--- a/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
+++ b/extensions/healthie/actions/dataExchange/pushFormResponsesToHealthie/pushFormResponsesToHealthie.ts
@@ -36,17 +36,13 @@ export const pushFormResponsesToHealthie: Action<
         fieldsSchema: FieldsValidationSchema,
         payload,
       })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
+
     const log = (
       data: Record<string, unknown>,
       message: string,
       error?: Error,
     ): void => {
-      helpers.log({ ...data, meta }, message, error)
+      helpers.log({ ...data }, message, error)
     }
 
     const awellSdk = await helpers.awellSdk()
@@ -64,7 +60,6 @@ export const pushFormResponsesToHealthie: Action<
 
     helpers.log(
       {
-        meta,
         formsData,
       },
       '[pushFormResponsesToHealthie] Forms data',
@@ -73,7 +68,6 @@ export const pushFormResponsesToHealthie: Action<
     const formDataWithHealthieFormAnswers = formsData.map((formData) => {
       helpers.log(
         {
-          meta,
           formActivityId: formData.formActivityId,
           formId: formData.formId,
         },
@@ -101,7 +95,6 @@ export const pushFormResponsesToHealthie: Action<
 
     helpers.log(
       {
-        meta,
         mergedHealthieFormAnswers,
         mergedOmittedFormAnswers,
       },
@@ -113,7 +106,6 @@ export const pushFormResponsesToHealthie: Action<
 
     helpers.log(
       {
-        meta,
         lock,
       },
       '[pushFormResponsesToHealthie] Indicates whether to make form values editable in Healthie',
@@ -130,7 +122,6 @@ export const pushFormResponsesToHealthie: Action<
 
     helpers.log(
       {
-        meta,
         healthieFormAnswersLog,
       },
       '[pushFormResponsesToHealthie] Healthie form answers log',
@@ -148,7 +139,7 @@ export const pushFormResponsesToHealthie: Action<
       }
 
       helpers.log(
-        { meta, createFormAnswerGroupInput },
+        { createFormAnswerGroupInput },
         '[pushFormResponsesToHealthie] Creating Healthie form answer group',
       )
 
@@ -168,7 +159,6 @@ export const pushFormResponsesToHealthie: Action<
       if (isEmpty(formAnswerGroupId)) {
         helpers.log(
           {
-            meta,
             formAnswerGroupId,
           },
           '[pushFormResponsesToHealthie] Form answer group ID is empty',
@@ -183,7 +173,7 @@ export const pushFormResponsesToHealthie: Action<
         }
 
         helpers.log(
-          { meta, lockFormAnswerGroupInput },
+          { lockFormAnswerGroupInput },
           '[pushFormResponsesToHealthie] Locking Healthie form answer group',
         )
 
@@ -206,7 +196,7 @@ export const pushFormResponsesToHealthie: Action<
       })
     } catch (error) {
       helpers.log(
-        { meta, error },
+        { error },
         '[pushFormResponsesToHealthie] Error when pushing form responses to Healthie',
       )
       if (error instanceof HealthieError) {

--- a/extensions/healthie/actions/deleteAppointment/deleteAppointment.ts
+++ b/extensions/healthie/actions/deleteAppointment/deleteAppointment.ts
@@ -18,16 +18,7 @@ export const deleteAppointment: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing deleteAppointment',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing deleteAppointment')
 
     const { fields, settings } = payload
     const { id } = fields
@@ -71,7 +62,7 @@ export const deleteAppointment: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/deleteGoal/deleteGoal.ts
+++ b/extensions/healthie/actions/deleteGoal/deleteGoal.ts
@@ -13,13 +13,7 @@ export const deleteGoal: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deleteGoal')
+    helpers.log({ fields: payload.fields }, 'Processing deleteGoal')
 
     try {
       const { fields, healthieSdk } = await validatePayloadAndCreateSdk({
@@ -42,7 +36,7 @@ export const deleteGoal: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/healthie/actions/deleteTask/deleteTask.ts
+++ b/extensions/healthie/actions/deleteTask/deleteTask.ts
@@ -18,13 +18,7 @@ export const deleteTask: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deleteTask')
+    helpers.log({ fields: payload.fields }, 'Processing deleteTask')
 
     const { fields, settings } = payload
     const { id } = fields
@@ -68,7 +62,7 @@ export const deleteTask: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/getAppointment/getAppointment.ts
+++ b/extensions/healthie/actions/getAppointment/getAppointment.ts
@@ -23,13 +23,7 @@ export const getAppointment: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getAppointment')
+    helpers.log({ fields: payload.fields }, 'Processing getAppointment')
 
     const { fields, settings } = payload
     const { appointmentId } = fields
@@ -66,7 +60,7 @@ export const getAppointment: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/getFormAnswers/getFormAnswers.ts
+++ b/extensions/healthie/actions/getFormAnswers/getFormAnswers.ts
@@ -14,13 +14,7 @@ export const getFormAnswers: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getFormAnswers')
+    helpers.log({ fields: payload.fields }, 'Processing getFormAnswers')
 
     const {
       fields: input,
@@ -54,7 +48,7 @@ export const getFormAnswers: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       await onError({
         events: [
           {

--- a/extensions/healthie/actions/getMetricEntry/getMetricEntry.ts
+++ b/extensions/healthie/actions/getMetricEntry/getMetricEntry.ts
@@ -26,13 +26,7 @@ export const getMetricEntry: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getMetricEntry')
+    helpers.log({ fields: payload.fields }, 'Processing getMetricEntry')
 
     try {
       const {
@@ -75,7 +69,7 @@ export const getMetricEntry: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/healthie/actions/getPatient/getPatient.ts
+++ b/extensions/healthie/actions/getPatient/getPatient.ts
@@ -24,13 +24,7 @@ export const getPatient: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     const { fields, settings } = payload
     const { patientId } = fields
@@ -74,7 +68,7 @@ export const getPatient: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.ts
+++ b/extensions/healthie/actions/getSetPasswordLink/getSetPasswordLink.ts
@@ -14,16 +14,7 @@ export const getSetPasswordLink: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getSetPasswordLink',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getSetPasswordLink')
 
     try {
       const MAX_RETRIES = 3
@@ -70,7 +61,7 @@ export const getSetPasswordLink: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/healthie/actions/lockFormAnswer/lockFormAnswerGroup.ts
+++ b/extensions/healthie/actions/lockFormAnswer/lockFormAnswerGroup.ts
@@ -14,16 +14,7 @@ export const lockFormAnswerGroup: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing lockFormAnswerGroup',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing lockFormAnswerGroup')
 
     try {
       const { fields, healthieSdk } = await validatePayloadAndCreateSdk({
@@ -46,7 +37,7 @@ export const lockFormAnswerGroup: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/healthie/actions/removeTagFromPatient/removeTagFromPatient.ts
+++ b/extensions/healthie/actions/removeTagFromPatient/removeTagFromPatient.ts
@@ -18,16 +18,7 @@ export const removeTagFromPatient: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing removeTagFromPatient',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing removeTagFromPatient')
 
     const { fields, settings } = payload
     const { id, patient_id } = fields
@@ -72,7 +63,7 @@ export const removeTagFromPatient: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/sendChatMessage/sendChatMessage.ts
+++ b/extensions/healthie/actions/sendChatMessage/sendChatMessage.ts
@@ -25,13 +25,7 @@ export const sendChatMessage: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendChatMessage')
+    helpers.log({ fields: payload.fields }, 'Processing sendChatMessage')
 
     const { fields, settings } = payload
     const { healthie_patient_id, provider_id, message } = fields
@@ -210,7 +204,7 @@ export const sendChatMessage: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof HealthieError) {
         const errors = mapHealthieToActivityError(err.errors)
         await onError({

--- a/extensions/healthie/actions/sendFormCompletionRequest/sendFormCompletionRequest.ts
+++ b/extensions/healthie/actions/sendFormCompletionRequest/sendFormCompletionRequest.ts
@@ -25,14 +25,8 @@ export const sendFormCompletionRequest: Action<typeof fields, typeof settings> =
       onError,
       helpers,
     }): Promise<void> => {
-      const meta = {
-        tenant_id: payload.pathway.tenant_id,
-        careflow_id: payload.pathway.id,
-        activity_id: payload.activity.id,
-      }
-
       helpers.log(
-        { meta, fields: payload.fields },
+        { fields: payload.fields },
         'Processing sendFormCompletionRequest',
       )
 
@@ -93,7 +87,7 @@ export const sendFormCompletionRequest: Action<typeof fields, typeof settings> =
           })
         }
       } catch (err) {
-        helpers.log({ meta, err }, 'error', err as Error)
+        helpers.log({ err }, 'error', err as Error)
         if (err instanceof HealthieError) {
           const errors = mapHealthieToActivityError(err.errors)
           await onError({

--- a/extensions/healthie/actions/updatePatient/updatePatient.ts
+++ b/extensions/healthie/actions/updatePatient/updatePatient.ts
@@ -18,12 +18,6 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const { fields, healthieSdk } = await validatePayloadAndCreateSdk({
         fieldsSchema: FieldsValidationSchema,
@@ -56,7 +50,7 @@ export const updatePatient: Action<typeof fields, typeof settings> = {
       }
 
       helpers.log(
-        { meta, updateClientInput },
+        { updateClientInput },
         '[updatePatient] Updating Healthie client',
       )
 

--- a/extensions/healthie/actions/updatePatientQuickNote/updatePatientQuickNote.ts
+++ b/extensions/healthie/actions/updatePatientQuickNote/updatePatientQuickNote.ts
@@ -19,16 +19,7 @@ export const updatePatientQuickNote: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing updatePatientQuickNote',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing updatePatientQuickNote')
 
     try {
       const {
@@ -63,7 +54,7 @@ export const updatePatientQuickNote: Action<typeof fields, typeof settings> = {
         await onComplete({})
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/hello-world/actions/frontend.ts
+++ b/extensions/hello-world/actions/frontend.ts
@@ -42,12 +42,6 @@ export const frontend: Action<
   },
   dataPoints,
   onEvent: async ({ payload, helpers: { log } }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    log({ meta, payload }, 'Frontend payload')
+    log({ payload }, 'Frontend payload')
   },
 }

--- a/extensions/hello-world/actions/log.ts
+++ b/extensions/hello-world/actions/log.ts
@@ -58,13 +58,7 @@ export const log: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing world')
+    helpers.log({ fields: payload.fields }, 'Processing world')
 
     try {
       const { fields, settings } = payload
@@ -76,7 +70,7 @@ export const log: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/hello-world/actions/log_two.ts
+++ b/extensions/hello-world/actions/log_two.ts
@@ -36,13 +36,7 @@ export const logTwo: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing world')
+    helpers.log({ fields: payload.fields }, 'Processing world')
 
     try {
       const { fields } = payload
@@ -52,7 +46,7 @@ export const logTwo: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/hubspot/actions/createOrUpdateContact/createOrUpdateContact.ts
+++ b/extensions/hubspot/actions/createOrUpdateContact/createOrUpdateContact.ts
@@ -25,12 +25,6 @@ export const createOrUpdateContact: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const eventLogs: ActivityEvent[] = []
 
     const { hubSpotSdk, fields } = await validatePayloadAndCreateSdks({
@@ -72,7 +66,7 @@ export const createOrUpdateContact: Action<
           properties: createOrUpdateProperties,
         }
 
-        helpers.log({ meta, updateContactInput }, 'Updating HubSpot contact')
+        helpers.log({ updateContactInput }, 'Updating HubSpot contact')
         const updatedContact = await hubSpotSdk.crm.contacts.basicApi.update(
           existingContact.id,
           updateContactInput,
@@ -105,7 +99,7 @@ export const createOrUpdateContact: Action<
         properties: createOrUpdateProperties,
       }
 
-      helpers.log({ meta, createContactInput }, 'Creating HubSpot contact')
+      helpers.log({ createContactInput }, 'Creating HubSpot contact')
       const newContact =
         await hubSpotSdk.crm.contacts.basicApi.create(createContactInput)
 

--- a/extensions/hubspot/actions/getContact/getContact.ts
+++ b/extensions/hubspot/actions/getContact/getContact.ts
@@ -16,13 +16,7 @@ export const getcontact: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getcontact')
+    helpers.log({ fields: payload.fields }, 'Processing getcontact')
 
     try {
       const { hubSpotSdk, fields } = await validatePayloadAndCreateSdks({
@@ -42,7 +36,7 @@ export const getcontact: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/hubspot/actions/sendEmailWithSingleSendApi/sendEmailWithSingleSendApi.ts
+++ b/extensions/hubspot/actions/sendEmailWithSingleSendApi/sendEmailWithSingleSendApi.ts
@@ -16,14 +16,8 @@ export const sendEmailWithSingleSendApi: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing sendEmailWithSingleSendApi',
     )
 
@@ -45,10 +39,7 @@ export const sendEmailWithSingleSendApi: Action<
         customProperties: fields.customProperties,
       }
 
-      helpers.log(
-        { meta, requestBody },
-        'Sending email via HubSpot Single Send API',
-      )
+      helpers.log({ requestBody }, 'Sending email via HubSpot Single Send API')
       const res =
         await hubSpotSdk.marketing.transactional.singleSendApi.sendEmail(
           requestBody,
@@ -60,7 +51,7 @@ export const sendEmailWithSingleSendApi: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/hubspot/actions/sendEmailWithSmtp/sendEmailWithSmtp.ts
+++ b/extensions/hubspot/actions/sendEmailWithSmtp/sendEmailWithSmtp.ts
@@ -16,16 +16,7 @@ export const sendEmailWithSmtp: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendEmailWithSmtp',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendEmailWithSmtp')
 
     try {
       const { hubSpotSmtpSdk, fields } = await validatePayloadAndCreateSdks({
@@ -38,12 +29,12 @@ export const sendEmailWithSmtp: Action<
           'Could not instantiate SMTP client. Make sure the SMTP username and password are provided and valid.',
         )
 
-      helpers.log({ meta, fields }, 'Sending email via HubSpot SMTP')
+      helpers.log({ fields }, 'Sending email via HubSpot SMTP')
       await hubSpotSmtpSdk.sendEmail(fields)
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/identityVerification/actions/dobCheck/dobCheck.ts
+++ b/extensions/identityVerification/actions/dobCheck/dobCheck.ts
@@ -23,13 +23,7 @@ export const dobCheck: Action<
     },
   },
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing dobCheck')
+    helpers.log({ fields: payload.fields }, 'Processing dobCheck')
 
     try {
       validate({
@@ -44,7 +38,7 @@ export const dobCheck: Action<
        * Completion happens in Awell Hosted Pages
        */
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/infobip/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/infobip/v1/actions/sendEmail/sendEmail.ts
@@ -14,13 +14,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendEmail')
+    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
 
     try {
       const {
@@ -59,7 +53,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (isInfobipError(err)) {
         const events = infobipErrorToActivityEvent(err)
         await onError({ events })

--- a/extensions/infobip/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
+++ b/extensions/infobip/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
@@ -13,16 +13,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendEmailWithTemplate',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendEmailWithTemplate')
 
     try {
       const {
@@ -47,7 +38,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (isInfobipError(err)) {
         const events = infobipErrorToActivityEvent(err)
         await onError({ events })

--- a/extensions/infobip/v1/actions/sendSms/sendSms.ts
+++ b/extensions/infobip/v1/actions/sendSms/sendSms.ts
@@ -14,13 +14,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     try {
       const {
@@ -62,7 +56,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (isInfobipError(err)) {
         const events = infobipErrorToActivityEvent(err)
         await onError({ events })

--- a/extensions/iterable/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/iterable/v1/actions/sendEmail/sendEmail.ts
@@ -14,13 +14,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendEmail')
+    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
 
     try {
       const {
@@ -56,7 +50,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/iterable/v1/actions/trackEvent/trackEvent.ts
+++ b/extensions/iterable/v1/actions/trackEvent/trackEvent.ts
@@ -14,13 +14,7 @@ export const trackEvent: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing trackEvent')
+    helpers.log({ fields: payload.fields }, 'Processing trackEvent')
 
     try {
       const {
@@ -47,7 +41,7 @@ export const trackEvent: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/landingAi/actions/documentExtraction/documentExtraction.ts
+++ b/extensions/landingAi/actions/documentExtraction/documentExtraction.ts
@@ -19,12 +19,6 @@ export const documentExtraction: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { fields, landingAiSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -46,7 +40,7 @@ export const documentExtraction: Action<
     }
 
     helpers.log(
-      { meta, documentAnalysisRequest },
+      { documentAnalysisRequest },
       'Running LandingAI document extraction',
     )
     const { data } = await landingAiSdk.agenticDocumentAnalysis(

--- a/extensions/mailchimp/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/mailchimp/v1/actions/sendEmail/sendEmail.ts
@@ -15,12 +15,6 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patient: { id: patientId },
@@ -55,14 +49,14 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Sending email via Mailchimp')
+      helpers.log({ requestBody }, 'Sending email via Mailchimp')
       await apiClient.messages.send(requestBody)
 
       await onComplete()
     } catch (err) {
       if (err instanceof ZodError) {
         const error = fromZodError(err)
-        helpers.log({ meta, error }, 'error', error as Error)
+        helpers.log({ error }, 'error', error as Error)
         await onError({
           events: [
             {

--- a/extensions/mailchimp/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
+++ b/extensions/mailchimp/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
@@ -16,12 +16,6 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         patient: { id: patientId },
@@ -57,14 +51,14 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
         },
       }
 
-      helpers.log({ meta, requestBody }, 'Sending template email via Mailchimp')
+      helpers.log({ requestBody }, 'Sending template email via Mailchimp')
       await apiClient.messages.sendTemplate(requestBody)
 
       await onComplete()
     } catch (err) {
       if (err instanceof ZodError) {
         const error = fromZodError(err)
-        helpers.log({ meta, error }, 'error', error as Error)
+        helpers.log({ error }, 'error', error as Error)
         await onError({
           events: [
             {

--- a/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
@@ -17,13 +17,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendEmail')
+    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
 
     try {
       const { to, subject, body } = validateActionFields(payload.fields)
@@ -54,7 +48,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
+++ b/extensions/mailgun/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
@@ -17,16 +17,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendEmailWithTemplate',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendEmailWithTemplate')
 
     try {
       const { to, subject, template, variables } = validateActionFields(
@@ -60,7 +51,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/math/v1/actions/assignToCohort/assignToCohort.ts
+++ b/extensions/math/v1/actions/assignToCohort/assignToCohort.ts
@@ -17,12 +17,6 @@ export const assignToCohort: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { input, numberOfCohorts },
@@ -35,10 +29,7 @@ export const assignToCohort: Action<typeof fields, typeof settings> = {
       const hashInt = parseInt(hash.substring(0, 8), 16)
       const cohortNumber = (hashInt % numberOfCohorts) + 1
 
-      helpers.log(
-        { meta, input, numberOfCohorts, cohortNumber },
-        'Assigned cohort',
-      )
+      helpers.log({ input, numberOfCohorts, cohortNumber }, 'Assigned cohort')
 
       await onComplete({
         data_points: {
@@ -46,7 +37,7 @@ export const assignToCohort: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/math/v1/actions/calculateDateDifference/calculateDateDifference.ts
+++ b/extensions/math/v1/actions/calculateDateDifference/calculateDateDifference.ts
@@ -25,12 +25,6 @@ export const calculateDateDifference: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { dateLeft, dateRight, unit },
@@ -74,7 +68,7 @@ export const calculateDateDifference: Action<typeof fields, typeof settings> = {
       const dateDifference = calculateDifference()
 
       helpers.log(
-        { meta, dateLeft, dateRight, unit, dateDifference },
+        { dateLeft, dateRight, unit, dateDifference },
         'Calculated date difference',
       )
 
@@ -84,7 +78,7 @@ export const calculateDateDifference: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/math/v1/actions/divide/divide.ts
+++ b/extensions/math/v1/actions/divide/divide.ts
@@ -13,13 +13,7 @@ export const divide: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing divide')
+    helpers.log({ fields: payload.fields }, 'Processing divide')
 
     try {
       const {
@@ -31,7 +25,7 @@ export const divide: Action<typeof fields, typeof settings> = {
 
       const quotient = dividend / divisor
 
-      helpers.log({ meta, dividend, divisor, quotient }, 'Calculated quotient')
+      helpers.log({ dividend, divisor, quotient }, 'Calculated quotient')
 
       await onComplete({
         data_points: {
@@ -39,7 +33,7 @@ export const divide: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/math/v1/actions/generateRandomNumber/generateRandomNumber.ts
+++ b/extensions/math/v1/actions/generateRandomNumber/generateRandomNumber.ts
@@ -15,12 +15,6 @@ export const generateRandomNumber: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { min, max },
@@ -35,10 +29,7 @@ export const generateRandomNumber: Action<typeof fields, typeof settings> = {
         Math.floor(Math.random() * (maxSerialized - minSerialized + 1)) +
         minSerialized
 
-      helpers.log(
-        { meta, min, max, generatedNumber },
-        'Generated random number',
-      )
+      helpers.log({ min, max, generatedNumber }, 'Generated random number')
 
       await onComplete({
         data_points: {
@@ -46,7 +37,7 @@ export const generateRandomNumber: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/math/v1/actions/multiply/multiply.ts
+++ b/extensions/math/v1/actions/multiply/multiply.ts
@@ -15,13 +15,7 @@ export const multiply: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing multiply')
+    helpers.log({ fields: payload.fields }, 'Processing multiply')
 
     try {
       const { fields } = validate({
@@ -35,7 +29,7 @@ export const multiply: Action<typeof fields, typeof settings> = {
 
       const product = multiplyAddends(fields)
 
-      helpers.log({ meta, fields, product }, 'Calculated product')
+      helpers.log({ fields, product }, 'Calculated product')
 
       await onComplete({
         data_points: {
@@ -43,7 +37,7 @@ export const multiply: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/math/v1/actions/subtract/subtract.ts
+++ b/extensions/math/v1/actions/subtract/subtract.ts
@@ -13,13 +13,7 @@ export const subtract: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing subtract')
+    helpers.log({ fields: payload.fields }, 'Processing subtract')
 
     try {
       const {
@@ -31,10 +25,7 @@ export const subtract: Action<typeof fields, typeof settings> = {
 
       const difference = minuend - subtrahend
 
-      helpers.log(
-        { meta, minuend, subtrahend, difference },
-        'Calculated difference',
-      )
+      helpers.log({ minuend, subtrahend, difference }, 'Calculated difference')
 
       await onComplete({
         data_points: {
@@ -43,7 +34,7 @@ export const subtract: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/math/v1/actions/sum/sum.ts
+++ b/extensions/math/v1/actions/sum/sum.ts
@@ -15,13 +15,7 @@ export const sum: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sum')
+    helpers.log({ fields: payload.fields }, 'Processing sum')
 
     try {
       const { fields } = validate({
@@ -35,7 +29,7 @@ export const sum: Action<typeof fields, typeof settings> = {
 
       const sum = sumAddends(fields)
 
-      helpers.log({ meta, fields, sum }, 'Calculated sum')
+      helpers.log({ fields, sum }, 'Calculated sum')
 
       await onComplete({
         data_points: {
@@ -43,7 +37,7 @@ export const sum: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/addSideEffect/addSideEffect.ts
+++ b/extensions/medplum/actions/addSideEffect/addSideEffect.ts
@@ -17,13 +17,7 @@ export const addSideEffect: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addSideEffect')
+    helpers.log({ fields: payload.fields }, 'Processing addSideEffect')
 
     try {
       const {
@@ -67,7 +61,7 @@ export const addSideEffect: Action<
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/createCalculationObservation/createCalculationObservation.ts
+++ b/extensions/medplum/actions/createCalculationObservation/createCalculationObservation.ts
@@ -37,11 +37,6 @@ export const createCalculationObservation: Action<
       fieldsSchema: FieldsValidationSchema,
       payload,
     })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const awellSdk = await helpers.awellSdk()
 
@@ -158,7 +153,7 @@ export const createCalculationObservation: Action<
     }
 
     helpers.log(
-      { meta, observationResource },
+      { observationResource },
       '[createCalculationObservation] Creating Medplum observation',
     )
 

--- a/extensions/medplum/actions/createPatient/createPatient.ts
+++ b/extensions/medplum/actions/createPatient/createPatient.ts
@@ -21,13 +21,7 @@ export const createPatient: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createPatient')
+    helpers.log({ fields: payload.fields }, 'Processing createPatient')
 
     try {
       const {
@@ -107,7 +101,7 @@ export const createPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/createResource/createResource.ts
+++ b/extensions/medplum/actions/createResource/createResource.ts
@@ -18,11 +18,6 @@ export const createResource: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
     const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -65,7 +60,7 @@ export const createResource: Action<
 
       if (resourceData.resourceType === 'Bundle') {
         helpers.log(
-          { meta, resourceData },
+          { resourceData },
           '[createResource] Executing Medplum bundle',
         )
 
@@ -152,7 +147,7 @@ export const createResource: Action<
         })
       } else {
         helpers.log(
-          { meta, resourceData },
+          { resourceData },
           '[createResource] Creating Medplum resource',
         )
 

--- a/extensions/medplum/actions/createServiceRequest/createServiceRequest.ts
+++ b/extensions/medplum/actions/createServiceRequest/createServiceRequest.ts
@@ -16,16 +16,7 @@ export const createServiceRequest: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createServiceRequest',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createServiceRequest')
 
     try {
       const {
@@ -61,7 +52,7 @@ export const createServiceRequest: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/createTask/createTask.ts
+++ b/extensions/medplum/actions/createTask/createTask.ts
@@ -17,13 +17,7 @@ export const createTask: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTask')
+    helpers.log({ fields: payload.fields }, 'Processing createTask')
 
     try {
       const {
@@ -73,7 +67,7 @@ export const createTask: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/executeBot/executeBot.ts
+++ b/extensions/medplum/actions/executeBot/executeBot.ts
@@ -16,13 +16,7 @@ export const executeBot: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing executeBot')
+    helpers.log({ fields: payload.fields }, 'Processing executeBot')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -43,7 +37,7 @@ export const executeBot: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/getAppointment/getAppointment.ts
+++ b/extensions/medplum/actions/getAppointment/getAppointment.ts
@@ -17,13 +17,7 @@ export const getAppointment: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getAppointment')
+    helpers.log({ fields: payload.fields }, 'Processing getAppointment')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -42,7 +36,7 @@ export const getAppointment: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/getMedicationRequest/getMedicationRequest.ts
+++ b/extensions/medplum/actions/getMedicationRequest/getMedicationRequest.ts
@@ -17,16 +17,7 @@ export const getMedicationRequest: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getMedicationRequest',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getMedicationRequest')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -93,7 +84,7 @@ export const getMedicationRequest: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/getPatient/getPatient.ts
+++ b/extensions/medplum/actions/getPatient/getPatient.ts
@@ -17,13 +17,7 @@ export const getPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -50,7 +44,7 @@ export const getPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/getServiceRequest/getServiceRequest.ts
+++ b/extensions/medplum/actions/getServiceRequest/getServiceRequest.ts
@@ -17,16 +17,7 @@ export const getServiceRequest: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getServiceRequest',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getServiceRequest')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -59,7 +50,7 @@ export const getServiceRequest: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/searchPatient/searchPatient.ts
+++ b/extensions/medplum/actions/searchPatient/searchPatient.ts
@@ -16,13 +16,7 @@ export const searchPatient: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing searchPatient')
+    helpers.log({ fields: payload.fields }, 'Processing searchPatient')
 
     try {
       const { fields: input, medplumSdk } = await validateAndCreateSdkClient({
@@ -44,7 +38,7 @@ export const searchPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/medplum/actions/submitQuestionnaireResponse/submitQuestionnaireResponse.ts
+++ b/extensions/medplum/actions/submitQuestionnaireResponse/submitQuestionnaireResponse.ts
@@ -33,11 +33,6 @@ export const submitQuestionnaireResponse: Action<
       fieldsSchema: FieldsValidationSchema,
       payload,
     })
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     const awellSdk = await helpers.awellSdk()
 
@@ -50,11 +45,11 @@ export const submitQuestionnaireResponse: Action<
         pathwayId: pathway.id,
         activityId: activity.id,
       })
-      helpers.log({ meta, formRes }, 'Form response')
+      helpers.log({ formRes }, 'Form response')
       formDefinition = formRes.formDefinition
       formResponse = formRes.formResponse
     } catch (error) {
-      helpers.log({ meta, error }, 'Error')
+      helpers.log({ error }, 'Error')
       const err = error as Error
       await onError({
         events: [addActivityEventLog({ message: err.message })],
@@ -63,7 +58,7 @@ export const submitQuestionnaireResponse: Action<
     }
 
     helpers.log(
-      { meta, formDefinition, formResponse },
+      { formDefinition, formResponse },
       'Form definition and response',
     )
 
@@ -76,12 +71,12 @@ export const submitQuestionnaireResponse: Action<
       })
 
     helpers.log(
-      { meta, FhirQuestionnaire, FhirQuestionnaireResponse },
+      { fhirQuestionnaire, FhirQuestionnaireResponse },
       'Fhir questionnaire and response',
     )
 
     helpers.log(
-      { meta, FhirQuestionnaire },
+      { fhirQuestionnaire },
       '[submitQuestionnaireResponse] Creating Medplum questionnaire resource',
     )
 
@@ -90,7 +85,7 @@ export const submitQuestionnaireResponse: Action<
       `identifier=${formDefinition.definition_id}/published/${formDefinition.id}`,
     )
 
-    helpers.log({ meta, QuestionnaireResource }, 'Questionnaire resource')
+    helpers.log({ QuestionnaireResource }, 'Questionnaire resource')
 
     const questionnaireResponseResource: QuestionnaireResponse = {
       resourceType: 'QuestionnaireResponse',
@@ -105,13 +100,13 @@ export const submitQuestionnaireResponse: Action<
     }
 
     helpers.log(
-      { meta, questionnaireResponseResource },
+      { questionnaireResponseResource },
       '[submitQuestionnaireResponse] Creating Medplum questionnaire response',
     )
 
     const res = await medplumSdk.createResource(questionnaireResponseResource)
 
-    helpers.log({ meta, res }, 'Questionnaire response')
+    helpers.log({ res }, 'Questionnaire response')
 
     await onComplete({
       data_points: {

--- a/extensions/medplum/actions/submitQuestionnaireResponse/submitQuestionnaireResponse.ts
+++ b/extensions/medplum/actions/submitQuestionnaireResponse/submitQuestionnaireResponse.ts
@@ -71,12 +71,12 @@ export const submitQuestionnaireResponse: Action<
       })
 
     helpers.log(
-      { fhirQuestionnaire, FhirQuestionnaireResponse },
+      { FhirQuestionnaire, FhirQuestionnaireResponse },
       'Fhir questionnaire and response',
     )
 
     helpers.log(
-      { fhirQuestionnaire },
+      { FhirQuestionnaire },
       '[submitQuestionnaireResponse] Creating Medplum questionnaire resource',
     )
 

--- a/extensions/messagebird/v1/actions/sendSms/sendSms.ts
+++ b/extensions/messagebird/v1/actions/sendSms/sendSms.ts
@@ -13,13 +13,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     const {
       fields: { originator, recipient, body },
@@ -90,7 +84,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
         },
       )
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/messagebird/v1/actions/sendVoiceMessage/sendVoiceMessage.ts
+++ b/extensions/messagebird/v1/actions/sendVoiceMessage/sendVoiceMessage.ts
@@ -14,13 +14,7 @@ export const sendVoiceMessage: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendVoiceMessage')
+    helpers.log({ fields: payload.fields }, 'Processing sendVoiceMessage')
 
     const {
       fields: { originator, recipient, body, language, voice },
@@ -92,7 +86,7 @@ export const sendVoiceMessage: Action<typeof fields, typeof settings> = {
         },
       )
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/messagebird/v1/actions/sendWhatsAppMessage/sendWhatsAppMessage.ts
+++ b/extensions/messagebird/v1/actions/sendWhatsAppMessage/sendWhatsAppMessage.ts
@@ -13,16 +13,7 @@ export const sendWhatsAppMessage: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendWhatsAppMessage',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendWhatsAppMessage')
 
     const {
       fields: { from, to, content },
@@ -96,7 +87,7 @@ export const sendWhatsAppMessage: Action<typeof fields, typeof settings> = {
         },
       )
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/metriport/actions/consolidated/getConsolidatedQueryStatus.ts
+++ b/extensions/metriport/actions/consolidated/getConsolidatedQueryStatus.ts
@@ -27,14 +27,8 @@ export const getConsolidatedQueryStatus: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing getConsolidatedQueryStatus',
     )
 
@@ -54,7 +48,7 @@ export const getConsolidatedQueryStatus: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/consolidated/startConsolidatedQuery.ts
+++ b/extensions/metriport/actions/consolidated/startConsolidatedQuery.ts
@@ -35,16 +35,7 @@ export const startConsolidatedQuery: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing startConsolidatedQuery',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing startConsolidatedQuery')
 
     try {
       const { patientId, resources, dateFrom, dateTo, conversionType } =
@@ -76,7 +67,7 @@ export const startConsolidatedQuery: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/document/getUrl.ts
+++ b/extensions/metriport/actions/document/getUrl.ts
@@ -20,13 +20,7 @@ export const getUrl: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getUrl')
+    helpers.log({ fields: payload.fields }, 'Processing getUrl')
 
     try {
       const { fileName } = getUrlSchema.parse(payload.fields)
@@ -41,7 +35,7 @@ export const getUrl: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/document/list.ts
+++ b/extensions/metriport/actions/document/list.ts
@@ -21,13 +21,7 @@ export const listDocuments: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing listDocs')
+    helpers.log({ fields: payload.fields }, 'Processing listDocs')
 
     try {
       const { patientId } = startQuerySchema.parse(payload.fields)
@@ -42,7 +36,7 @@ export const listDocuments: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/document/query.ts
+++ b/extensions/metriport/actions/document/query.ts
@@ -21,13 +21,7 @@ export const queryDocs: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing queryDocs')
+    helpers.log({ fields: payload.fields }, 'Processing queryDocs')
 
     try {
       const { patientId, facilityId } = startQuerySchema.parse(payload.fields)
@@ -45,7 +39,7 @@ export const queryDocs: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/network/startNetworkQuery.ts
+++ b/extensions/metriport/actions/network/startNetworkQuery.ts
@@ -27,16 +27,7 @@ export const startNetworkQuery: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing startNetworkQuery',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing startNetworkQuery')
 
     try {
       const { patientId } = startNetworkQuerySchema.parse(payload.fields)
@@ -55,7 +46,7 @@ export const startNetworkQuery: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/patient/create.ts
+++ b/extensions/metriport/actions/patient/create.ts
@@ -28,13 +28,7 @@ export const createPatient: Action<
   supports_automated_retries: true,
   dataPoints: patientIdDataPoint,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createPatient')
+    helpers.log({ fields: payload.fields }, 'Processing createPatient')
 
     try {
       const patient = patientCreateSchema.parse(payload.fields)
@@ -53,7 +47,7 @@ export const createPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/patient/delete.ts
+++ b/extensions/metriport/actions/patient/delete.ts
@@ -14,13 +14,7 @@ export const deletePatient: Action<typeof deleteFields, typeof settings> = {
   fields: deleteFields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deletePatient')
+    helpers.log({ fields: payload.fields }, 'Processing deletePatient')
 
     try {
       const patientId = stringId.parse(payload.fields.patientId)
@@ -31,7 +25,7 @@ export const deletePatient: Action<typeof deleteFields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/patient/get.ts
+++ b/extensions/metriport/actions/patient/get.ts
@@ -20,13 +20,7 @@ export const getPatient: Action<
   previewable: true,
   dataPoints: patientDataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getPatient')
+    helpers.log({ fields: payload.fields }, 'Processing getPatient')
 
     try {
       const patientId = stringId.parse(payload.fields.patientId)
@@ -65,7 +59,7 @@ export const getPatient: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/metriport/actions/patient/update.ts
+++ b/extensions/metriport/actions/patient/update.ts
@@ -16,13 +16,7 @@ export const updatePatient: Action<typeof updateFields, typeof settings> = {
   fields: updateFields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updatePatient')
+    helpers.log({ fields: payload.fields }, 'Processing updatePatient')
 
     try {
       const patient = patientUpdateSchema.parse(payload.fields)
@@ -40,7 +34,7 @@ export const updatePatient: Action<typeof updateFields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       await handleErrorMessage(err, onError)
     }
   },

--- a/extensions/nexuzhealth/v1/actions/sendDocumentation/sendDocumentation.ts
+++ b/extensions/nexuzhealth/v1/actions/sendDocumentation/sendDocumentation.ts
@@ -11,21 +11,12 @@ export const sendDocumentation: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendDocumentation',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendDocumentation')
 
     try {
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/nexuzhealth/v1/actions/sendMessage/sendMessage.ts
+++ b/extensions/nexuzhealth/v1/actions/sendMessage/sendMessage.ts
@@ -11,18 +11,12 @@ export const sendMessage: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendMessage')
+    helpers.log({ fields: payload.fields }, 'Processing sendMessage')
 
     try {
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/nexuzhealth/v1/actions/sendQuestionnaire/sendQuestionnaire.ts
+++ b/extensions/nexuzhealth/v1/actions/sendQuestionnaire/sendQuestionnaire.ts
@@ -11,21 +11,12 @@ export const sendQuestionnaire: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendQuestionnaire',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendQuestionnaire')
 
     try {
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/rest/actions/post/post.ts
+++ b/extensions/rest/actions/post/post.ts
@@ -19,13 +19,7 @@ export const post: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing post')
+    helpers.log({ fields: payload.fields }, 'Processing post')
 
     const {
       fields: { endpoint, headers, jsonPayload, additionalPayload },
@@ -82,7 +76,7 @@ export const post: Action<
         )
       }
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (error instanceof FetchError) {
         await onError({
           events: [

--- a/extensions/sendbird/v1/actions/activateUser/activateUser.ts
+++ b/extensions/sendbird/v1/actions/activateUser/activateUser.ts
@@ -19,13 +19,7 @@ export const activateUser: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing activateUser')
+    helpers.log({ fields: payload.fields }, 'Processing activateUser')
 
     try {
       const {
@@ -52,7 +46,7 @@ export const activateUser: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/createCustomer/createCustomer.ts
+++ b/extensions/sendbird/v1/actions/createCustomer/createCustomer.ts
@@ -20,13 +20,7 @@ export const createCustomer: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createCustomer')
+    helpers.log({ fields: payload.fields }, 'Processing createCustomer')
 
     try {
       const {
@@ -52,7 +46,7 @@ export const createCustomer: Action<typeof fields, typeof settings> = {
 
       await onComplete({ data_points: { customerId: String(res.data.id) } })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/createTicket/createTicket.ts
+++ b/extensions/sendbird/v1/actions/createTicket/createTicket.ts
@@ -21,13 +21,7 @@ export const createTicket: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTicket')
+    helpers.log({ fields: payload.fields }, 'Processing createTicket')
 
     try {
       const {
@@ -89,7 +83,7 @@ export const createTicket: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/createUser/createUser.ts
+++ b/extensions/sendbird/v1/actions/createUser/createUser.ts
@@ -22,13 +22,7 @@ export const createUser: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createUser')
+    helpers.log({ fields: payload.fields }, 'Processing createUser')
 
     try {
       const {
@@ -58,7 +52,7 @@ export const createUser: Action<typeof fields, typeof settings> = {
 
       await onComplete({ data_points: { userId: res.data.user_id } })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/deactivateUser/deactivateUser.ts
+++ b/extensions/sendbird/v1/actions/deactivateUser/deactivateUser.ts
@@ -19,13 +19,7 @@ export const deactivateUser: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deactivateUser')
+    helpers.log({ fields: payload.fields }, 'Processing deactivateUser')
 
     try {
       const {
@@ -53,7 +47,7 @@ export const deactivateUser: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/deleteMetadata/deleteMetadata.ts
+++ b/extensions/sendbird/v1/actions/deleteMetadata/deleteMetadata.ts
@@ -20,13 +20,7 @@ export const deleteMetadata: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deleteMetadata')
+    helpers.log({ fields: payload.fields }, 'Processing deleteMetadata')
 
     try {
       const {
@@ -53,7 +47,7 @@ export const deleteMetadata: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/deleteUser/deleteUser.ts
+++ b/extensions/sendbird/v1/actions/deleteUser/deleteUser.ts
@@ -19,13 +19,7 @@ export const deleteUser: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing deleteUser')
+    helpers.log({ fields: payload.fields }, 'Processing deleteUser')
 
     try {
       const {
@@ -49,7 +43,7 @@ export const deleteUser: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/getCustomer/getCustomer.ts
+++ b/extensions/sendbird/v1/actions/getCustomer/getCustomer.ts
@@ -21,13 +21,7 @@ export const getCustomer: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getCustomer')
+    helpers.log({ fields: payload.fields }, 'Processing getCustomer')
 
     try {
       const {
@@ -65,7 +59,7 @@ export const getCustomer: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/getUser/getUser.ts
+++ b/extensions/sendbird/v1/actions/getUser/getUser.ts
@@ -21,13 +21,7 @@ export const getUser: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getUser')
+    helpers.log({ fields: payload.fields }, 'Processing getUser')
 
     try {
       const {
@@ -61,7 +55,7 @@ export const getUser: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/updateCustomerCustomFields/updateCustomerCustomFields.ts
+++ b/extensions/sendbird/v1/actions/updateCustomerCustomFields/updateCustomerCustomFields.ts
@@ -26,14 +26,8 @@ export const updateCustomerCustomFields: Action<
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing updateCustomerCustomFields',
     )
 
@@ -143,7 +137,7 @@ export const updateCustomerCustomFields: Action<
       // if all checks passed, we can assume that the update was successful
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/updateMetadata/updateMetadata.ts
+++ b/extensions/sendbird/v1/actions/updateMetadata/updateMetadata.ts
@@ -19,13 +19,7 @@ export const updateMetadata: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updateMetadata')
+    helpers.log({ fields: payload.fields }, 'Processing updateMetadata')
 
     try {
       const {
@@ -49,7 +43,7 @@ export const updateMetadata: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/updateTicket/updateTicket.ts
+++ b/extensions/sendbird/v1/actions/updateTicket/updateTicket.ts
@@ -19,13 +19,7 @@ export const updateTicket: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updateTicket')
+    helpers.log({ fields: payload.fields }, 'Processing updateTicket')
 
     try {
       const {
@@ -52,7 +46,7 @@ export const updateTicket: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendbird/v1/actions/updateUser/updateUser.ts
+++ b/extensions/sendbird/v1/actions/updateUser/updateUser.ts
@@ -19,13 +19,7 @@ export const updateUser: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updateUser')
+    helpers.log({ fields: payload.fields }, 'Processing updateUser')
 
     try {
       const {
@@ -54,7 +48,7 @@ export const updateUser: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/addOrUpdateContact/addOrUpdateContact.ts
+++ b/extensions/sendgrid-extension/v1/actions/addOrUpdateContact/addOrUpdateContact.ts
@@ -34,13 +34,7 @@ export const addOrUpdateContact: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing jobId')
+    helpers.log({ fields: payload.fields }, 'Processing jobId')
 
     try {
       const {
@@ -72,7 +66,7 @@ export const addOrUpdateContact: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/addSuppressions/addSuppressions.ts
+++ b/extensions/sendgrid-extension/v1/actions/addSuppressions/addSuppressions.ts
@@ -19,13 +19,7 @@ export const addSuppressions: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing addSuppressions')
+    helpers.log({ fields: payload.fields }, 'Processing addSuppressions')
 
     try {
       const {
@@ -63,7 +57,7 @@ export const addSuppressions: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/importStatus/importStatus.ts
+++ b/extensions/sendgrid-extension/v1/actions/importStatus/importStatus.ts
@@ -53,13 +53,7 @@ export const importStatus: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing importStatus')
+    helpers.log({ fields: payload.fields }, 'Processing importStatus')
 
     try {
       const {
@@ -106,7 +100,7 @@ export const importStatus: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/removeSuppressions/removeSuppressions.ts
+++ b/extensions/sendgrid-extension/v1/actions/removeSuppressions/removeSuppressions.ts
@@ -19,16 +19,7 @@ export const removeSuppressions: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing removeSuppressions',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing removeSuppressions')
 
     try {
       const {
@@ -66,7 +57,7 @@ export const removeSuppressions: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/sendgrid-extension/v1/actions/sendEmail/sendEmail.ts
@@ -20,13 +20,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendEmail')
+    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
 
     try {
       const {
@@ -100,7 +94,7 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sendgrid-extension/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
+++ b/extensions/sendgrid-extension/v1/actions/sendEmailWithTemplate/sendEmailWithTemplate.ts
@@ -21,16 +21,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing sendEmailWithTemplate',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing sendEmailWithTemplate')
 
     try {
       const {
@@ -123,7 +114,7 @@ export const sendEmailWithTemplate: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/sfdc/actions/createLead/createLead.ts
+++ b/extensions/sfdc/actions/createLead/createLead.ts
@@ -19,13 +19,7 @@ export const createLead: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createLead')
+    helpers.log({ fields: payload.fields }, 'Processing createLead')
 
     const { fields, pathwayId, salesforceClient } =
       await validatePayloadAndCreateClient({
@@ -63,7 +57,7 @@ export const createLead: Action<
         ],
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (isSalesforceError(error)) {
         await onError({
           events: [parseSalesforceError(error)],

--- a/extensions/sfdc/actions/updateLead/updateLead.ts
+++ b/extensions/sfdc/actions/updateLead/updateLead.ts
@@ -19,13 +19,7 @@ export const updateLead: Action<
   supports_automated_retries: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing updateLead')
+    helpers.log({ fields: payload.fields }, 'Processing updateLead')
 
     const { fields, salesforceClient } = await validatePayloadAndCreateClient({
       fieldsSchema: FieldsValidationSchema,
@@ -50,7 +44,7 @@ export const updateLead: Action<
         ],
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (isSalesforceError(error)) {
         await onError({
           events: [parseSalesforceError(error)],

--- a/extensions/shelly/actions/generateMessage/generateMessage.ts
+++ b/extensions/shelly/actions/generateMessage/generateMessage.ts
@@ -28,13 +28,7 @@ export const generateMessage: Action<
   dataPoints,
 
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing generateMessage')
+    helpers.log({ fields: payload.fields }, 'Processing generateMessage')
 
     try {
       // 1. Validate input fields
@@ -70,7 +64,7 @@ export const generateMessage: Action<
         data_points: { subject, message: htmlMessage },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/shelly/actions/reviewMedicationExtraction/reviewMedicationExtraction.ts
+++ b/extensions/shelly/actions/reviewMedicationExtraction/reviewMedicationExtraction.ts
@@ -22,14 +22,8 @@ export const reviewMedicationExtraction: Action<
     },
   },
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing reviewMedicationExtraction',
     )
 
@@ -41,7 +35,7 @@ export const reviewMedicationExtraction: Action<
 
       // Completion in Hosted Pages
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/shelly/actions/summarizeCareFlow/summarizeCareFlow.ts
+++ b/extensions/shelly/actions/summarizeCareFlow/summarizeCareFlow.ts
@@ -20,16 +20,7 @@ export const summarizeCareFlow: Action<
   dataPoints,
 
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing summarizeCareFlow',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing summarizeCareFlow')
 
     try {
       // 1. Validate input fields
@@ -107,7 +98,7 @@ export const summarizeCareFlow: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/shelly/actions/summarizeFormsInStep/summarizeFormsInStep.ts
+++ b/extensions/shelly/actions/summarizeFormsInStep/summarizeFormsInStep.ts
@@ -22,16 +22,7 @@ export const summarizeFormsInStep: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing summarizeFormsInStep',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing summarizeFormsInStep')
 
     try {
       // 1. Validate input fields
@@ -99,7 +90,7 @@ export const summarizeFormsInStep: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
+++ b/extensions/shelly/actions/summarizeTrackOutcome/summarizeTrackOutcome.ts
@@ -25,16 +25,7 @@ export const summarizeTrackOutcome: Action<
   dataPoints,
 
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing summarizeTrackOutcome',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing summarizeTrackOutcome')
 
     try {
       // 1. Validate input fields
@@ -122,7 +113,7 @@ export const summarizeTrackOutcome: Action<
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/slack/v1/actions/sendMessageToChannel/sendMessageToChannel.ts
+++ b/extensions/slack/v1/actions/sendMessageToChannel/sendMessageToChannel.ts
@@ -28,12 +28,6 @@ export const sendMessageToChannel: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings: { botToken },
@@ -56,7 +50,7 @@ export const sendMessageToChannel: Action<
         text: messageWithLink,
       }
 
-      helpers.log({ meta, requestBody }, 'Sending message via Slack')
+      helpers.log({ requestBody }, 'Sending message via Slack')
       const response = await slackClient.postMessage(requestBody)
 
       await onComplete({

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
@@ -20,16 +20,7 @@ export const getFaxDocumentWithOCR: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getFaxDocumentWithOCR',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getFaxDocumentWithOCR')
 
     const { fields, srfaxSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,

--- a/extensions/stedi/actions/checkEligibility/checkEligibility.ts
+++ b/extensions/stedi/actions/checkEligibility/checkEligibility.ts
@@ -18,13 +18,7 @@ export const checkEligibility: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing checkEligibility')
+    helpers.log({ fields: payload.fields }, 'Processing checkEligibility')
 
     try {
       const { fields } = validate({
@@ -41,7 +35,7 @@ export const checkEligibility: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/stripe/actions/createCustomer/createCustomer.ts
+++ b/extensions/stripe/actions/createCustomer/createCustomer.ts
@@ -16,13 +16,7 @@ export const createCustomer: Action<
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createCustomer')
+    helpers.log({ fields: payload.fields }, 'Processing createCustomer')
 
     try {
       const {
@@ -48,7 +42,7 @@ export const createCustomer: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/stripe/actions/createSubscription/createSubscription.ts
+++ b/extensions/stripe/actions/createSubscription/createSubscription.ts
@@ -16,16 +16,7 @@ export const createSubscription: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createSubscription',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createSubscription')
 
     try {
       const {
@@ -62,7 +53,7 @@ export const createSubscription: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/talkDesk/actions/triggerFlow/triggerFlow.ts
+++ b/extensions/talkDesk/actions/triggerFlow/triggerFlow.ts
@@ -17,13 +17,7 @@ export const triggerFlow: Action<
   previewable: false,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing triggerFlow')
+    helpers.log({ fields: payload.fields }, 'Processing triggerFlow')
 
     try {
       const { fields, client } = await validatePayloadAndCreateClient({
@@ -52,7 +46,7 @@ export const triggerFlow: Action<
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/text-em-all/actions/createCallBroadcast/createCallBroadcast.ts
+++ b/extensions/text-em-all/actions/createCallBroadcast/createCallBroadcast.ts
@@ -18,12 +18,6 @@ export const createCallBroadcast: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers: { log } }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const {
       fields: {
         broadcastName: BroadcastName,
@@ -60,7 +54,7 @@ export const createCallBroadcast: Action<
       ContinueOnNextDay,
       Contacts: [{ PrimaryPhone: phoneNumber }],
     }
-    log({ meta, request }, 'Creating call broadcast via Text-Em-All')
+    log({ request }, 'Creating call broadcast via Text-Em-All')
     const resp = await client.createBroadcast(request)
     const data = resp.data
     if (resp.status === 200 && 'BroadcastID' in data) {

--- a/extensions/text-em-all/actions/createSMSBroadcast/createSMSBroadcast.test.ts
+++ b/extensions/text-em-all/actions/createSMSBroadcast/createSMSBroadcast.test.ts
@@ -293,11 +293,6 @@ describe('CreateSMSBroadcast', () => {
     expect(helpers.log).toHaveBeenNthCalledWith(
       1,
       {
-        meta: {
-          tenant_id: 'tenant-id',
-          careflow_id: 'pathway-id',
-          activity_id: 'activity-id',
-        },
         source: 'patient_profile',
         field: 'mobile_phone',
       },
@@ -306,11 +301,6 @@ describe('CreateSMSBroadcast', () => {
     expect(helpers.log).toHaveBeenNthCalledWith(
       4,
       expect.objectContaining({
-        meta: {
-          tenant_id: 'tenant-id',
-          careflow_id: 'pathway-id',
-          activity_id: 'activity-id',
-        },
         request: expect.objectContaining({
           BroadcastName: 'testBroadcast',
           Contacts: [

--- a/extensions/text-em-all/actions/createSMSBroadcast/createSMSBroadcast.ts
+++ b/extensions/text-em-all/actions/createSMSBroadcast/createSMSBroadcast.ts
@@ -66,12 +66,6 @@ export const createSMSBroadcast: Action<
     onError,
     helpers: { log },
   }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     // Step 1: Extract raw field values and settings
     const { fields: rawFields, settings } = validate({
       schema: z.object({ fields: FieldsSchema, settings: SettingsSchema }),
@@ -103,7 +97,7 @@ export const createSMSBroadcast: Action<
         return
       }
       log(
-        { meta, source: 'patient_profile', field: 'mobile_phone' },
+        { source: 'patient_profile', field: 'mobile_phone' },
         'Phone number not provided — using patient profile mobile phone',
       )
     }
@@ -112,7 +106,7 @@ export const createSMSBroadcast: Action<
     if (isEmpty(firstName) && !isEmpty(patientProfile?.first_name)) {
       firstName = patientProfile?.first_name as string
       log(
-        { meta, source: 'patient_profile', field: 'first_name' },
+        { source: 'patient_profile', field: 'first_name' },
         'First name not provided — using patient profile first name',
       )
     }
@@ -121,7 +115,7 @@ export const createSMSBroadcast: Action<
     if (isEmpty(lastName) && !isEmpty(patientProfile?.last_name)) {
       lastName = patientProfile?.last_name as string
       log(
-        { meta, source: 'patient_profile', field: 'last_name' },
+        { source: 'patient_profile', field: 'last_name' },
         'Last name not provided — using patient profile last name',
       )
     }
@@ -169,7 +163,7 @@ export const createSMSBroadcast: Action<
 
     // Step 5: Send to Text-Em-All
     const client = new TextEmAllClient(settings)
-    log({ meta, request }, 'Creating SMS broadcast via Text-Em-All')
+    log({ request }, 'Creating SMS broadcast via Text-Em-All')
     const resp = await client.createBroadcast(request)
     const data = resp.data
 

--- a/extensions/textline/actions/getMessages/getMessages.ts
+++ b/extensions/textline/actions/getMessages/getMessages.ts
@@ -20,13 +20,7 @@ export const getMessages: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getMessages')
+    helpers.log({ fields: payload.fields }, 'Processing getMessages')
 
     try {
       const {
@@ -80,7 +74,7 @@ export const getMessages: Action<typeof fields, typeof settings> = {
         })
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/textline/actions/sendSms/sendSms.ts
+++ b/extensions/textline/actions/sendSms/sendSms.ts
@@ -18,13 +18,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
   previewable: true,
   dataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     try {
       const {
@@ -60,7 +54,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/textline/actions/setContactConsent/setContactConsent.ts
+++ b/extensions/textline/actions/setContactConsent/setContactConsent.ts
@@ -15,16 +15,7 @@ export const setContactConsent: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing setContactConsent',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing setContactConsent')
 
     try {
       const {
@@ -43,7 +34,7 @@ export const setContactConsent: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/combineDateAndTime/combineDateAndTime.ts
+++ b/extensions/transform/v1/actions/combineDateAndTime/combineDateAndTime.ts
@@ -19,12 +19,6 @@ export const combineDateAndTime: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const {
       fields: { referenceDate, timeString },
     } = validate({
@@ -47,10 +41,7 @@ export const combineDateAndTime: Action<
     } else {
       const parsedDateTime = parseISO(timeString)
       if (!isValid(parsedDateTime)) {
-        helpers.log(
-          { meta, referenceDate, timeString },
-          'Invalid time string format',
-        )
+        helpers.log({ referenceDate, timeString }, 'Invalid time string format')
         await onError({
           events: [
             {
@@ -78,7 +69,7 @@ export const combineDateAndTime: Action<
     const isoDateTime = formatISO(combinedDate)
 
     helpers.log(
-      { meta, referenceDate, timeString, combinedDateTime: isoDateTime },
+      { referenceDate, timeString, combinedDateTime: isoDateTime },
       'Combined date and time',
     )
 

--- a/extensions/transform/v1/actions/feetAndInchesToInches/feetAndInchesToInches.ts
+++ b/extensions/transform/v1/actions/feetAndInchesToInches/feetAndInchesToInches.ts
@@ -17,16 +17,7 @@ export const feetAndInchesToInches: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing feetAndInchesToInches',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing feetAndInchesToInches')
 
     try {
       const {
@@ -40,7 +31,7 @@ export const feetAndInchesToInches: Action<
 
       const totalInches = feet * 12 + inches
 
-      helpers.log({ meta, feet, inches, totalInches }, 'Converted to inches')
+      helpers.log({ feet, inches, totalInches }, 'Converted to inches')
 
       await onComplete({
         data_points: {
@@ -48,7 +39,7 @@ export const feetAndInchesToInches: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/transform/v1/actions/generateDynamicUrl/generateDynamicUrl.ts
+++ b/extensions/transform/v1/actions/generateDynamicUrl/generateDynamicUrl.ts
@@ -25,12 +25,6 @@ export const generateDynamicUrl: Action<
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { urlTemplate, value },
@@ -48,7 +42,7 @@ export const generateDynamicUrl: Action<
       const url = urlTemplate.replace(placeholderPattern, valueForUrl)
 
       helpers.log(
-        { meta, urlTemplate, value, valueForUrl, url },
+        { urlTemplate, value, valueForUrl, url },
         'Generated dynamic URL',
       )
 
@@ -58,7 +52,7 @@ export const generateDynamicUrl: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/htmlToPdf/htmlToPdf.ts
+++ b/extensions/transform/v1/actions/htmlToPdf/htmlToPdf.ts
@@ -19,13 +19,7 @@ export const htmlToPdf: Action<
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing htmlToPdf')
+    helpers.log({ fields: payload.fields }, 'Processing htmlToPdf')
 
     try {
       const {
@@ -55,7 +49,7 @@ export const htmlToPdf: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/transform/v1/actions/htmlToPdf/htmlToPdf.ts
+++ b/extensions/transform/v1/actions/htmlToPdf/htmlToPdf.ts
@@ -35,7 +35,6 @@ export const htmlToPdf: Action<
 
       helpers.log(
         {
-          meta,
           htmlStringLength: htmlString.length,
           options,
           base64PdfLength: base64Pdf.length,

--- a/extensions/transform/v1/actions/listToCommaSeparatedText/listToCommaSeparatedText.ts
+++ b/extensions/transform/v1/actions/listToCommaSeparatedText/listToCommaSeparatedText.ts
@@ -18,14 +18,8 @@ export const listToCommaSeparatedText: Action<
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing listToCommaSeparatedText',
     )
 
@@ -40,10 +34,7 @@ export const listToCommaSeparatedText: Action<
       })
 
       const output = list.join(',')
-      helpers.log(
-        { meta, list, output },
-        'Converted list to comma separated text',
-      )
+      helpers.log({ list, output }, 'Converted list to comma separated text')
 
       await onComplete({
         data_points: {
@@ -51,7 +42,7 @@ export const listToCommaSeparatedText: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/transform/v1/actions/parseDateToUnixTimestamp/parseDateToUnixTimestamp.ts
+++ b/extensions/transform/v1/actions/parseDateToUnixTimestamp/parseDateToUnixTimestamp.ts
@@ -18,12 +18,6 @@ export const parseDateToUnixTimestamp: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { date },
@@ -41,10 +35,7 @@ export const parseDateToUnixTimestamp: Action<
        */
       const unixTimeStamp = Math.floor(dateObj.getTime() / 1000)
 
-      helpers.log(
-        { meta, date, unixTimeStamp },
-        'Parsed date to unix timestamp',
-      )
+      helpers.log({ date, unixTimeStamp }, 'Parsed date to unix timestamp')
 
       await onComplete({
         data_points: {
@@ -52,7 +43,7 @@ export const parseDateToUnixTimestamp: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/parseNumberToText/parseNumberToText.ts
+++ b/extensions/transform/v1/actions/parseNumberToText/parseNumberToText.ts
@@ -18,12 +18,6 @@ export const parseNumberToText: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { number },
@@ -34,10 +28,7 @@ export const parseNumberToText: Action<
         payload,
       })
 
-      helpers.log(
-        { meta, number, text: String(number) },
-        'Parsed number to text',
-      )
+      helpers.log({ number, text: String(number) }, 'Parsed number to text')
 
       await onComplete({
         data_points: {
@@ -45,7 +36,7 @@ export const parseNumberToText: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/parseNumberToTextWithDictionary/parseNumberToTextWithDictionary.ts
+++ b/extensions/transform/v1/actions/parseNumberToTextWithDictionary/parseNumberToTextWithDictionary.ts
@@ -18,12 +18,6 @@ export const parseNumberToTextWithDictionary: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { number, dictionary },
@@ -50,7 +44,7 @@ export const parseNumberToTextWithDictionary: Action<
 
       const text = getStringFromDictionary()
       helpers.log(
-        { meta, number, dictionary, text },
+        { number, dictionary, text },
         'Parsed number to text with dictionary',
       )
 
@@ -60,7 +54,7 @@ export const parseNumberToTextWithDictionary: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/parseStringToPhoneNumber/parseStringToPhoneNumber.ts
+++ b/extensions/transform/v1/actions/parseStringToPhoneNumber/parseStringToPhoneNumber.ts
@@ -23,14 +23,8 @@ export const parseStringToPhoneNumber: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing parseStringToPhoneNumber',
     )
 
@@ -59,7 +53,7 @@ export const parseStringToPhoneNumber: Action<
             }),
           )
           helpers.log(
-            { meta, text, countryCallingCode, phoneNumber: parsed.data },
+            { text, countryCallingCode, phoneNumber: parsed.data },
             'Parsed text to phone number',
           )
           return parsed.data
@@ -75,7 +69,7 @@ export const parseStringToPhoneNumber: Action<
             }),
           )
           const err = new ZodError(parsed.error.issues)
-          helpers.log({ meta, text, countryCallingCode, err }, 'error', err)
+          helpers.log({ text, countryCallingCode, err }, 'error', err)
           throw err
         }
 
@@ -93,12 +87,12 @@ export const parseStringToPhoneNumber: Action<
         try {
           phoneNumber = E164PhoneValidationSchema.parse(withCode)
         } catch (err) {
-          helpers.log({ meta, err }, 'error', err as Error)
+          helpers.log({ err }, 'error', err as Error)
           throw err
         }
 
         helpers.log(
-          { meta, text, countryCallingCode, phoneNumber },
+          { text, countryCallingCode, phoneNumber },
           'Parsed text to phone number',
         )
         return phoneNumber
@@ -111,7 +105,7 @@ export const parseStringToPhoneNumber: Action<
         events,
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/transform/v1/actions/parseTextToNumber/parseTextToNumber.ts
+++ b/extensions/transform/v1/actions/parseTextToNumber/parseTextToNumber.ts
@@ -19,12 +19,6 @@ export const parseTextToNumber: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { text },
@@ -38,7 +32,7 @@ export const parseTextToNumber: Action<
       const parsed = parseFloat(text)
       const output = isNaN(parsed) ? NaN : parsed
 
-      helpers.log({ meta, text, number: output }, 'Parsed text to number')
+      helpers.log({ text, number: output }, 'Parsed text to number')
 
       await onComplete({
         data_points: {
@@ -46,7 +40,7 @@ export const parseTextToNumber: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/parseUnixTimestampToDate/parseUnixTimestampToDate.ts
+++ b/extensions/transform/v1/actions/parseUnixTimestampToDate/parseUnixTimestampToDate.ts
@@ -18,12 +18,6 @@ export const parseUnixTimestampToDate: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         fields: { unixTimeStamp },
@@ -36,10 +30,7 @@ export const parseUnixTimestampToDate: Action<
 
       const isoDate = new Date(unixTimeStamp * 1000).toISOString()
 
-      helpers.log(
-        { meta, unixTimeStamp, isoDate },
-        'Parsed unix timestamp to date',
-      )
+      helpers.log({ unixTimeStamp, isoDate }, 'Parsed unix timestamp to date')
 
       await onComplete({
         data_points: {
@@ -47,7 +38,7 @@ export const parseUnixTimestampToDate: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/transform/v1/actions/serializeJson/serializeJson.ts
+++ b/extensions/transform/v1/actions/serializeJson/serializeJson.ts
@@ -17,13 +17,7 @@ export const serializeJson: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing serializeJson')
+    helpers.log({ fields: payload.fields }, 'Processing serializeJson')
 
     try {
       const {
@@ -36,7 +30,7 @@ export const serializeJson: Action<
       })
 
       const serializedJson = JSON.stringify(json)
-      helpers.log({ meta, json, serializedJson }, 'Serialized JSON')
+      helpers.log({ json, serializedJson }, 'Serialized JSON')
 
       await onComplete({
         data_points: {
@@ -44,7 +38,7 @@ export const serializeJson: Action<
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/twilio/v1/actions/patientSmsNotification.ts
+++ b/extensions/twilio/v1/actions/patientSmsNotification.ts
@@ -43,16 +43,7 @@ export const patientSmsNotification: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing patientSmsNotification',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing patientSmsNotification')
 
     try {
       const {
@@ -76,7 +67,7 @@ export const patientSmsNotification: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/twilio/v1/actions/smsNotification.ts
+++ b/extensions/twilio/v1/actions/smsNotification.ts
@@ -50,13 +50,7 @@ export const smsNotification: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing smsNotification')
+    helpers.log({ fields: payload.fields }, 'Processing smsNotification')
 
     try {
       const {
@@ -77,7 +71,7 @@ export const smsNotification: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/twilio/v2/actions/createFlowExecution/createFlowExecution.ts
+++ b/extensions/twilio/v2/actions/createFlowExecution/createFlowExecution.ts
@@ -15,16 +15,7 @@ export const createFlowExecution: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing createFlowExecution',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing createFlowExecution')
 
     try {
       const {
@@ -55,7 +46,7 @@ export const createFlowExecution: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/twilio/v2/actions/getMessages/getMessages.ts
+++ b/extensions/twilio/v2/actions/getMessages/getMessages.ts
@@ -20,13 +20,7 @@ export const getMessages: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getMessages')
+    helpers.log({ fields: payload.fields }, 'Processing getMessages')
 
     try {
       const {
@@ -76,7 +70,7 @@ export const getMessages: Action<typeof fields, typeof settings> = {
         },
       })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (err instanceof ZodError) {
         const error = fromZodError(err)
         await onError({

--- a/extensions/twilio/v2/actions/sendSms/sendSms.ts
+++ b/extensions/twilio/v2/actions/sendSms/sendSms.ts
@@ -19,13 +19,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendSms')
+    helpers.log({ fields: payload.fields }, 'Processing sendSms')
 
     try {
       const {
@@ -87,7 +81,7 @@ export const sendSms: Action<typeof fields, typeof settings> = {
         ],
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (isTwilioErrorResponse(error)) {
         await onError({
           events: [parseTwilioError(error)],

--- a/extensions/twilio/v2/actions/sendSmsDuringBusinessHours/sendSmsDuringBusinessHours.ts
+++ b/extensions/twilio/v2/actions/sendSmsDuringBusinessHours/sendSmsDuringBusinessHours.ts
@@ -27,14 +27,8 @@ export const sendSmsDuringBusinessHours: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing sendSmsDuringBusinessHours',
     )
 
@@ -115,7 +109,7 @@ export const sendSmsDuringBusinessHours: Action<
         ],
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (isTwilioErrorResponse(error)) {
         await onError({
           events: [parseTwilioError(error)],

--- a/extensions/twilio/v2/actions/sendSmsWithMessagingSid/sendSmsWithMessagingService.ts
+++ b/extensions/twilio/v2/actions/sendSmsWithMessagingSid/sendSmsWithMessagingService.ts
@@ -22,14 +22,8 @@ export const sendSmsWithMessagingService: Action<
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     helpers.log(
-      { meta, fields: payload.fields },
+      { fields: payload.fields },
       'Processing sendSmsWithMessagingService',
     )
 
@@ -96,7 +90,7 @@ export const sendSmsWithMessagingService: Action<
         ],
       })
     } catch (error) {
-      helpers.log({ meta, error }, 'error', error as Error)
+      helpers.log({ error }, 'error', error as Error)
       if (isTwilioErrorResponse(error)) {
         await onError({
           events: [parseTwilioError(error)],

--- a/extensions/westFax/actions/getFaxDocument/getFaxDocument.ts
+++ b/extensions/westFax/actions/getFaxDocument/getFaxDocument.ts
@@ -16,13 +16,7 @@ export const getFaxDocument: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing getFaxDocument')
+    helpers.log({ fields: payload.fields }, 'Processing getFaxDocument')
 
     const { fields, westFaxSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,

--- a/extensions/westFax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
+++ b/extensions/westFax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
@@ -20,16 +20,7 @@ export const getFaxDocumentWithOCR: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log(
-      { meta, fields: payload.fields },
-      'Processing getFaxDocumentWithOCR',
-    )
+    helpers.log({ fields: payload.fields }, 'Processing getFaxDocumentWithOCR')
 
     const { fields, westFaxSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,

--- a/extensions/westFax/actions/sendFax/sendFax.ts
+++ b/extensions/westFax/actions/sendFax/sendFax.ts
@@ -18,13 +18,7 @@ export const sendFax: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing sendFax')
+    helpers.log({ fields: payload.fields }, 'Processing sendFax')
 
     const { fields, settings } = validate({
       schema: z.object({
@@ -124,7 +118,7 @@ export const sendFax: Action<typeof fields, typeof settings> = {
         }
       }
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       const error = err as Error
       await onError({
         events: [

--- a/extensions/zendesk/v1/actions/createTicket/createTicket.ts
+++ b/extensions/zendesk/v1/actions/createTicket/createTicket.ts
@@ -20,12 +20,6 @@ export const createTicket: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings,
@@ -49,7 +43,7 @@ export const createTicket: Action<typeof fields, typeof settings> = {
         ...(!isNil(tag) && { tags: [tag] }),
       }
 
-      helpers.log({ meta, ticketData }, 'Creating Zendesk ticket')
+      helpers.log({ ticketData }, 'Creating Zendesk ticket')
       const response = await client.createTicket(ticketData)
 
       await onComplete({

--- a/extensions/zendesk/v1/actions/deleteTicket/deleteTicket.ts
+++ b/extensions/zendesk/v1/actions/deleteTicket/deleteTicket.ts
@@ -18,12 +18,6 @@ export const deleteTicket: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings,
@@ -39,7 +33,7 @@ export const deleteTicket: Action<typeof fields, typeof settings> = {
       const client = makeAPIClient(settings)
       const ticketIdInput = String(ticketId)
 
-      helpers.log({ meta, ticketIdInput }, 'Deleting Zendesk ticket')
+      helpers.log({ ticketIdInput }, 'Deleting Zendesk ticket')
       await client.deleteTicket(ticketIdInput)
 
       await onComplete()

--- a/extensions/zendesk/v1/actions/updateTicket/updateTicket.ts
+++ b/extensions/zendesk/v1/actions/updateTicket/updateTicket.ts
@@ -19,12 +19,6 @@ export const updateTicket: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     try {
       const {
         settings,
@@ -45,7 +39,7 @@ export const updateTicket: Action<typeof fields, typeof settings> = {
         ...(!isNil(status) && { status }),
       }
 
-      helpers.log({ meta, updateData }, 'Updating Zendesk ticket')
+      helpers.log({ updateData }, 'Updating Zendesk ticket')
       await client.updateTicket(ticket_id.toString(), updateData)
 
       await onComplete({})

--- a/extensions/zendeskSell/v1/actions/completeTask/completeTask.ts
+++ b/extensions/zendeskSell/v1/actions/completeTask/completeTask.ts
@@ -18,13 +18,7 @@ export const completeTask: Action<typeof fields, typeof settings> = {
   fields,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing completeTask')
+    helpers.log({ fields: payload.fields }, 'Processing completeTask')
 
     try {
       const {
@@ -48,7 +42,7 @@ export const completeTask: Action<typeof fields, typeof settings> = {
 
       await onComplete()
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (isSalesApiError(err)) {
         const events = salesApiErrorToActivityEvent(err)
         await onError({ events })

--- a/extensions/zendeskSell/v1/actions/createTask/createTask.ts
+++ b/extensions/zendeskSell/v1/actions/createTask/createTask.ts
@@ -19,13 +19,7 @@ export const createTask: Action<typeof fields, typeof settings> = {
   dataPoints,
   previewable: true,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
-    helpers.log({ meta, fields: payload.fields }, 'Processing createTask')
+    helpers.log({ fields: payload.fields }, 'Processing createTask')
 
     try {
       const {
@@ -63,7 +57,7 @@ export const createTask: Action<typeof fields, typeof settings> = {
 
       await onComplete({ data_points: { taskId: String(res.data.data.id) } })
     } catch (err) {
-      helpers.log({ meta, err }, 'error', err as Error)
+      helpers.log({ err }, 'error', err as Error)
       if (isSalesApiError(err)) {
         const events = salesApiErrorToActivityEvent(err)
         await onError({ events })

--- a/extensions/zoom/actions/sendSms/sendSms.ts
+++ b/extensions/zoom/actions/sendSms/sendSms.ts
@@ -60,12 +60,6 @@ export const sendSms: Action<
     onError,
     helpers: { log },
   }): Promise<void> => {
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
-
     const { fields, zoomSdk } = await validatePayloadAndCreateSdk({
       fieldsSchema: FieldsValidationSchema,
       payload,
@@ -77,7 +71,7 @@ export const sendSms: Action<
       body: fields.body,
     }
 
-    log({ meta, sendSmsInput }, 'Sending SMS via Zoom')
+    log({ sendSmsInput }, 'Sending SMS via Zoom')
     const { data } = await zoomSdk.sendSms(sendSmsInput)
 
     /**

--- a/scripts/generate-extension.ts
+++ b/scripts/generate-extension.ts
@@ -232,14 +232,9 @@ export const helloWorld: Action<
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     const { fields } = payload
     const message = fields.message ?? 'Hello, World!'
-    const meta = {
-      tenant_id: payload.pathway.tenant_id,
-      careflow_id: payload.pathway.id,
-      activity_id: payload.activity.id,
-    }
 
     // Log the message using the helpers
-    helpers.log({ meta, message }, 'Hello World Action')
+    helpers.log({ message }, 'Hello World Action')
 
     await onComplete({
       data_points: {


### PR DESCRIPTION
Rely on extension-server context instead of duplicating tenant, careflow, and activity metadata in every action log.