### PR TITLE
chore(webhooks): refactor webhook handlers from onWebhookReceived to onEvent

### DIFF
--- a/extensions/awell/v1/webhooks/pathwayCompleted.ts
+++ b/extensions/awell/v1/webhooks/pathwayCompleted.ts
@@ -31,7 +31,7 @@ export const pathwayCompleted: Webhook<
 > = {
   key: 'pathwayCompleted',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const { pathway, complete_date } = payload
     if (isNil(pathway.pathway_definition_id)) {
       await onError({

--- a/extensions/awell/v1/webhooks/pathwayStart.ts
+++ b/extensions/awell/v1/webhooks/pathwayStart.ts
@@ -18,7 +18,7 @@ export const pathwayStart: Webhook<
   description:
     'Start a pathway via webhook. No data points are expected nor required.',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess) => {
+  onEvent: async ({ payload: { payload }, onSuccess }) => {
     if (!isNil(payload.patient_id)) {
       const { patient_id } = payload
       await onSuccess({

--- a/extensions/bland/webhooks/CallCompleted/callCompleted.test.ts
+++ b/extensions/bland/webhooks/CallCompleted/callCompleted.test.ts
@@ -14,7 +14,7 @@ describe('Webhook - Call completed', () => {
     test('Should call onError and not call onSuccess', async () => {
       const { call_id, ...payloadWithoutCallId } = callCompletedPayload
 
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: payloadWithoutCallId as any,
           settings: { apiKey: 'api-key' },
@@ -38,7 +38,7 @@ describe('Webhook - Call completed', () => {
 
   describe('When payload is valid', () => {
     test('Should call onSuccess, which starts the care flow', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: callCompletedPayload,
           settings: {

--- a/extensions/calDotCom/webhooks/bookingCancelled.ts
+++ b/extensions/calDotCom/webhooks/bookingCancelled.ts
@@ -22,7 +22,7 @@ export const bookingCancelled: Webhook<
 > = {
   key: 'bookingCancelled',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     const {
       payload: { bookingId, uid },
     } = payload

--- a/extensions/calDotCom/webhooks/bookingCreated.ts
+++ b/extensions/calDotCom/webhooks/bookingCreated.ts
@@ -22,7 +22,7 @@ export const bookingCreated: Webhook<
 > = {
   key: 'bookingCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     const {
       payload: { bookingId, uid },
     } = payload

--- a/extensions/calDotCom/webhooks/bookingRescheduled.ts
+++ b/extensions/calDotCom/webhooks/bookingRescheduled.ts
@@ -22,7 +22,7 @@ export const bookingRescheduled: Webhook<
 > = {
   key: 'bookingRescheduled',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     const {
       payload: { bookingId, uid },
     } = payload

--- a/extensions/calendly/__tests__/eventCanceled.test.ts
+++ b/extensions/calendly/__tests__/eventCanceled.test.ts
@@ -1,6 +1,6 @@
+import { TestHelpers } from '@awell-health/extensions-core'
 import { eventCanceled } from '../webhooks/eventCanceled'
 import { testInviteeCanceled } from '../__mocks__/objects'
-import { type OnWebhookReceivedParams } from '@awell-health/extensions-core'
 import {
   type CalendlyInviteeCanceledWebhook,
   type CalendlyWebhookPayload,
@@ -9,36 +9,34 @@ import _ from 'lodash'
 import { ZodError } from 'zod'
 
 describe('Test event canceled', () => {
-  const onComplete = jest.fn()
-  const onError = jest.fn()
-  const buildOnWebhookReceivedParams = <Payload>({
-    payload,
-  }: {
-    payload: Payload
-  }): OnWebhookReceivedParams<Payload> => {
-    return {
+  const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
+    TestHelpers.fromWebhook(eventCanceled)
+
+  const buildOnEventParams = <Payload>({ payload }: { payload: Payload }) => ({
+    payload: {
       payload,
       rawBody: Buffer.from(JSON.stringify(payload)),
       headers: {},
       settings: {},
-    }
-  }
+    },
+    onSuccess,
+    onError,
+    helpers,
+  })
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    clearMocks()
   })
 
   it('should return the correct data points', async () => {
     const event = testInviteeCanceled
-    const evt = eventCanceled.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyInviteeCanceledWebhook>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyInviteeCanceledWebhook>({
         payload: event,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).resolves.toBeUndefined()
-    expect(onComplete).toBeCalled()
+    expect(onSuccess).toBeCalled()
   })
 
   it.each([
@@ -62,19 +60,17 @@ describe('Test event canceled', () => {
         cancellation_reason: 'ouch',
       },
     },
-  ])('onComplete should always be called $name', async (params) => {
+  ])('onSuccess should always be called $name', async (params) => {
     const { payload, output } = params
     const merged = _.merge({}, testInviteeCanceled, { payload })
-    const evt = eventCanceled.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyWebhookPayload>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyWebhookPayload>({
         payload: merged,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).resolves.toBeUndefined()
-    expect(onComplete).toHaveBeenCalledWith(
-      expect.objectContaining({ data_points: expect.objectContaining(output) })
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ data_points: expect.objectContaining(output) }),
     )
   })
 
@@ -92,12 +88,10 @@ describe('Test event canceled', () => {
   ])('Error should throw: $name', async (params) => {
     const { payload, error } = params
     const merged = _.merge({}, testInviteeCanceled, { payload })
-    const evt = eventCanceled.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyWebhookPayload>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyWebhookPayload>({
         payload: merged,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).rejects.toThrow(error)
   })

--- a/extensions/calendly/__tests__/eventCreated.test.ts
+++ b/extensions/calendly/__tests__/eventCreated.test.ts
@@ -1,6 +1,6 @@
+import { TestHelpers } from '@awell-health/extensions-core'
 import { eventCreated } from '../webhooks/eventCreated'
 import { testInviteeCreated } from '../__mocks__/objects'
-import { type OnWebhookReceivedParams } from '@awell-health/extensions-core'
 import {
   type CalendlyInviteeCreatedWebhook,
   type CalendlyWebhookPayload,
@@ -9,36 +9,34 @@ import * as _ from 'lodash'
 import { ZodError } from 'zod'
 
 describe('Test event Created', () => {
-  const onComplete = jest.fn()
-  const onError = jest.fn()
-  const buildOnWebhookReceivedParams = <Payload>({
-    payload,
-  }: {
-    payload: Payload
-  }): OnWebhookReceivedParams<Payload> => {
-    return {
+  const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
+    TestHelpers.fromWebhook(eventCreated)
+
+  const buildOnEventParams = <Payload>({ payload }: { payload: Payload }) => ({
+    payload: {
       payload,
       rawBody: Buffer.from(JSON.stringify(payload)),
       headers: {},
       settings: {},
-    }
-  }
+    },
+    onSuccess,
+    onError,
+    helpers,
+  })
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    clearMocks()
   })
 
   it('should return the correct data points', async () => {
     const event = testInviteeCreated
-    const evt = eventCreated.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyInviteeCreatedWebhook>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyInviteeCreatedWebhook>({
         payload: event,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).resolves.toBeUndefined()
-    expect(onComplete).toBeCalled()
+    expect(onSuccess).toBeCalled()
   })
 
   it.each([
@@ -75,19 +73,17 @@ describe('Test event Created', () => {
         inviteeLastName: '',
       },
     },
-  ])('onComplete should always be called $name', async (params) => {
+  ])('onSuccess should always be called $name', async (params) => {
     const { payload, output } = params
     const merged = _.merge({}, testInviteeCreated, { payload })
-    const evt = eventCreated.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyWebhookPayload>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyWebhookPayload>({
         payload: merged,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).resolves.toBeUndefined()
-    expect(onComplete).toHaveBeenCalledWith(
-      expect.objectContaining({ data_points: expect.objectContaining(output) })
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ data_points: expect.objectContaining(output) }),
     )
   })
 
@@ -116,25 +112,23 @@ describe('Test event Created', () => {
       payload: { scheduled_event: { event_type: 'missing-scheduled-events' } },
       name: 'scheduled_event.event_type is empty',
       error: Error(
-        'Could not parse scheduled event type id from uri missing-scheduled-events'
+        'Could not parse scheduled event type id from uri missing-scheduled-events',
       ),
     },
     {
       payload: { scheduled_event: { uri: 'missing-event-types' } },
       name: 'scheduled_event.uri is empty',
       error: Error(
-        'Could not parse scheduled event id from uri missing-event-types'
+        'Could not parse scheduled event id from uri missing-event-types',
       ),
     },
   ])('Error should throw: $name', async (params) => {
     const { payload, error } = params
     const merged = _.merge({}, testInviteeCreated, { payload })
-    const evt = eventCreated.onWebhookReceived!(
-      buildOnWebhookReceivedParams<CalendlyWebhookPayload>({
+    const evt = extensionWebhook.onEvent(
+      buildOnEventParams<CalendlyWebhookPayload>({
         payload: merged,
       }),
-      onComplete,
-      onError
     )
     await expect(evt).rejects.toThrow(error)
   })

--- a/extensions/calendly/webhooks/eventCanceled.ts
+++ b/extensions/calendly/webhooks/eventCanceled.ts
@@ -92,7 +92,7 @@ export const eventCanceled: Webhook<
 > = {
   key: 'eventCanceled',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const {
       payload: {
         email,

--- a/extensions/calendly/webhooks/eventCreated.ts
+++ b/extensions/calendly/webhooks/eventCreated.ts
@@ -92,7 +92,7 @@ export const eventCreated: Webhook<
 > = {
   key: 'eventCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const {
       payload: {
         email,

--- a/extensions/documo/webhooks/documentFieldValueAssigned.test.ts
+++ b/extensions/documo/webhooks/documentFieldValueAssigned.test.ts
@@ -18,7 +18,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('When payload has all mapped fields', () => {
     it('should extract all patient fields correctly', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: fullPayload,
           settings: {},
@@ -47,7 +47,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('When payload has only phone number', () => {
     it('should extract phone number and set other fields to empty strings', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: phoneOnlyPayload,
           settings: {},
@@ -76,7 +76,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('When payload has no mapped fields', () => {
     it('should set all patient fields to empty strings', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: unmappedFieldsPayload,
           settings: {},
@@ -105,7 +105,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('When payload has empty assignments', () => {
     it('should set all patient fields to empty strings', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: emptyAssignmentsPayload,
           settings: {},
@@ -134,7 +134,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('When payload has user present', () => {
     it('should extract patient fields regardless of user presence', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: withUserPayload,
           settings: {},
@@ -163,7 +163,7 @@ describe('Documo - Webhook - Document Field Value Assigned', () => {
 
   describe('webhookData data point', () => {
     it('should always include the full payload as JSON', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: fullPayload,
           settings: {},

--- a/extensions/documo/webhooks/documentTypeUpdated.test.ts
+++ b/extensions/documo/webhooks/documentTypeUpdated.test.ts
@@ -16,7 +16,7 @@ describe('Documo - Webhook - Document Type Updated', () => {
 
   describe('When payload has all fields populated', () => {
     it('should extract all data points correctly', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: fullPayload,
           settings: {},
@@ -44,7 +44,7 @@ describe('Documo - Webhook - Document Type Updated', () => {
 
   describe('When payload has a different type', () => {
     it('should extract data points correctly', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: alternateTypePayload,
           settings: {},
@@ -72,7 +72,7 @@ describe('Documo - Webhook - Document Type Updated', () => {
 
   describe('When payload has no user', () => {
     it('should extract data points and set userEmail to an empty string', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: withoutUserPayload,
           settings: {},
@@ -100,7 +100,7 @@ describe('Documo - Webhook - Document Type Updated', () => {
 
   describe('webhookData data point', () => {
     it('should always include the full payload as JSON', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: fullPayload,
           settings: {},

--- a/extensions/freshdesk/webhooks/TicketCreated/ticketCreated.test.ts
+++ b/extensions/freshdesk/webhooks/TicketCreated/ticketCreated.test.ts
@@ -25,7 +25,7 @@ describe('Freshesk - Webhook - Ticket created', () => {
     })
 
     test('Should call onSuccess, which starts the care flow', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: ticketCreatedPayload,
           settings: {

--- a/extensions/healthie/webhooks/appliedTagCreated.ts
+++ b/extensions/healthie/webhooks/appliedTagCreated.ts
@@ -23,7 +23,7 @@ export const appliedTagCreated: Webhook<
 > = {
   key: 'appliedTagCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/appliedTagDeleted.ts
+++ b/extensions/healthie/webhooks/appliedTagDeleted.ts
@@ -23,7 +23,7 @@ export const appliedTagDeleted: Webhook<
 > = {
   key: 'appliedTagDeleted',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/appointmentCreated.ts
+++ b/extensions/healthie/webhooks/appointmentCreated.ts
@@ -27,7 +27,7 @@ export const appointmentCreated: Webhook<
 > = {
   key: 'appointmentCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/appointmentDeleted.ts
+++ b/extensions/healthie/webhooks/appointmentDeleted.ts
@@ -23,7 +23,7 @@ export const appointmentDeleted: Webhook<
 > = {
   key: 'appointmentDeleted',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/formAnswerGroupCreated.ts
+++ b/extensions/healthie/webhooks/formAnswerGroupCreated.ts
@@ -27,7 +27,7 @@ export const formAnswerGroupCreated: Webhook<
 > = {
   key: 'formAnswerGroupCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/formAnswerGroupDeleted.ts
+++ b/extensions/healthie/webhooks/formAnswerGroupDeleted.ts
@@ -23,7 +23,7 @@ export const formAnswerGroupDeleted: Webhook<
 > = {
   key: 'formAnswerGroupDeleted',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/formAnswerGroupLocked.ts
+++ b/extensions/healthie/webhooks/formAnswerGroupLocked.ts
@@ -28,7 +28,7 @@ export const formAnswerGroupLocked: Webhook<
 > = {
   key: 'formAnswerGroupLocked',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
       const formAnswerMaxSizeKB =

--- a/extensions/healthie/webhooks/formAnswerGroupSigned.ts
+++ b/extensions/healthie/webhooks/formAnswerGroupSigned.ts
@@ -27,7 +27,7 @@ export const formAnswerGroupSigned: Webhook<
 > = {
   key: 'formAnswerGroupSigned',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/goalCreated.ts
+++ b/extensions/healthie/webhooks/goalCreated.ts
@@ -23,7 +23,7 @@ export const goalCreated: Webhook<
 > = {
   key: 'goalCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/goalUpdated.ts
+++ b/extensions/healthie/webhooks/goalUpdated.ts
@@ -23,7 +23,7 @@ export const goalUpdated: Webhook<
 > = {
   key: 'goalUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/labOrderCreated.ts
+++ b/extensions/healthie/webhooks/labOrderCreated.ts
@@ -23,7 +23,7 @@ export const labOrderCreated: Webhook<
 > = {
   key: 'labOrderCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/labOrderUpdated.ts
+++ b/extensions/healthie/webhooks/labOrderUpdated.ts
@@ -23,7 +23,7 @@ export const labOrderUpdated: Webhook<
 > = {
   key: 'labOrderUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/messageCreated.ts
+++ b/extensions/healthie/webhooks/messageCreated.ts
@@ -23,7 +23,7 @@ export const messageCreated: Webhook<
 > = {
   key: 'messageCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/messageDeleted.ts
+++ b/extensions/healthie/webhooks/messageDeleted.ts
@@ -23,7 +23,7 @@ export const messageDeleted: Webhook<
 > = {
   key: 'messageDeleted',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/metricEntryCreated.ts
+++ b/extensions/healthie/webhooks/metricEntryCreated.ts
@@ -23,7 +23,7 @@ export const metricEntryCreated: Webhook<
 > = {
   key: 'metricEntryCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/metricEntryUpdated.ts
+++ b/extensions/healthie/webhooks/metricEntryUpdated.ts
@@ -23,7 +23,7 @@ export const metricEntryUpdated: Webhook<
 > = {
   key: 'metricEntryUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/patientCreated.ts
+++ b/extensions/healthie/webhooks/patientCreated.ts
@@ -19,7 +19,7 @@ export const patientCreated: Webhook<
 > = {
   key: 'patientCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     const validatedPayload = webhookPayloadSchema.parse(payload)
     const patientId = validatedPayload.resource_id.toString()
 

--- a/extensions/healthie/webhooks/patientUpdated.ts
+++ b/extensions/healthie/webhooks/patientUpdated.ts
@@ -19,7 +19,7 @@ export const patientUpdated: Webhook<
 > = {
   key: 'patientUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     const validatedPayload = webhookPayloadSchema.parse(payload)
     const updatedPatientId = validatedPayload.resource_id.toString()
 

--- a/extensions/healthie/webhooks/requestedFormCompletionCreated.ts
+++ b/extensions/healthie/webhooks/requestedFormCompletionCreated.ts
@@ -23,7 +23,7 @@ export const requestFormCompletionCreated: Webhook<
 > = {
   key: 'requestFormCompletionCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/requestedFormCompletionUpdated.ts
+++ b/extensions/healthie/webhooks/requestedFormCompletionUpdated.ts
@@ -23,7 +23,7 @@ export const requestFormCompletionUpdated: Webhook<
 > = {
   key: 'requestFormCompletionUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/taskCreated.ts
+++ b/extensions/healthie/webhooks/taskCreated.ts
@@ -23,7 +23,7 @@ export const taskCreated: Webhook<
 > = {
   key: 'taskCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/healthie/webhooks/taskUpdated.ts
+++ b/extensions/healthie/webhooks/taskUpdated.ts
@@ -23,7 +23,7 @@ export const taskUpdated: Webhook<
 > = {
   key: 'taskUpdated',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       const { sdk } = await createSdk({ settings })
 

--- a/extensions/hello-world/webhooks/demo.ts
+++ b/extensions/hello-world/webhooks/demo.ts
@@ -54,7 +54,7 @@ export interface Payload {
 export const demo: Webhook<keyof typeof dataPoints, Payload> = {
   key: 'demo',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const {
       eventType,
       hello,

--- a/extensions/medplum/webhooks/ObservationCreated/ObservationCreated.test.ts
+++ b/extensions/medplum/webhooks/ObservationCreated/ObservationCreated.test.ts
@@ -15,7 +15,7 @@ describe('Medplum - Webhook - Observation created', () => {
   describe('When payload is invalid', () => {
     describe('When subject reference is missing', () => {
       test('Should call onError', async () => {
-        await extensionWebhook.onEvent!({
+        await extensionWebhook.onEvent({
           payload: {
             payload: {
               ...ObservationCreatedPayloadExample,
@@ -43,7 +43,7 @@ describe('Medplum - Webhook - Observation created', () => {
 
     describe('When subject reference is not a patient', () => {
       test('Should call onError', async () => {
-        await extensionWebhook.onEvent!({
+        await extensionWebhook.onEvent({
           payload: {
             payload: {
               ...ObservationCreatedPayloadExample,
@@ -73,7 +73,7 @@ describe('Medplum - Webhook - Observation created', () => {
 
     describe('When subject reference is empty', () => {
       test('Should call onError', async () => {
-        await extensionWebhook.onEvent!({
+        await extensionWebhook.onEvent({
           payload: {
             payload: {
               ...ObservationCreatedPayloadExample,
@@ -102,7 +102,7 @@ describe('Medplum - Webhook - Observation created', () => {
 
   describe('When payload is valid', () => {
     test('Should call onSuccess', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: ObservationCreatedPayloadExample,
           settings: mockSettings,

--- a/extensions/medplum/webhooks/patientCreated.ts
+++ b/extensions/medplum/webhooks/patientCreated.ts
@@ -20,7 +20,7 @@ export const patientCreated: Webhook<
 > = {
   key: 'patientCreated',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const patientId = payload.id
 
     if (isNil(patientId)) {

--- a/extensions/metriport/webhooks/realtimeUpdate.test.ts
+++ b/extensions/metriport/webhooks/realtimeUpdate.test.ts
@@ -53,7 +53,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
   })
 
   const invoke = async (payload: unknown, headers = {}): Promise<void> => {
-    await extensionWebhook.onEvent!({
+    await extensionWebhook.onEvent({
       payload: {
         payload,
         settings: mockSettings,
@@ -247,7 +247,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     const rawBody = Buffer.from(JSON.stringify(admitPayload))
 
     test('Should reject requests with a missing signature header', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: admitPayload,
           settings: { ...mockSettings, webhookKey: 'secret' },
@@ -269,7 +269,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
 
     test('Should reject requests with an invalid signature', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: admitPayload,
           settings: { ...mockSettings, webhookKey: 'secret' },
@@ -293,7 +293,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
     })
 
     test('Should accept requests with a valid HMAC-SHA256 signature over the raw body', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: admitPayload,
           settings: { ...mockSettings, webhookKey: 'secret' },
@@ -323,7 +323,7 @@ describe('Metriport - Webhook - Realtime Update', () => {
       payload: unknown,
       settings: Record<string, string>,
     ): Promise<void> => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload,
           settings,

--- a/extensions/text-em-all/webhooks/broadcastStatusChange.ts
+++ b/extensions/text-em-all/webhooks/broadcastStatusChange.ts
@@ -21,7 +21,7 @@ export const broadcastStatusChange: Webhook<
 > = {
   key: 'broadcastStatusChange',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const { notification, payload: broadcastStatusNotification } = payload
 
     const skippedStatuses = ['created', 'ready', 'paused', 'resumed']

--- a/extensions/westFax/webhooks/FaxReceived/faxReceived.test.ts
+++ b/extensions/westFax/webhooks/FaxReceived/faxReceived.test.ts
@@ -12,7 +12,7 @@ describe('WestFax - Webhook - Fax received', () => {
 
   describe('When payload is valid', () => {
     test('Should call onSuccess, which starts the care flow', async () => {
-      await extensionWebhook.onEvent!({
+      await extensionWebhook.onEvent({
         payload: {
           payload: faxReceivedPayload,
           settings: {

--- a/extensions/workramp/webhooks/EventWebhook.ts
+++ b/extensions/workramp/webhooks/EventWebhook.ts
@@ -20,7 +20,7 @@ export const eventWebhook: Webhook<
 > = {
   key: 'eventWebhook',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const {
       user: { id: value },
       eventType,

--- a/extensions/workramp/webhooks/__tests__/event_webhook.ts
+++ b/extensions/workramp/webhooks/__tests__/event_webhook.ts
@@ -1,7 +1,4 @@
-import {
-  OnWebhookReceivedParams,
-  Settings,
-} from '@awell-health/extensions-core'
+import { TestHelpers } from '@awell-health/extensions-core'
 import { WORKRAMP_IDENTIFIER } from '../../config'
 import { EventPayload, EventType } from '../../types'
 import { eventWebhook } from '../EventWebhook'
@@ -21,21 +18,26 @@ describe('Event webhook', () => {
       },
     },
   }
-  const onSuccess = jest.fn()
-  const onError = jest.fn()
 
-  beforeAll(() => {
-    jest.clearAllMocks()
+  const { extensionWebhook, onSuccess, onError, helpers, clearMocks } =
+    TestHelpers.fromWebhook(eventWebhook)
+
+  beforeEach(() => {
+    clearMocks()
   })
+
   it('should validate the example webhook', async () => {
-    await eventWebhook.onWebhookReceived!(
-      {
+    await extensionWebhook.onEvent({
+      payload: {
         payload: exampleWebhook,
-        settings: {} as Settings,
-      } as OnWebhookReceivedParams<EventPayload, {}>,
+        settings: {},
+        rawBody: Buffer.from(''),
+        headers: {},
+      },
       onSuccess,
-      onError
-    )
+      onError,
+      helpers,
+    })
     expect(onSuccess).toHaveBeenCalledTimes(1)
     expect(onSuccess).toHaveBeenCalledWith({
       data_points: {

--- a/extensions/zusHealth/webhooks/patientAdmitted.ts
+++ b/extensions/zusHealth/webhooks/patientAdmitted.ts
@@ -66,7 +66,7 @@ export const patientAdmitted: Webhook<
 > = {
   key: 'patientAdmitted',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       let { resourceId } = payload
 

--- a/extensions/zusHealth/webhooks/patientDischarged.ts
+++ b/extensions/zusHealth/webhooks/patientDischarged.ts
@@ -70,7 +70,7 @@ export const patientDischarged: Webhook<
 > = {
   key: 'patientDischarged',
   dataPoints,
-  onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => {
     try {
       let { resourceId } = payload
 

--- a/scripts/generate-extension.ts
+++ b/scripts/generate-extension.ts
@@ -288,7 +288,7 @@ export interface HelloWorldPayload {
 export const helloWorldWebhook: Webhook<keyof typeof dataPoints, HelloWorldPayload> = {
   key: 'helloWorldWebhook',
   dataPoints,
-  onWebhookReceived: async ({ payload }, onSuccess, onError) => {
+  onEvent: async ({ payload: { payload }, onSuccess, onError }) => {
     const { eventType, data, patient_id } = payload
 
     await onSuccess({


### PR DESCRIPTION
## Summary
- Replaces all deprecated `onWebhookReceived` handlers with the named-arg `onEvent` pattern across 36 webhook files in awell, calDotCom, calendly, healthie, hello-world, medplum, text-em-all, workramp, and zusHealth extensions
- Updates calendly and workramp webhook tests to call `onEvent` via `TestHelpers.fromWebhook`
- Updates the `generate-extension` scaffold so new extensions use `onEvent` by default

## Migration pattern
```ts
// Before (deprecated positional args)
onWebhookReceived: async ({ payload, settings }, onSuccess, onError) => { ... }

// After (named args)
onEvent: async ({ payload: { payload, settings }, onSuccess, onError }) => { ... }
```

## Test plan
- [x] `yarn test --testPathPattern="calendly/__tests__|workramp/webhooks/__tests__"` — 16 tests passed
- [ ] CI green


Made with [Cursor](https://cursor.com)