### PR TITLE
chore(metriport): rename the enrollment webhook to realtimeUpdate

### DIFF
--- a/extensions/metriport/CHANGELOG.md
+++ b/extensions/metriport/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## August 2026
 
+- Rename the `enrollment` webhook to `realtimeUpdate`. The old name described what Awell does with the notification rather than what Metriport sends, which read confusingly next to the genuine enrolment concepts (the `Cohort` field, enrolling a patient into a care flow). Behaviour is unchanged. **Breaking: the webhook endpoint URL changes, so any webhook already configured in the Metriport dashboard must be repointed.**
 - `Date of Birth` on the `Create Patient` and `Update Patient` actions is now a date field rather than a free-text string, so care flows can map a date onto it directly instead of hand-formatting `YYYY-MM-DD`. The value is normalised to the date-only string Metriport expects, so care flows already passing `YYYY-MM-DD` are unaffected.
 
 ## July 2026

--- a/extensions/metriport/README.md
+++ b/extensions/metriport/README.md
@@ -77,16 +77,16 @@ Visit [endpoint docs](https://docs.metriport.com/medical-api/api-reference/cohor
 
 ## Get Webhook Bundle
 
-Fetches the FHIR bundle from a Metriport webhook payload URL — e.g. the [Encounter Bundle](https://docs.metriport.com/medical-api/handling-data/patient-encounter-bundle) from an ADT notification, or a discharge summary. Pass the `bundleUrl` data point emitted by the **Enrollment** webhook; the action downloads the bundle and returns it on the `bundle` data point.
+Fetches the FHIR bundle from a Metriport webhook payload URL — e.g. the [Encounter Bundle](https://docs.metriport.com/medical-api/handling-data/patient-encounter-bundle) from an ADT notification, or a discharge summary. Pass the `bundleUrl` data point emitted by the **Realtime Update** webhook; the action downloads the bundle and returns it on the `bundle` data point.
 
 When the payload is a Patient Encounter Bundle, the action also rewrites it into an executable FHIR transaction and returns that on the `transactionBundle` data point, ready to hand to the Medplum **Find or create resource** action.
 
-**NOTE: Metriport pre-signed URLs are only valid for 10 minutes, so this action should run early in the care flow, shortly after the enrollment webhook fires.**
+**NOTE: Metriport pre-signed URLs are only valid for 10 minutes, so this action should run early in the care flow, shortly after the realtime update webhook fires.**
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `url` | string | The pre-signed payload URL to fetch (the webhook's `bundleUrl` data point). |
-| `eventType` | string (optional) | The Metriport notification type — wire this from the enrollment webhook's `eventType` data point. Recorded on the import Provenance so admit, transfer and discharge can be told apart. |
+| `eventType` | string (optional) | The Metriport notification type — wire this from the realtime update webhook's `eventType` data point. Recorded on the import Provenance so admit, transfer and discharge can be told apart. |
 | `provenanceReason` | text (optional) | Free-text reason recorded on the import Provenance, describing why the data was imported. |
 
 | Data point | Type | Description |
@@ -134,7 +134,7 @@ A transaction resolves an internal reference by matching it against `fullUrl` ve
 
 ### Wiring it into a care flow
 
-1. **Enrollment** webhook fires and emits `bundleUrl` and `eventType`.
+1. **Realtime Update** webhook fires and emits `bundleUrl` and `eventType`.
 2. **Get Webhook Bundle** — pass `bundleUrl` to `url` and `eventType` to `eventType`. Run this early; the URL expires after 10 minutes.
 3. Medplum **Find or create resource** — pass the `transactionBundle` data point to its `resourceJson` field. No changes to that action are needed; it detects a Bundle and executes it.
 
@@ -150,7 +150,7 @@ A `collection` bundle that is missing its Patient or Encounter entry is treated 
 
 # Webhooks
 
-## Enrollment
+## Realtime Update
 
 An enrollment trigger that starts a care flow when Metriport sends a [real-time patient notification](https://docs.metriport.com/medical-api/handling-data/realtime-patient-notifications).
 

--- a/extensions/metriport/actions/webhookBundle/fields.ts
+++ b/extensions/metriport/actions/webhookBundle/fields.ts
@@ -6,7 +6,7 @@ export const fields = {
     id: 'url',
     label: 'Bundle URL',
     description:
-      'The pre-signed Metriport payload URL to fetch the FHIR bundle from. This is the `bundleUrl` data point emitted by the enrollment webhook. Note: Metriport pre-signed URLs are only valid for 10 minutes, so this action should run shortly after the webhook fires.',
+      'The pre-signed Metriport payload URL to fetch the FHIR bundle from. This is the `bundleUrl` data point emitted by the realtime update webhook. Note: Metriport pre-signed URLs are only valid for 10 minutes, so this action should run shortly after the webhook fires.',
     type: FieldType.STRING,
     required: true,
   },
@@ -14,7 +14,7 @@ export const fields = {
     id: 'eventType',
     label: 'Event Type',
     description:
-      'The Metriport notification type, as emitted on the enrollment webhook `eventType` data point. Recorded on the Provenance of the importable bundle so admission, transfer and discharge imports can be told apart. Leave empty to omit it.',
+      'The Metriport notification type, as emitted on the realtime update webhook `eventType` data point. Recorded on the Provenance of the importable bundle so admission, transfer and discharge imports can be told apart. Leave empty to omit it.',
     type: FieldType.STRING,
     required: false,
     options: {

--- a/extensions/metriport/actions/webhookBundle/getWebhookBundle.ts
+++ b/extensions/metriport/actions/webhookBundle/getWebhookBundle.ts
@@ -16,7 +16,7 @@ export const getWebhookBundle: Action<
   category: Category.EHR_INTEGRATIONS,
   title: 'Get Webhook Bundle',
   description:
-    'Fetches the FHIR bundle from a Metriport webhook payload URL (e.g. the Encounter Bundle from an ADT notification, or a discharge summary). The URL is provided by the enrollment webhook on the `bundleUrl` data point and is only valid for 10 minutes.',
+    'Fetches the FHIR bundle from a Metriport webhook payload URL (e.g. the Encounter Bundle from an ADT notification, or a discharge summary). The URL is provided by the realtime update webhook on the `bundleUrl` data point and is only valid for 10 minutes.',
   fields,
   previewable: true,
   supports_automated_retries: true,

--- a/extensions/metriport/webhooks/index.ts
+++ b/extensions/metriport/webhooks/index.ts
@@ -1,4 +1,4 @@
-import { enrollment } from './enrollment'
-export type { Enrollment } from './enrollment'
+import { realtimeUpdate } from './realtimeUpdate'
+export type { RealtimeUpdate } from './realtimeUpdate'
 
-export const webhooks = [enrollment]
+export const webhooks = [realtimeUpdate]

--- a/extensions/metriport/webhooks/realtimeUpdate.test.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.test.ts
@@ -1,9 +1,9 @@
 import crypto from 'crypto'
 import { TestHelpers } from '@awell-health/extensions-core'
 import {
-  enrollment as webhook,
+  realtimeUpdate as webhook,
   METRIPORT_PATIENT_IDENTIFIER_SYSTEM,
-} from './enrollment'
+} from './realtimeUpdate'
 import { MetriportWebhookType } from './types'
 
 const sign = (key: string, body: string): string =>
@@ -46,7 +46,7 @@ const dischargeSummaryPayload = {
   ],
 }
 
-describe('Metriport - Webhook - Enrollment', () => {
+describe('Metriport - Webhook - Realtime Update', () => {
   const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
     TestHelpers.fromWebhook(webhook)
 

--- a/extensions/metriport/webhooks/realtimeUpdate.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.ts
@@ -13,7 +13,7 @@ import {
 import { isWebhookRequestAuthorized } from '../shared/verifyWebhookSignature'
 import {
   MetriportWebhookType,
-  type MetriportEnrollmentWebhookPayload,
+  type MetriportRealtimeUpdateWebhookPayload,
 } from './types'
 import { webhookPayloadSchema, type WebhookPayloadSchema } from './validation.zod'
 
@@ -74,14 +74,14 @@ const isDischargeSummary = (
 ): webhook is DischargeSummaryWebhook =>
   webhook.meta.type === MetriportWebhookType.DischargeSummary
 
-export const enrollment: Webhook<
+export const realtimeUpdate: Webhook<
   keyof typeof dataPoints,
-  MetriportEnrollmentWebhookPayload,
+  MetriportRealtimeUpdateWebhookPayload,
   typeof settings
 > = {
-  key: 'enrollment',
+  key: 'realtimeUpdate',
   description:
-    'Enrolls a patient when Metriport sends a real-time notification. The `eventType` data point carries the Metriport webhook type (`patient.admit` or `medical.discharge-summary`) so it can be distinguished on. The FHIR bundle is not fetched here — the pre-signed URL is passed on the `bundleUrl` data point and can be retrieved later with the "Get Webhook Bundle" action.',
+    'Starts a care flow when Metriport sends a real-time patient notification. The `eventType` data point carries the Metriport webhook type (`patient.admit` or `medical.discharge-summary`) so it can be distinguished on. The FHIR bundle is not fetched here — the pre-signed URL is passed on the `bundleUrl` data point and can be retrieved later with the "Get Webhook Bundle" action.',
   dataPoints,
   onEvent: async ({
     payload: { payload, rawBody, headers, settings, endpoint },
@@ -241,4 +241,4 @@ export const enrollment: Webhook<
   },
 }
 
-export type Enrollment = typeof enrollment
+export type RealtimeUpdate = typeof realtimeUpdate

--- a/extensions/metriport/webhooks/types.ts
+++ b/extensions/metriport/webhooks/types.ts
@@ -94,11 +94,11 @@ export interface MetriportPingWebhook {
 }
 
 /**
- * The union of all payloads that can be received on the enrollment webhook
+ * The union of all payloads that can be received on the realtime update webhook
  * endpoint. Metriport POSTs every notification type to the same URL, so the
  * handler must discriminate on `meta.type`.
  */
-export type MetriportEnrollmentWebhookPayload =
+export type MetriportRealtimeUpdateWebhookPayload =
   | MetriportPatientAdmitWebhook
   | MetriportPatientDischargeWebhook
   | MetriportPatientTransferWebhook


### PR DESCRIPTION
> Stacked on #811.

"Enrollment" named what *Awell* does with the notification rather than what *Metriport* sends, which read confusingly alongside the genuine enrolment concepts in this extension — the `Cohort` field, and enrolling a patient into a care flow. Metriport calls these [real-time patient notifications](https://docs.metriport.com/medical-api/handling-data/realtime-patient-notifications), so this names the webhook after the event it carries.

No behaviour change.

### What changed

| before | after |
| --- | --- |
| `webhooks/enrollment.ts` | `webhooks/realtimeUpdate.ts` |
| `webhooks/enrollment.test.ts` | `webhooks/realtimeUpdate.test.ts` |
| `export const enrollment` | `export const realtimeUpdate` |
| `type Enrollment` | `type RealtimeUpdate` |
| `MetriportEnrollmentWebhookPayload` | `MetriportRealtimeUpdateWebhookPayload` |
| `key: 'enrollment'` | `key: 'realtimeUpdate'` |

Both files moved with `git mv` so history follows. Prose updated in the README (`## Enrollment` → `## Realtime Update`, plus 4 references) and in the **Get Webhook Bundle** action/field descriptions that pointed at the webhook.

Genuine enrolment language is deliberately left alone — "an enrollment trigger", the `Cohort` field description, and the note that `metriportPatientId` doubles as the patient identifier for enrollment all still describe real enrolment.

### ⚠️ Breaking

`key` changes, so **the webhook endpoint URL changes** and any webhook already configured in the Metriport dashboard must be repointed.

**This is the open question on this PR.** I changed the key on the assumption it isn't stably configured anywhere yet — the webhook shipped last month, and its `medical.discharge-summary` payload shape is still marked TBD in the code pending confirmation from Metriport. If that assumption is wrong, keeping `key: 'enrollment'` while renaming everything else is a one-line revert here plus the CHANGELOG note; the cost is a permanent mismatch between the file name and the wire-facing key.

### Verification

- `yarn compile` — clean
- `yarn test-file extensions/metriport` — 10 suites, 99 tests passing, including the renamed suite (11 tests) under its new `Metriport - Webhook - Realtime Update` describe
- `grep -ri enrollment extensions/metriport` — only the two intentional prose hits remain
- Lint — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
