### PR TITLE
feat(metriport): accept Awell gender labels for genderAtBirth

### DIFF
--- a/extensions/metriport/actions/patient/fields.ts
+++ b/extensions/metriport/actions/patient/fields.ts
@@ -33,7 +33,7 @@ export const createFields = {
   genderAtBirth: {
     id: 'genderAtBirth',
     label: 'Gender at Birth',
-    description: `The Patient's gender at birth, can be one of M or F`,
+    description: `The Patient's gender at birth. Accepts M, F, O or U as well as Male, Female, Other or Unknown`,
     type: FieldType.STRING,
     required: true,
   },

--- a/extensions/metriport/actions/patient/validation.test.ts
+++ b/extensions/metriport/actions/patient/validation.test.ts
@@ -1,0 +1,26 @@
+import { genderAtBirthTransformSchema } from './validation'
+
+describe('genderAtBirthTransformSchema', () => {
+  test.each([
+    ['Male', 'M'],
+    ['Female', 'F'],
+    ['Other', 'O'],
+    ['Unknown', 'U'],
+    ['NOT_KNOWN', 'U'],
+    [' female ', 'F'],
+    ['m', 'M'],
+  ])('maps the Awell value "%s" to "%s"', (input, expected) => {
+    expect(genderAtBirthTransformSchema.parse(input)).toBe(expected)
+  })
+
+  test.each(['M', 'F', 'O', 'U'])(
+    'passes through the Metriport code "%s"',
+    (input) => {
+      expect(genderAtBirthTransformSchema.parse(input)).toBe(input)
+    },
+  )
+
+  test.each(['', 'Man', 'X', undefined, null, 1])('rejects %p', (input) => {
+    expect(() => genderAtBirthTransformSchema.parse(input)).toThrow()
+  })
+})

--- a/extensions/metriport/actions/patient/validation.ts
+++ b/extensions/metriport/actions/patient/validation.ts
@@ -5,11 +5,39 @@ import {
   usStateForAddressSchema,
 } from '@metriport/api-sdk'
 
+/**
+ * Awell stores a patient's sex as `Male`, `Female` or `Unknown` while Metriport
+ * expects a single letter code (`M`, `F`, `O`, `U`). Anything already in
+ * Metriport's format is passed through untouched; anything we don't recognise
+ * is left alone so Metriport's schema rejects it, surfacing the bad patient
+ * data rather than quietly recording the sex as unknown.
+ */
+const genderAtBirthAliases: Record<
+  string,
+  z.infer<typeof genderAtBirthSchema>
+> = {
+  m: 'M',
+  male: 'M',
+  f: 'F',
+  female: 'F',
+  o: 'O',
+  other: 'O',
+  u: 'U',
+  unknown: 'U',
+  not_known: 'U',
+}
+
+export const genderAtBirthTransformSchema = z.preprocess((value) => {
+  if (typeof value !== 'string') return value
+
+  return genderAtBirthAliases[value.trim().toLowerCase()] ?? value
+}, genderAtBirthSchema)
+
 export const patientCreateSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
   dob: z.string().length(10),
-  genderAtBirth: genderAtBirthSchema,
+  genderAtBirth: genderAtBirthTransformSchema,
   addressLine1: z.string().min(1),
   addressLine2: z.string().optional(),
   city: z.string().min(1),


### PR DESCRIPTION
Awell stores a patient's sex as `Male`, `Female` or `Unknown` while Metriport's `genderAtBirthSchema` only accepts the single letter codes `M`, `F`, `O` and `U`. Passing a care flow's patient sex straight into `createPatient` or `updatePatient` therefore failed validation before the request ever reached Metriport.

`genderAtBirthTransformSchema` preprocesses the field into Metriport's format:

- the Awell labels (plus the GraphQL `NOT_KNOWN` variant) map onto their codes
- matching is case-insensitive and trimmed
- values already in Metriport's format pass through untouched
- unrecognised values are left alone so Metriport's schema rejects them and the action errors — bad patient data should be surfaced, not quietly recorded as an unknown sex

The SDK's schema stays the source of truth for the output, so the parsed type is unchanged and `convertToMetriportPatient` needed no change. Because the schema is shared, both `createPatient` and `updatePatient` pick this up.

The `genderAtBirth` field description is updated too — it previously claimed the field "can be one of M or F", which was already wrong for `O`/`U`.

## Testing

- `extensions/metriport/actions/patient/validation.test.ts` covers the label mappings, pass-through of Metriport codes, and rejection of unrecognised or missing values (17 cases, passing)
- `yarn compile` and `eslint` clean on the touched files