### PR TITLE
feat(metriport): expose the encounter id from the webhook bundle

### DIFF
--- a/extensions/metriport/README.md
+++ b/extensions/metriport/README.md
@@ -81,6 +81,8 @@ Fetches the FHIR bundle from a Metriport webhook payload URL — e.g. the [Encou
 
 When the payload is a Patient Encounter Bundle, the action also rewrites it into an executable FHIR transaction and returns that on the `transactionBundle` data point, ready to hand to the Medplum **Find or create resource** action.
 
+The Encounter's Metriport id is returned separately on the `encounterId` data point, so a later step can address the imported Encounter without re-parsing the bundle.
+
 **NOTE: Metriport pre-signed URLs are only valid for 10 minutes, so this action should run early in the care flow, shortly after the realtime update webhook fires.**
 
 | Field | Type | Description |
@@ -93,6 +95,7 @@ When the payload is a Patient Encounter Bundle, the action also rewrites it into
 | --- | --- | --- |
 | `bundle` | json | The FHIR bundle fetched from the URL, exactly as Metriport sent it. |
 | `transactionBundle` | json | The same data rewritten as an executable FHIR transaction. Omitted when the payload is not a Patient Encounter Bundle. |
+| `encounterId` | string | Metriport's UUID for the Encounter in the bundle. Resolve the imported Encounter in Medplum with `Encounter?identifier=https://metriport.com/fhir/encounter\|<encounterId>`. Omitted when the bundle carries no Encounter. |
 
 ### Building the transaction bundle
 

--- a/extensions/metriport/actions/webhookBundle/bundle/encounter.test.ts
+++ b/extensions/metriport/actions/webhookBundle/bundle/encounter.test.ts
@@ -1,0 +1,72 @@
+import { type Bundle } from '@medplum/fhirtypes'
+import { findEncounterId } from './encounter'
+import { patientAdmitBundle } from './__testdata__/patientAdmitBundle'
+
+describe('findEncounterId', () => {
+  test('Should return the id of the Encounter in a patient encounter bundle', () => {
+    expect(findEncounterId(patientAdmitBundle)).toBe(
+      'c60544e1-2e37-45fb-8160-3d583902cfde',
+    )
+  })
+
+  test('Should return undefined when the bundle has no Encounter', () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [{ resource: { resourceType: 'Patient', id: 'p1' } }],
+    }
+
+    expect(findEncounterId(bundle)).toBeUndefined()
+  })
+
+  test('Should return undefined when the bundle has no entries', () => {
+    expect(
+      findEncounterId({ resourceType: 'Bundle', type: 'searchset' }),
+    ).toBeUndefined()
+  })
+
+  test('Should return undefined when the Encounter has no id', () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Encounter',
+            status: 'finished',
+            class: { code: 'IMP' },
+          },
+        },
+      ],
+    }
+
+    expect(findEncounterId(bundle)).toBeUndefined()
+  })
+
+  test('Should return the first Encounter when the bundle carries several', () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Encounter',
+            id: 'enc-1',
+            status: 'finished',
+            class: { code: 'IMP' },
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Encounter',
+            id: 'enc-2',
+            status: 'finished',
+            class: { code: 'IMP' },
+          },
+        },
+      ],
+    }
+
+    expect(findEncounterId(bundle)).toBe('enc-1')
+  })
+})

--- a/extensions/metriport/actions/webhookBundle/bundle/encounter.ts
+++ b/extensions/metriport/actions/webhookBundle/bundle/encounter.ts
@@ -1,0 +1,18 @@
+import { type Bundle } from '@medplum/fhirtypes'
+
+/**
+ * The Metriport id of the Encounter a webhook bundle describes.
+ *
+ * This is Metriport's own UUID, not a Medplum resource id. It is the value
+ * `buildResourceEntry` stamps as `https://metriport.com/fhir/encounter|<id>`,
+ * so a care flow resolves the imported Encounter with
+ * `Encounter?identifier=https://metriport.com/fhir/encounter|<id>`.
+ *
+ * Read from any bundle rather than only a `collection`: a Patient Encounter
+ * Bundle is guaranteed to carry an Encounter — `buildTransactionBundle` throws
+ * without one — and there is no reason to hide the id when another bundle type
+ * happens to include one.
+ */
+export const findEncounterId = (bundle: Bundle): string | undefined =>
+  bundle.entry?.find((entry) => entry.resource?.resourceType === 'Encounter')
+    ?.resource?.id

--- a/extensions/metriport/actions/webhookBundle/dataPoints.ts
+++ b/extensions/metriport/actions/webhookBundle/dataPoints.ts
@@ -14,4 +14,14 @@ export const dataPoints = {
     key: 'transactionBundle',
     valueType: 'json',
   },
