### PR TITLE
chore: notify awell-docs to regenerate Marketplace on release

### DIFF
--- a/.github/workflows/version-created.yml
+++ b/.github/workflows/version-created.yml
@@ -51,3 +51,20 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/awell-health/awell-extension-server/actions/workflows/update-dependency.yml/dispatches \
             -d '{"ref":"main","inputs":{"dependency":"@awell-health/awell-extensions","version":"'"$CURRENT_VERSION"'"}}'
+
+      - name: Notify awell-docs to regenerate Marketplace
+        env:
+          TOKEN: ${{ secrets.CONTENTS_AND_WORKFLOWS_TOKEN }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+        run: |
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+          jq -n \
+            --arg v "$CURRENT_VERSION" --arg u "$RELEASE_URL" --arg n "$RELEASE_NOTES" \
+            '{event_type:"marketplace-update", client_payload:{version:$v, release_url:$u, release_notes:$n}}' \
+            > /tmp/payload.json
+          curl -sf -X POST \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/awell-health/awell-docs/dispatches \
+            -d @/tmp/payload.json


### PR DESCRIPTION
## Summary
- Adds a step to the `Publish Release` workflow (`version-created.yml`) that fires a `marketplace-update` `repository_dispatch` event to `awell-health/awell-docs` whenever a release is published, so the Marketplace docs regenerate automatically.
- Sources the version from `package.json` (bare semver) rather than `github.event.release.tag_name` (which carries a `v` prefix in this repo — see `create-release.yml`), so it matches what was actually published to npm and what the awell-docs manifest records.
- Leaves the existing `Redeploy the extension server` step untouched; the new step extracts its own `CURRENT_VERSION`.

## Notes
- Requires a `CONTENTS_AND_WORKFLOWS_TOKEN` repo secret with dispatch access to `awell-health/awell-docs`. Make sure it exists before the next release publishes, otherwise this step will 401.
- `release_notes` is included in the dispatch payload. If the awell-docs receiver doesn't use it, it's harmless extra payload; if you'd like it surfaced in the generated PR body, that's a change on the awell-docs side.

## Test plan
- [ ] Confirm `CONTENTS_AND_WORKFLOWS_TOKEN` secret exists in repo settings.
- [ ] On the next release publish, verify the `Notify awell-docs to regenerate Marketplace` step succeeds (HTTP 204).
- [ ] Verify a `marketplace-update` dispatch is received in `awell-health/awell-docs` and the automated PR opens.

Made with [Cursor](https://cursor.com)