### PR TITLE
chore: Relax Metriport dedupe for non-prod environments

### DIFF
--- a/extensions/metriport/shared/shouldDedupe.test.ts
+++ b/extensions/metriport/shared/shouldDedupe.test.ts
@@ -1,0 +1,33 @@
+import { shouldDedupe } from './shouldDedupe'
+
+describe('Metriport - shouldDedupe', () => {
+  const ORIGINAL_AWELL_ENVIRONMENT = process.env.AWELL_ENVIRONMENT
+
+  afterEach(() => {
+    process.env.AWELL_ENVIRONMENT = ORIGINAL_AWELL_ENVIRONMENT
+  })
+
+  test.each(['production', 'production-eu', 'api-production'])(
+    'Should dedupe when AWELL_ENVIRONMENT is "%s"',
+    (environment) => {
+      process.env.AWELL_ENVIRONMENT = environment
+
+      expect(shouldDedupe()).toBe(true)
+    },
+  )
+
+  test.each(['sandbox', 'staging', 'development', ''])(
+    'Should not dedupe when AWELL_ENVIRONMENT is "%s"',
+    (environment) => {
+      process.env.AWELL_ENVIRONMENT = environment
+
+      expect(shouldDedupe()).toBe(false)
+    },
+  )
+
+  test('Should not dedupe when AWELL_ENVIRONMENT is unset', () => {
+    delete process.env.AWELL_ENVIRONMENT
+
+    expect(shouldDedupe()).toBe(false)
+  })
+})

--- a/extensions/metriport/shared/shouldDedupe.ts
+++ b/extensions/metriport/shared/shouldDedupe.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether duplicate webhook deliveries should be deduped via the rate limiter.
+ *
+ * We only dedupe in production: Metriport sandbox testing always sends the same
+ * data (and reuses the same `meta.messageId`), which would make the dedupe guard
+ * a blocker for development.
+ *
+ * Lives in its own module so tests can mock it and exercise the rate-limiting
+ * behaviour without mutating `process.env`.
+ */
+export const shouldDedupe = (): boolean =>
+  process.env.AWELL_ENVIRONMENT?.includes('production') ?? false

--- a/extensions/metriport/webhooks/realtimeUpdate.test.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.test.ts
@@ -1,10 +1,17 @@
 import crypto from 'crypto'
 import { TestHelpers } from '@awell-health/extensions-core'
+import { shouldDedupe } from '../shared/shouldDedupe'
 import {
   realtimeUpdate as webhook,
   METRIPORT_PATIENT_IDENTIFIER_SYSTEM,
 } from './realtimeUpdate'
 import { MetriportWebhookType } from './types'
+
+jest.mock('../shared/shouldDedupe', () => ({
+  shouldDedupe: jest.fn().mockReturnValue(false),
+}))
+
+const mockedShouldDedupe = jest.mocked(shouldDedupe)
 
 const sign = (key: string, body: string): string =>
   crypto.createHmac('sha256', key).update(body).digest('hex')
@@ -52,6 +59,9 @@ describe('Metriport - Webhook - Realtime Update', () => {
 
   beforeEach(() => {
     clearMocks()
+    // Deduping is production-only; default to off so the other suites don't
+    // construct a rate limiter.
+    mockedShouldDedupe.mockReturnValue(false)
   })
 
   const invoke = async (payload: unknown, headers = {}): Promise<void> => {
@@ -296,6 +306,10 @@ describe('Metriport - Webhook - Realtime Update', () => {
   describe('When rate limiting is configured', () => {
     const settingsWithRateLimit = { ...mockSettings, rateLimitDuration: '1 m' }
 
+    beforeEach(() => {
+      mockedShouldDedupe.mockReturnValue(true)
+    })
+
     const invokeWithSettings = async (
       payload: unknown,
       settings: Record<string, string>,
@@ -356,6 +370,16 @@ describe('Metriport - Webhook - Realtime Update', () => {
       expect(onError).not.toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledTimes(1)
       // With no rateLimitDuration set the limiter is never constructed.
+      expect(helpers.rateLimiter).not.toHaveBeenCalled()
+    })
+
+    test('Should skip deduping entirely when the environment does not dedupe', async () => {
+      mockedShouldDedupe.mockReturnValue(false)
+
+      await invokeWithSettings(admitPayload, settingsWithRateLimit)
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
       expect(helpers.rateLimiter).not.toHaveBeenCalled()
     })
   })

--- a/extensions/metriport/webhooks/realtimeUpdate.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.ts
@@ -10,6 +10,7 @@ import {
   transformRateLimitDuration,
   type settings,
 } from '../settings'
+import { shouldDedupe } from '../shared/shouldDedupe'
 import { isWebhookRequestAuthorized } from '../shared/verifyWebhookSignature'
 import {
   MetriportWebhookType,
@@ -190,25 +191,30 @@ export const realtimeUpdate: Webhook<
       // a duplicate delivery of the same message within the configured window is
       // acknowledged with 200 OK (so Metriport stops retrying) but does not
       // re-enroll the patient. Distinct messages always pass.
-      const { success, data: durationString } =
-        rateLimitDurationSchema.safeParse(settings.rateLimitDuration)
-      if (success && !isNil(durationString)) {
-        const duration = transformRateLimitDuration(durationString)
-        const limiterName = `metriport-enrollment-${webhook.meta.type}-${endpoint?.id ?? 'global'}`
-        const limiter = rateLimiter(limiterName, {
-          requests: 1,
-          duration,
-        })
-        const key = webhook.meta.messageId
-        const { success } = await limiter.limit(key)
-        if (!success) {
-          await onError({
-            response: {
-              statusCode: 200,
-              message: `Rate limit exceeded on limiter ${limiterName} for messageId ${key}. 200 OK response sent to Metriport to prevent re-enrolling patient ${patientId} for a duplicate delivery of this message on endpoint ${endpoint?.url ?? 'global'}.`,
-            },
+      //
+      // We only add this rate limiter in production — see `shouldDedupe`.
+      //
+      if (shouldDedupe()) {
+        const { success, data: durationString } =
+          rateLimitDurationSchema.safeParse(settings.rateLimitDuration)
+        if (success && !isNil(durationString)) {
+          const duration = transformRateLimitDuration(durationString)
+          const limiterName = `metriport-enrollment-${webhook.meta.type}-${endpoint?.id ?? 'global'}`
+          const limiter = rateLimiter(limiterName, {
+            requests: 1,
+            duration,
           })
-          return
+          const key = webhook.meta.messageId
+          const { success } = await limiter.limit(key)
+          if (!success) {
+            await onError({
+              response: {
+                statusCode: 200,
+                message: `Rate limit exceeded on limiter ${limiterName} for messageId ${key}. 200 OK response sent to Metriport to prevent re-enrolling patient ${patientId} for a duplicate delivery of this message on endpoint ${endpoint?.url ?? 'global'}.`,
+              },
+            })
+            return
+          }
         }
       }
 


### PR DESCRIPTION
Metriport doens't allow for unique messageIds in sandbox testing. Consequently, we always get the same messageId which triggers our idempotency guard. 

Relaxing this check in non-prod environments until they allow generating random Ids. 