+  /**
+   * Metriport's own UUID for the Encounter in the bundle — not a Medplum
+   * resource id. The imported Encounter is addressable in Medplum as
+   * `Encounter?identifier=https://metriport.com/fhir/encounter|<encounterId>`.
+   * Omitted when the bundle carries no Encounter.
+   */
+  encounterId: {
+    key: 'encounterId',
+    valueType: 'string',
+  },
 } satisfies Record<string, DataPointDefinition>

--- a/extensions/metriport/actions/webhookBundle/getWebhookBundle.test.ts
+++ b/extensions/metriport/actions/webhookBundle/getWebhookBundle.test.ts
@@ -50,6 +50,7 @@ describe('Metriport - Get Webhook Bundle', () => {
     expect(onComplete).toHaveBeenCalledWith({
       data_points: {
         bundle: JSON.stringify(bundle),
+        encounterId: 'enc-1',
       },
     })
   })
@@ -93,6 +94,7 @@ describe('Metriport - Get Webhook Bundle', () => {
 
     const dataPoints = onComplete.mock.calls[0][0].data_points
     expect(dataPoints.bundle).toBe(JSON.stringify(patientAdmitBundle))
+    expect(dataPoints.encounterId).toBe('c60544e1-2e37-45fb-8160-3d583902cfde')
 
     const transactionBundle = JSON.parse(dataPoints.transactionBundle)
     expect(transactionBundle.type).toBe('transaction')
@@ -132,6 +134,30 @@ describe('Metriport - Get Webhook Bundle', () => {
     expect(
       onComplete.mock.calls[0][0].data_points.transactionBundle,
     ).toBeUndefined()
+  })
+
+  test('Should omit the encounter id when the bundle has no Encounter', async () => {
+    mockedFetchBundle.mockResolvedValue({
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [{ resource: { resourceType: 'Patient', id: 'p1' } }],
+    } as never)
+
+    await getWebhookBundle.onActivityCreated!(
+      generateTestPayload({
+        fields: {
+          url: 'https://example.com/other-bundle',
+          eventType: undefined,
+          provenanceReason: undefined,
+        },
+        settings,
+      }),
+      onComplete,
+      onError,
+    )
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onComplete.mock.calls[0][0].data_points.encounterId).toBeUndefined()
   })
 
   test('Should call onError when a collection bundle has no Encounter', async () => {

--- a/extensions/metriport/actions/webhookBundle/getWebhookBundle.ts
+++ b/extensions/metriport/actions/webhookBundle/getWebhookBundle.ts
@@ -6,6 +6,7 @@ import { getWebhookBundleSchema } from './validation'
 import { dataPoints } from './dataPoints'
 import { fetchBundle } from './fetchBundle'
 import { buildTransactionBundle } from './bundle'
+import { findEncounterId } from './bundle/encounter'
 
 export const getWebhookBundle: Action<
   typeof fields,
@@ -41,9 +42,12 @@ export const getWebhookBundle: Action<
         reason: provenanceReason,
       })
 
+      const encounterId = findEncounterId(bundle)
+
       await onComplete({
         data_points: {
           bundle: JSON.stringify(bundle),
+          ...(encounterId !== undefined ? { encounterId } : {}),
           ...(transactionBundle !== undefined
             ? { transactionBundle: JSON.stringify(transactionBundle) }
             : {}),


### PR DESCRIPTION
## What

Adds an `encounterId` data point to the **Get Webhook Bundle** action, carrying Metriport's UUID for the Encounter in the fetched bundle.

## Why

Nothing in the extension surfaced the Encounter's identity, so a care flow that imported an encounter bundle had no way to refer back to the Encounter it just wrote. The value is the same one stamped as `https://metriport.com/fhir/encounter|<id>` on the imported resource, so the Encounter is addressable in Medplum as `Encounter?identifier=https://metriport.com/fhir/encounter|<encounterId>`.

The webhook cannot supply this — Metriport's notification carries only a pre-signed URL to the bundle, and the realtime update webhook deliberately does not fetch it — so it is emitted where the bundle is already downloaded.

## How

- New pure helper `bundle/encounter.ts` — `findEncounterId(bundle)` returns the first Encounter entry's `id`, or `undefined`.
- Emitted conditionally, in the same shape as `transactionBundle`; omitted when the bundle carries no Encounter.
- Read from any bundle rather than only a `collection`, since a Patient Encounter Bundle is already guaranteed to carry an Encounter.

## Testing

`yarn build && yarn test extensions/metriport` — 139 passing.