### PR TITLE
fix: ease validation on Metriport baseUrl

### DIFF
--- a/extensions/metriport/client.ts
+++ b/extensions/metriport/client.ts
@@ -7,7 +7,7 @@ export const createMetriportApi = (
 ): MetriportMedicalApi => {
   const { apiKey, baseUrl } = settingsSchema.parse(payloadSettings)
 
-  if (baseUrl !== undefined && baseUrl.length > 0) {
+  if (baseUrl) {
     return new MetriportMedicalApi(apiKey, {
       baseAddress: baseUrl,
     })

--- a/extensions/metriport/validation/settings.zod.ts
+++ b/extensions/metriport/validation/settings.zod.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 export const settingsSchema = z.object({
   baseUrl: z
     .string({ errorMap: () => ({ message: 'Missing baseUrl' }) })
-    .min(1)
     .optional(),
   apiKey: z.string({ errorMap: () => ({ message: 'Missing apiKey' }) }).min(1),
 })


### PR DESCRIPTION
Arango isn't able to return `undefined` for values where we have keys. So `min(1)` in Zod always evaluates false if we don't have a baseUrl. 