### PR TITLE
feat(metriport): accept every realtime notification type on one payload shape

### DIFF
--- a/extensions/metriport/README.md
+++ b/extensions/metriport/README.md
@@ -157,24 +157,27 @@ A `collection` bundle that is missing its Patient or Encounter entry is treated 
 
 An enrollment trigger that starts a care flow when Metriport sends a [real-time patient notification](https://docs.metriport.com/medical-api/handling-data/realtime-patient-notifications).
 
-Metriport POSTs every notification type to the same endpoint, so this webhook discriminates on the notification `type` and only enrolls on two events. The `eventType` data point carries the raw Metriport webhook type:
+Metriport POSTs every notification type to the same endpoint. Four of them share one payload shape — a `meta` envelope plus a `payload` pointing at a pre-signed bundle URL — and this webhook enrolls a patient on all four:
 
-- `patient.admit` (HL7 ADT^A01) → `eventType` = `patient.admit`. The payload carries a pre-signed URL to the [FHIR Encounter Bundle](https://docs.metriport.com/medical-api/handling-data/patient-encounter-bundle).
-- `medical.discharge-summary` → `eventType` = `medical.discharge-summary`. This event is currently undocumented by Metriport and is modelled on the published `medical.*` webhook family (a `patients` array).
+- `patient.admit` (HL7 ADT^A01)
+- `patient.discharge` (HL7 ADT^A03)
+- `patient.transfer` (HL7 ADT^A02)
+- `medical.discharge-summary`
+
+The `eventType` data point carries the raw Metriport webhook type, so a care flow can branch on it. The payload's `url` is a pre-signed link to the [FHIR Encounter Bundle](https://docs.metriport.com/medical-api/handling-data/patient-encounter-bundle).
 
 The webhook validates the request, emits the data points (including the pre-signed bundle URL on `bundleUrl`), and replies immediately — it does **not** download the bundle. Fetch the bundle later in the care flow with the **Get Webhook Bundle** action, using the `bundleUrl` data point. Because the URL expires after 10 minutes, run that action early.
 
-Use the `eventType` data point in your care flow to branch on admit vs discharge. Every other notification type (`patient.discharge`, `patient.transfer`, ...) is acknowledged with a `200` but does not enroll a patient. Metriport [verification `ping` messages](https://docs.metriport.com/medical-api/getting-started/webhooks#the-ping-message) are answered with a `200` that echoes the ping value back as `pong: <value>`.
+Any other notification type Metriport sends — `medical.document-download`, `medical.consolidated-data`, and anything added in future — is acknowledged with a `200` and does not enroll a patient. A notification whose type *is* handled but whose payload is malformed fails loudly instead, so a genuine integration problem is not mistaken for an event we chose to ignore. Metriport [verification `ping` messages](https://docs.metriport.com/medical-api/getting-started/webhooks#the-ping-message) are answered with a `200` that echoes the ping value back as `pong: <value>`.
 
 ### Data points
 
 | Data point | Type | Description |
 | --- | --- | --- |
-| `eventType` | string | The Metriport webhook type: `patient.admit` or `medical.discharge-summary` |
+| `eventType` | string | The Metriport webhook type: `patient.admit`, `patient.discharge`, `patient.transfer` or `medical.discharge-summary` |
 | `metriportPatientId` | string | The Metriport patient ID (also used as the patient identifier for enrollment) |
 | `externalId` | string | Your external patient ID, if provided to Metriport |
-| `admitTimestamp` | date | When the patient was admitted (admit events only) |
-| `whenSourceSent` | date | When the source sent the notification, if available (admit events) |
+| `when` | date | When the event occurred — the admit time on an admit event, the discharge time on a discharge event |
 | `messageId` | string | The Metriport message ID for the notification |
 | `bundleUrl` | string | Pre-signed URL to the FHIR bundle; fetch it with the **Get Webhook Bundle** action (valid for 10 minutes) |
 

--- a/extensions/metriport/webhooks/realtimeUpdate.test.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.test.ts
@@ -22,36 +22,24 @@ const mockSettings = {
   webhookKey: '',
 }
 
-const admitPayload = {
+const notification = (
+  type: MetriportWebhookType,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
   meta: {
     messageId: 'msg-1',
     when: '2026-07-21T10:00:00.000Z',
-    type: MetriportWebhookType.PatientAdmit,
+    type,
   },
   payload: {
     url: 'https://example.com/encounter-bundle',
     patientId: 'patient-123',
     externalId: 'external-abc',
-    admitTimestamp: '2026-07-21T09:00:00.000Z',
-    whenSourceSent: '2026-07-21T09:30:00.000Z',
+    ...overrides,
   },
-}
+})
 
-const dischargeSummaryPayload = {
-  meta: {
-    messageId: 'msg-2',
-    when: '2026-07-22T10:00:00.000Z',
-    type: MetriportWebhookType.DischargeSummary,
-  },
-  patients: [
-    {
-      patientId: 'patient-123',
-      externalId: 'external-abc',
-      status: 'completed',
-      url: 'https://example.com/discharge-summary',
-    },
-  ],
-}
+const admitPayload = notification(MetriportWebhookType.PatientAdmit)
 
 describe('Metriport - Webhook - Realtime Update', () => {
   const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
@@ -78,18 +66,22 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
   }
 
-  describe('When an admit (patient.admit) event is received', () => {
-    test('Should enroll the patient with eventType "patient.admit" and the bundle URL', async () => {
-      await invoke(admitPayload)
+  describe('When an enrolling notification is received', () => {
+    test.each([
+      MetriportWebhookType.PatientAdmit,
+      MetriportWebhookType.PatientDischarge,
+      MetriportWebhookType.PatientTransfer,
+      MetriportWebhookType.DischargeSummary,
+    ])('Should enroll the patient for %s', async (type) => {
+      await invoke(notification(type))
 
       expect(onError).not.toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledWith({
         data_points: {
-          eventType: 'patient.admit',
+          eventType: type,
           metriportPatientId: 'patient-123',
           externalId: 'external-abc',
-          admitTimestamp: '2026-07-21T09:00:00.000Z',
-          whenSourceSent: '2026-07-21T09:30:00.000Z',
+          when: '2026-07-21T10:00:00.000Z',
           messageId: 'msg-1',
           bundleUrl: 'https://example.com/encounter-bundle',
         },
@@ -99,44 +91,24 @@ describe('Metriport - Webhook - Realtime Update', () => {
         },
       })
     })
-  })
 
-  describe('When a discharge summary event is received', () => {
-    test('Should enroll the patient with eventType "medical.discharge-summary" and the bundle URL', async () => {
-      await invoke(dischargeSummaryPayload)
-
-      expect(onError).not.toHaveBeenCalled()
-      expect(onSuccess).toHaveBeenCalledWith({
-        data_points: {
-          eventType: 'medical.discharge-summary',
-          metriportPatientId: 'patient-123',
-          externalId: 'external-abc',
-          admitTimestamp: '',
-          whenSourceSent: '',
-          messageId: 'msg-2',
-          bundleUrl: 'https://example.com/discharge-summary',
-        },
-        patient_identifier: {
-          system: METRIPORT_PATIENT_IDENTIFIER_SYSTEM,
-          value: 'patient-123',
-        },
-      })
-    })
-
-    test('Should enroll with an empty bundle URL when none is provided', async () => {
+    test('Should emit an empty externalId when Metriport does not send one', async () => {
       await invoke({
         meta: {
-          messageId: 'msg-3',
+          messageId: 'msg-2',
           when: '2026-07-22T10:00:00.000Z',
           type: MetriportWebhookType.DischargeSummary,
         },
-        patients: [{ patientId: 'patient-789', status: 'completed' }],
+        payload: {
+          url: 'https://example.com/discharge-summary',
+          patientId: 'patient-789',
+        },
       })
 
       expect(onError).not.toHaveBeenCalled()
       const call = onSuccess.mock.calls[0][0]
+      expect(call.data_points.externalId).toBe('')
       expect(call.data_points.metriportPatientId).toBe('patient-789')
-      expect(call.data_points.bundleUrl).toBe('')
     })
   })
 
@@ -152,7 +124,6 @@ describe('Metriport - Webhook - Realtime Update', () => {
           url: '  https://example.com/encounter-bundle  ',
           patientId: '  patient-123  ',
           externalId: '  external-abc  ',
-          admitTimestamp: '2026-07-21T09:00:00.000Z',
         },
       })
 
@@ -189,42 +160,32 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
   })
 
-  describe('When an unhandled ADT event is received', () => {
-    test('Should acknowledge a transfer with 200 and not enroll', async () => {
+  describe('When a notification type we do not handle is received', () => {
+    test('Should acknowledge an undocumented medical.* event with 200 and not enroll', async () => {
       await invoke({
         meta: {
-          messageId: 'msg-transfer',
+          messageId: 'msg-doc',
           when: '2026-07-21T10:00:00.000Z',
-          type: MetriportWebhookType.PatientTransfer,
+          type: 'medical.document-download',
         },
-        payload: {
-          url: 'https://example.com/bundle',
-          patientId: 'patient-123',
-          admitTimestamp: '2026-07-21T09:00:00.000Z',
-        },
+        patients: [{ patientId: 'patient-123', status: 'completed' }],
       })
 
       expect(onSuccess).not.toHaveBeenCalled()
       expect(onError).toHaveBeenCalledWith({
         response: {
           statusCode: 200,
-          message: `Ignoring unhandled event type: ${MetriportWebhookType.PatientTransfer}`,
+          message: 'Ignoring unhandled event type: medical.document-download',
         },
       })
     })
 
-    test('Should acknowledge a patient.discharge ADT notification with 200 and not enroll', async () => {
+    test('Should acknowledge an unknown type carrying no payload at all', async () => {
       await invoke({
         meta: {
-          messageId: 'msg-adt-discharge',
+          messageId: 'msg-unknown',
           when: '2026-07-21T10:00:00.000Z',
-          type: MetriportWebhookType.PatientDischarge,
-        },
-        payload: {
-          url: 'https://example.com/bundle',
-          patientId: 'patient-123',
-          admitTimestamp: '2026-07-21T09:00:00.000Z',
-          dischargeTimestamp: '2026-07-22T09:00:00.000Z',
+          type: 'something.entirely.new',
         },
       })
 
@@ -232,9 +193,53 @@ describe('Metriport - Webhook - Realtime Update', () => {
       expect(onError).toHaveBeenCalledWith({
         response: {
           statusCode: 200,
-          message: `Ignoring unhandled event type: ${MetriportWebhookType.PatientDischarge}`,
+          message: 'Ignoring unhandled event type: something.entirely.new',
         },
       })
+    })
+  })
+
+  describe('When a handled notification is malformed', () => {
+    test('Should error rather than silently acknowledging a missing payload', async () => {
+      await invoke({
+        meta: {
+          messageId: 'msg-bad',
+          when: '2026-07-21T10:00:00.000Z',
+          type: MetriportWebhookType.PatientAdmit,
+        },
+      })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError.mock.calls[0][0].response).toBeUndefined()
+    })
+
+    test('Should error when the bundle URL is not a URL', async () => {
+      await invoke(
+        notification(MetriportWebhookType.PatientAdmit, { url: 'not-a-url' }),
+      )
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+
+    test('Should error when the patient id is empty', async () => {
+      await invoke(
+        notification(MetriportWebhookType.PatientAdmit, { patientId: '   ' }),
+      )
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('When the envelope itself is unreadable', () => {
+    test('Should call onError when meta is incomplete', async () => {
+      await invoke({ meta: { type: 'not-a-real-type' } })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError.mock.calls[0][0].response).toBeUndefined()
     })
   })
 
@@ -269,7 +274,9 @@ describe('Metriport - Webhook - Realtime Update', () => {
           payload: admitPayload,
           settings: { ...mockSettings, webhookKey: 'secret' },
           rawBody,
-          headers: { 'x-metriport-signature': sign('wrong-key', rawBody.toString()) },
+          headers: {
+            'x-metriport-signature': sign('wrong-key', rawBody.toString()),
+          },
         },
         onSuccess,
         onError,
@@ -291,7 +298,9 @@ describe('Metriport - Webhook - Realtime Update', () => {
           payload: admitPayload,
           settings: { ...mockSettings, webhookKey: 'secret' },
           rawBody,
-          headers: { 'x-metriport-signature': sign('secret', rawBody.toString()) },
+          headers: {
+            'x-metriport-signature': sign('secret', rawBody.toString()),
+          },
         },
         onSuccess,
         onError,
@@ -328,9 +337,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     }
 
     test('Should build the limiter from meta.type + endpoint and rate-limit on messageId, then enroll when not a duplicate', async () => {
-      const limit = jest
-        .fn()
-        .mockResolvedValue({ success: true, result: {} })
+      const limit = jest.fn().mockResolvedValue({ success: true, result: {} })
       jest
         .mocked(helpers.rateLimiter)
         .mockReturnValueOnce({ limit, reset: jest.fn() })
@@ -347,9 +354,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
 
     test('Should acknowledge a duplicate delivery with 200 and not enroll', async () => {
-      const limit = jest
-        .fn()
-        .mockResolvedValue({ success: false, result: {} })
+      const limit = jest.fn().mockResolvedValue({ success: false, result: {} })
       jest
         .mocked(helpers.rateLimiter)
         .mockReturnValueOnce({ limit, reset: jest.fn() })
@@ -381,15 +386,6 @@ describe('Metriport - Webhook - Realtime Update', () => {
       expect(onError).not.toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledTimes(1)
       expect(helpers.rateLimiter).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('When the payload is invalid', () => {
-    test('Should call onError', async () => {
-      await invoke({ meta: { type: 'not-a-real-type' } })
-
-      expect(onSuccess).not.toHaveBeenCalled()
-      expect(onError).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/extensions/metriport/webhooks/realtimeUpdate.test.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.test.ts
@@ -66,7 +66,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
   }
 
-  describe('When an enrolling notification is received', () => {
+  describe('When an ADT notification is received', () => {
     test.each([
       MetriportWebhookType.PatientAdmit,
       MetriportWebhookType.PatientDischarge,

--- a/extensions/metriport/webhooks/realtimeUpdate.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.ts
@@ -17,7 +17,7 @@ import {
   type MetriportRealtimeUpdateWebhookPayload,
 } from './types'
 import {
-  isEnrollingWebhookType,
+  isAdtWebhookType,
   pingWebhookSchema,
   realtimeNotificationSchema,
   webhookEnvelopeSchema,
@@ -117,7 +117,7 @@ export const realtimeUpdate: Webhook<
         return
       }
 
-      if (!isEnrollingWebhookType(eventType)) {
+      if (!isAdtWebhookType(eventType)) {
         await onError({
           response: {
             statusCode: 200,
@@ -127,8 +127,8 @@ export const realtimeUpdate: Webhook<
         return
       }
 
-      // Strict from here on: the type is one we enroll on, so a malformed
-      // payload is a real problem and must not be swallowed by the 200 above.
+      // Strict from here on: the type is an ADT one, so a malformed payload is
+      // a real problem and must not be swallowed by the 200 above.
       //
       // The bundle referenced by `bundleUrl` is intentionally NOT fetched here:
       // we validate, emit the data points (including the URL), and reply

--- a/extensions/metriport/webhooks/realtimeUpdate.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.ts
@@ -16,7 +16,12 @@ import {
   MetriportWebhookType,
   type MetriportRealtimeUpdateWebhookPayload,
 } from './types'
-import { webhookPayloadSchema, type WebhookPayloadSchema } from './validation.zod'
+import {
+  isEnrollingWebhookType,
+  pingWebhookSchema,
+  realtimeNotificationSchema,
+  webhookEnvelopeSchema,
+} from './validation.zod'
 
 /**
  * The identifier system used to enroll a patient based on their Metriport
@@ -37,12 +42,13 @@ const dataPoints = {
     key: 'externalId',
     valueType: 'string',
   },
-  admitTimestamp: {
-    key: 'admitTimestamp',
-    valueType: 'date',
-  },
-  whenSourceSent: {
-    key: 'whenSourceSent',
+  /**
+   * `meta.when` — the single event timestamp. It is the admit time on an admit
+   * event and the discharge time on a discharge event, which is why there are
+   * no per-event `*Timestamp` data points.
+   */
+  when: {
+    key: 'when',
     valueType: 'date',
   },
   messageId: {
@@ -57,23 +63,6 @@ const dataPoints = {
 
 type DataPoints = Record<keyof typeof dataPoints, string>
 
-type AdmitWebhook = Extract<
-  WebhookPayloadSchema,
-  { meta: { type: MetriportWebhookType.PatientAdmit } }
->
-type DischargeSummaryWebhook = Extract<
-  WebhookPayloadSchema,
-  { meta: { type: MetriportWebhookType.DischargeSummary } }
->
-
-const isAdmit = (webhook: WebhookPayloadSchema): webhook is AdmitWebhook =>
-  webhook.meta.type === MetriportWebhookType.PatientAdmit
-
-const isDischargeSummary = (
-  webhook: WebhookPayloadSchema,
-): webhook is DischargeSummaryWebhook =>
-  webhook.meta.type === MetriportWebhookType.DischargeSummary
-
 export const realtimeUpdate: Webhook<
   keyof typeof dataPoints,
   MetriportRealtimeUpdateWebhookPayload,
@@ -81,7 +70,7 @@ export const realtimeUpdate: Webhook<
 > = {
   key: 'realtimeUpdate',
   description:
-    'Starts a care flow when Metriport sends a real-time patient notification. The `eventType` data point carries the Metriport webhook type (`patient.admit` or `medical.discharge-summary`) so it can be distinguished on. The FHIR bundle is not fetched here — the pre-signed URL is passed on the `bundleUrl` data point and can be retrieved later with the "Get Webhook Bundle" action.',
+    'Starts a care flow when Metriport sends a real-time patient notification. Enrolls on `patient.admit`, `patient.discharge`, `patient.transfer` and `medical.discharge-summary`, which share one payload shape; the `eventType` data point carries the Metriport webhook type so it can be distinguished on. Any other notification type is acknowledged with a 200 without enrolling. The FHIR bundle is not fetched here — the pre-signed URL is passed on the `bundleUrl` data point and can be retrieved later with the "Get Webhook Bundle" action.',
   dataPoints,
   onEvent: async ({
     payload: { payload, rawBody, headers, settings, endpoint },
@@ -108,79 +97,53 @@ export const realtimeUpdate: Webhook<
         return
       }
 
-      const webhook = webhookPayloadSchema.parse(payload)
+      // Parsed permissively first. Metriport POSTs every webhook type to this
+      // one endpoint, so an unrecognised `meta.type` must be readable enough to
+      // acknowledge — rejecting it would make Metriport retry forever.
+      const envelope = webhookEnvelopeSchema.parse(payload)
+      const eventType = envelope.meta.type
 
       // Acknowledge Metriport's verification ping without enrolling anyone.
       // Metriport expects the response to echo back the ping value as `pong`.
       // https://docs.metriport.com/medical-api/getting-started/webhooks#the-ping-message
-      if ('ping' in webhook) {
+      if (eventType === MetriportWebhookType.Ping) {
+        const { ping } = pingWebhookSchema.parse(payload)
         await onError({
           response: {
             statusCode: 200,
-            message: `pong: ${webhook.ping}`,
+            message: `pong: ${ping}`,
           },
         })
         return
       }
 
-      // We enroll on admit (adt) and discharge-summary events only. Every other
-      // notification type (patient.discharge, patient.transfer, ...) is
-      // acknowledged with a 200 but does not enroll a patient.
+      if (!isEnrollingWebhookType(eventType)) {
+        await onError({
+          response: {
+            statusCode: 200,
+            message: `Ignoring unhandled event type: ${eventType}`,
+          },
+        })
+        return
+      }
+
+      // Strict from here on: the type is one we enroll on, so a malformed
+      // payload is a real problem and must not be swallowed by the 200 above.
       //
       // The bundle referenced by `bundleUrl` is intentionally NOT fetched here:
       // we validate, emit the data points (including the URL), and reply
       // immediately. The bundle is fetched later via the "Get Webhook Bundle"
       // action.
-      let data_points: DataPoints
-      let patientId: string | undefined
+      const { meta, payload: event } = realtimeNotificationSchema.parse(payload)
+      const patientId = event.patientId
 
-      if (isAdmit(webhook)) {
-        const event = webhook.payload
-        patientId = event.patientId
-        data_points = {
-          eventType: webhook.meta.type,
-          metriportPatientId: event.patientId,
-          externalId: event.externalId ?? '',
-          admitTimestamp: event.admitTimestamp ?? '',
-          whenSourceSent: event.whenSourceSent ?? '',
-          messageId: webhook.meta.messageId,
-          bundleUrl: event.url ?? '',
-        }
-      } else if (isDischargeSummary(webhook)) {
-        // TBD: the `medical.discharge-summary` payload shape is not yet
-        // documented by Metriport — we're still discussing it with them. The
-        // handling below (patient entry in a `patients` array, bundle URL) is a
-        // best guess modelled on the published `medical.*` webhook family and
-        // should be revisited once the event is confirmed.
-        const patient = webhook.patients?.[0]
-        patientId = patient?.patientId ?? webhook.payload?.patientId
-        data_points = {
-          eventType: webhook.meta.type,
-          metriportPatientId: patientId ?? '',
-          externalId: patient?.externalId ?? webhook.payload?.externalId ?? '',
-          admitTimestamp: '',
-          whenSourceSent: '',
-          messageId: webhook.meta.messageId,
-          bundleUrl: patient?.url ?? webhook.payload?.url ?? '',
-        }
-      } else {
-        await onError({
-          response: {
-            statusCode: 200,
-            message: `Ignoring unhandled event type: ${webhook.meta.type}`,
-          },
-        })
-        return
-      }
-
-      if (isNil(patientId) || patientId.length === 0) {
-        await onError({
-          response: {
-            statusCode: 400,
-            message: 'Unable to determine the Metriport patient ID from the payload',
-          },
-        })
-        return
+      const data_points: DataPoints = {
+        eventType: meta.type,
+        metriportPatientId: patientId,
+        externalId: event.externalId ?? '',
+        when: meta.when,
+        messageId: meta.messageId,
+        bundleUrl: event.url,
       }
 
       // rate limiting
@@ -198,12 +161,12 @@ export const realtimeUpdate: Webhook<
           rateLimitDurationSchema.safeParse(settings.rateLimitDuration)
         if (success && !isNil(durationString)) {
           const duration = transformRateLimitDuration(durationString)
-          const limiterName = `metriport-enrollment-${webhook.meta.type}-${endpoint?.id ?? 'global'}`
+          const limiterName = `metriport-enrollment-${meta.type}-${endpoint?.id ?? 'global'}`
           const limiter = rateLimiter(limiterName, {
             requests: 1,
             duration,
           })
-          const key = webhook.meta.messageId
+          const key = meta.messageId
           const { success } = await limiter.limit(key)
           if (!success) {
             await onError({

--- a/extensions/metriport/webhooks/types.ts
+++ b/extensions/metriport/webhooks/types.ts
@@ -16,8 +16,8 @@ export enum MetriportWebhookType {
   /** HL7 ADT^A02 transfer notification. */
   PatientTransfer = 'patient.transfer',
   /**
-   * Discharge summary notification. Currently undocumented by Metriport but
-   * modelled on the published `medical.*` webhook family (a `patients` array).
+   * Discharge summary notification. Undocumented by Metriport, but delivered
+   * with the same envelope and payload as the `patient.*` family.
    */
   DischargeSummary = 'medical.discharge-summary',
 }
@@ -35,57 +35,29 @@ export interface MetriportWebhookMeta {
 }
 
 /**
- * Payload shared by the ADT notification webhook types (admit / discharge /
- * transfer). `url` is a pre-signed link to the FHIR Encounter Bundle and is
- * only valid for 10 minutes.
+ * The payload shared by every real-time notification we enroll on. `url` is a
+ * pre-signed link to the FHIR bundle and is only valid for 10 minutes.
+ *
+ * Metriport also sends per-event timestamps (`admitTimestamp`,
+ * `dischargeTimestamp`, `whenSourceSent`); they are not modelled here because
+ * `meta.when` already carries the event's timestamp and nothing downstream
+ * consumes the others.
  * https://docs.metriport.com/medical-api/handling-data/patient-encounter-bundle
  */
-export interface MetriportAdtEventPayload {
+export interface MetriportRealtimeNotificationPayload {
   url: string
   patientId: string
   externalId?: string
   additionalIds?: Record<string, string[]>
-  admitTimestamp: string
-  dischargeTimestamp?: string
-  whenSourceSent?: string
 }
 
 /**
- * A single patient entry as delivered by the `medical.*` webhook family. The
- * discharge summary FHIR data may be embedded inline (`bundle`, as in
- * `medical.consolidated-data`) or referenced by a pre-signed `url`. Unknown
- * fields are preserved so nothing is lost while the event is undocumented.
+ * An ADT or discharge-summary notification. All four types share one shape, so
+ * `meta.type` is the only thing that distinguishes them.
  */
-export interface MetriportMedicalPatientEntry {
-  patientId: string
-  externalId?: string
-  additionalIds?: Record<string, string[]>
-  status?: string
-  bundle?: Bundle
-  url?: string
-  [key: string]: unknown
-}
-
-export interface MetriportPatientAdmitWebhook {
-  meta: MetriportWebhookMeta & { type: MetriportWebhookType.PatientAdmit }
-  payload: MetriportAdtEventPayload
-}
-
-export interface MetriportPatientDischargeWebhook {
-  meta: MetriportWebhookMeta & { type: MetriportWebhookType.PatientDischarge }
-  payload: MetriportAdtEventPayload & { dischargeTimestamp: string }
-}
-
-export interface MetriportPatientTransferWebhook {
-  meta: MetriportWebhookMeta & { type: MetriportWebhookType.PatientTransfer }
-  payload: MetriportAdtEventPayload
-}
-
-export interface MetriportDischargeSummaryWebhook {
-  meta: MetriportWebhookMeta & { type: MetriportWebhookType.DischargeSummary }
-  patients?: MetriportMedicalPatientEntry[]
-  /** Some notifications may carry a single top-level payload instead. */
-  payload?: MetriportAdtEventPayload
+export interface MetriportRealtimeNotificationWebhook {
+  meta: MetriportWebhookMeta
+  payload: MetriportRealtimeNotificationPayload
 }
 
 export interface MetriportPingWebhook {
@@ -96,13 +68,11 @@ export interface MetriportPingWebhook {
 /**
  * The union of all payloads that can be received on the realtime update webhook
  * endpoint. Metriport POSTs every notification type to the same URL, so the
- * handler must discriminate on `meta.type`.
+ * handler discriminates on `meta.type` and acknowledges anything it does not
+ * enroll on.
  */
 export type MetriportRealtimeUpdateWebhookPayload =
-  | MetriportPatientAdmitWebhook
-  | MetriportPatientDischargeWebhook
-  | MetriportPatientTransferWebhook
-  | MetriportDischargeSummaryWebhook
+  | MetriportRealtimeNotificationWebhook
   | MetriportPingWebhook
 
 /**

--- a/extensions/metriport/webhooks/validation.zod.ts
+++ b/extensions/metriport/webhooks/validation.zod.ts
@@ -8,22 +8,20 @@ import { MetriportWebhookType } from './types'
 const trimmedString = z.string().trim()
 
 /**
- * The notification types that enroll a patient. All four share one payload
- * shape; anything outside this list is acknowledged without enrolling.
+ * The ADT notification types. All four share one payload shape; anything
+ * outside this list is acknowledged without enrolling.
  */
-export const ENROLLING_WEBHOOK_TYPES = [
+export const ADT_WEBHOOK_TYPES = [
   MetriportWebhookType.PatientAdmit,
   MetriportWebhookType.PatientDischarge,
   MetriportWebhookType.PatientTransfer,
   MetriportWebhookType.DischargeSummary,
 ] as const
 
-export type EnrollingWebhookType = (typeof ENROLLING_WEBHOOK_TYPES)[number]
+export type AdtWebhookType = (typeof ADT_WEBHOOK_TYPES)[number]
 
-export const isEnrollingWebhookType = (
-  type: string,
-): type is EnrollingWebhookType =>
-  (ENROLLING_WEBHOOK_TYPES as readonly string[]).includes(type)
+export const isAdtWebhookType = (type: string): type is AdtWebhookType =>
+  (ADT_WEBHOOK_TYPES as readonly string[]).includes(type)
 
 const metaSchema = z.object({
   messageId: trimmedString,
@@ -50,12 +48,12 @@ export const pingWebhookSchema = z.object({
 })
 
 /**
- * The strict pass, applied only once `meta.type` is known to be one we enroll
- * on. A handled event with a broken payload must fail loudly rather than be
+ * The strict pass, applied only once `meta.type` is known to be an ADT type.
+ * A handled event with a broken payload must fail loudly rather than be
  * swallowed by the acknowledge-and-ignore path.
  */
 export const realtimeNotificationSchema = z.object({
-  meta: metaSchema.extend({ type: z.enum(ENROLLING_WEBHOOK_TYPES) }),
+  meta: metaSchema.extend({ type: z.enum(ADT_WEBHOOK_TYPES) }),
   payload: z.object({
     url: trimmedString.url(),
     patientId: trimmedString.min(1),

--- a/extensions/metriport/webhooks/validation.zod.ts
+++ b/extensions/metriport/webhooks/validation.zod.ts
@@ -7,6 +7,24 @@ import { MetriportWebhookType } from './types'
  */
 const trimmedString = z.string().trim()
 
+/**
+ * The notification types that enroll a patient. All four share one payload
+ * shape; anything outside this list is acknowledged without enrolling.
+ */
+export const ENROLLING_WEBHOOK_TYPES = [
+  MetriportWebhookType.PatientAdmit,
+  MetriportWebhookType.PatientDischarge,
+  MetriportWebhookType.PatientTransfer,
+  MetriportWebhookType.DischargeSummary,
+] as const
+
+export type EnrollingWebhookType = (typeof ENROLLING_WEBHOOK_TYPES)[number]
+
+export const isEnrollingWebhookType = (
+  type: string,
+): type is EnrollingWebhookType =>
+  (ENROLLING_WEBHOOK_TYPES as readonly string[]).includes(type)
+
 const metaSchema = z.object({
   messageId: trimmedString,
   when: trimmedString,
@@ -14,80 +32,39 @@ const metaSchema = z.object({
   data: z.unknown().optional(),
 })
 
-const adtEventPayloadSchema = z.object({
-  url: trimmedString.url(),
-  patientId: trimmedString,
-  externalId: trimmedString.optional(),
-  additionalIds: z.record(z.array(trimmedString)).optional(),
-  admitTimestamp: trimmedString,
-  dischargeTimestamp: trimmedString.optional(),
-  whenSourceSent: trimmedString.optional(),
-})
-
 /**
- * A patient entry as sent by the `medical.*` webhook family. Only `patientId`
- * is required; everything else is optional and unknown fields are preserved
- * (`passthrough`) since the discharge summary event is undocumented.
+ * The permissive first pass. Metriport POSTs every webhook type to the same
+ * endpoint, so `type` is an open string here: an unrecognised notification has
+ * to be readable enough to acknowledge with a 200, or Metriport retries it
+ * forever.
  */
-const medicalPatientEntrySchema = z
+export const webhookEnvelopeSchema = z
   .object({
-    patientId: trimmedString,
-    externalId: trimmedString.optional(),
-    additionalIds: z.record(z.array(trimmedString)).optional(),
-    status: trimmedString.optional(),
-    bundle: z.unknown().optional(),
-    url: trimmedString.url().optional(),
+    meta: metaSchema.extend({ type: trimmedString }),
   })
   .passthrough()
 
-const patientAdmitWebhookSchema = z.object({
-  meta: metaSchema.extend({
-    type: z.literal(MetriportWebhookType.PatientAdmit),
-  }),
-  payload: adtEventPayloadSchema,
-})
-
-const patientDischargeWebhookSchema = z.object({
-  meta: metaSchema.extend({
-    type: z.literal(MetriportWebhookType.PatientDischarge),
-  }),
-  payload: adtEventPayloadSchema.extend({
-    dischargeTimestamp: trimmedString,
-  }),
-})
-
-const patientTransferWebhookSchema = z.object({
-  meta: metaSchema.extend({
-    type: z.literal(MetriportWebhookType.PatientTransfer),
-  }),
-  payload: adtEventPayloadSchema,
-})
-
-const dischargeSummaryWebhookSchema = z.object({
-  meta: metaSchema.extend({
-    type: z.literal(MetriportWebhookType.DischargeSummary),
-  }),
-  patients: z.array(medicalPatientEntrySchema).optional(),
-  payload: adtEventPayloadSchema.partial().optional(),
-})
-
-const pingWebhookSchema = z.object({
-  meta: metaSchema.extend({
-    type: z.literal(MetriportWebhookType.Ping),
-  }),
+export const pingWebhookSchema = z.object({
+  meta: metaSchema.extend({ type: z.literal(MetriportWebhookType.Ping) }),
   ping: trimmedString,
 })
 
 /**
- * Parses an incoming Metriport webhook. The discriminator (`meta.type`) is
- * nested, so we rely on a union rather than a discriminated union.
+ * The strict pass, applied only once `meta.type` is known to be one we enroll
+ * on. A handled event with a broken payload must fail loudly rather than be
+ * swallowed by the acknowledge-and-ignore path.
  */
-export const webhookPayloadSchema = z.union([
-  patientAdmitWebhookSchema,
-  patientDischargeWebhookSchema,
-  patientTransferWebhookSchema,
-  dischargeSummaryWebhookSchema,
-  pingWebhookSchema,
-])
+export const realtimeNotificationSchema = z.object({
+  meta: metaSchema.extend({ type: z.enum(ENROLLING_WEBHOOK_TYPES) }),
+  payload: z.object({
+    url: trimmedString.url(),
+    patientId: trimmedString.min(1),
+    externalId: trimmedString.optional(),
+    additionalIds: z.record(z.array(trimmedString)).optional(),
+  }),
+})
 
-export type WebhookPayloadSchema = z.infer<typeof webhookPayloadSchema>
+export type WebhookEnvelopeSchema = z.infer<typeof webhookEnvelopeSchema>
+export type RealtimeNotificationSchema = z.infer<
+  typeof realtimeNotificationSchema
+>


### PR DESCRIPTION
## What

Collapses the realtime update webhook's per-event branching onto one payload shape, enrolls on all four notification types, and acknowledges everything else with a `200`.

## Why

All four notification types (`patient.admit`, `patient.discharge`, `patient.transfer`, `medical.discharge-summary`) carry the same shape: a `meta` envelope plus a `payload` pointing at a pre-signed bundle URL. The handler special-cased two of them with hand-written type guards and a divergent data-point branch each.

The old zod union also mishandled unknown types. The comments claimed every unhandled notification was acked with a `200`, but that only held for `patient.discharge` and `patient.transfer` — the two that happened to have schemas. A type with no schema, such as `medical.document-download`, failed the union, fell through to the catch block and returned a non-200, so **Metriport retried it indefinitely**. Metriport POSTs every webhook type to this one endpoint, so that was reachable in production.

## How

- `webhookEnvelopeSchema` parses permissively first (`meta.type` is an open string), so any Metriport webhook is readable enough to acknowledge.
- A handled-type gate runs before the strict parse, so a malformed *handled* event still fails loudly rather than being swallowed by the ignore path.
- `realtimeNotificationSchema` requires `url` and a non-empty `patientId`; the runtime `isNil` guard is gone.
- Five schemas and two type guards become three schemas and one. Net -94 lines.

## Data point changes

Six data points, down from seven. `when` (from `meta.when`) replaces `admitTimestamp`: it is the admit time on an admit event and the discharge time on a discharge event, so per-event timestamp data points were redundant. `whenSourceSent` is removed for the same reason.

The undocumented `patients[]` fallback for `medical.discharge-summary` is dropped — that event uses the same `payload` shape as the rest.

Safe to break: this webhook is unreleased, so no care flow depends on the removed data points.

## Testing

`yarn build && yarn test extensions/metriport` — 139 passing, including a case per notification type and coverage for the unknown-type and malformed-payload paths.