### PR TITLE
chore(ci): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-assign-ai-actions.yml
+++ b/.github/workflows/auto-assign-ai-actions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign AI Engineer to production AI Actions PRs
-        uses: actions-ecosystem/action-add-assignees@v1
+        uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1
         with:
           assignees: belmai
         env:

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: PR Agent action step
         id: pragent
-        uses: Codium-ai/pr-agent@main
+        uses: Codium-ai/pr-agent@4ebd5c5333c6ef21509e7304d27969eb825e6f22 # v0.43.0
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes Aikido SAST high finding(s) in group 3578095 — **3rd party GitHub Actions should be pinned** — for this repo.

## Reachability
Not an input-to-sink finding: a workflow that references `owner/action@<tag|branch>` runs whatever commit that ref points to *at run time*. Anyone who can move the tag/branch (the action's maintainers, or an attacker who compromises their repo or account) gets code execution with the workflow's `permissions` and `secrets` (here: `GITHUB_TOKEN` with `contents: write` / `pull-requests: write`, `OPENAI_KEY`, and for publish workflows the npm/GCP credentials). Pinning to a SHA makes the executed code immutable.

## Tests — before / after
Workflow files only; no runtime code changed. Each line was resolved with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` (annotated tags dereferenced) so the SHA is exactly the commit the previous mutable ref pointed to at time of writing:

| Action | Was | Now |
| --- | --- | --- |
| Codium-ai/pr-agent | `@main` | `@4ebd5c53…` = v0.43.0 (latest release) |
| pnpm/action-setup | `@v4` / `@v2` | `@b906affc…` = v4 (the v2 tag has been deleted upstream) |
| google-github-actions/auth | `@v2` | `@c200f369…` = v2 |
| peaceiris/actions-gh-pages | `@v3` | `@373f7f26…` = v3 |
| actions-ecosystem/action-add-assignees | `@v1` | `@ce5019e6…` = v1 |

Only the rows present in this repo's workflows apply — see the diff. CI on this PR exercises the pinned `test` workflow where one exists.

## Risk analysis
- **Same code, frozen:** for every action pinned to the SHA behind its existing tag, the next run executes the identical commit it would have yesterday — zero behaviour change until someone bumps it.
- **pr-agent `main` → v0.43.0:** this one *does* change which code runs (from tip-of-main to the latest tagged release). If PR-Agent is even active (needs `OPENAI_KEY`), a release is strictly more stable than `main`.
- **pnpm/action-setup v2 → v4 (extension-brave only):** the v2 tag no longer exists upstream, so the workflow was already at risk of failing; v4 accepts the same `with: version:` input. If the run fails on install, revert to `@v2`… which is not possible — so the real alternative is to remove the `version:` input and rely on `packageManager` in package.json.
- **Rollback:** revert the commit; nothing outside `.github/workflows` was touched.
- **Upkeep:** SHAs do not auto-move. The tag is kept as a trailing comment so Dependabot (`package-ecosystem: github-actions`) or Renovate will keep updating it if enabled.

**Very low** for tag-pinned rows (identical code, workflow-local); **Low** overall because of the pr-agent `main`→release and (brave) pnpm v2→v4 rows.

## Scanner outcome
The rule matches `uses:` refs that are not a 40-hex SHA; all third-party refs in this repo now are, so the finding(s) **clear on merge**. GitHub-owned `actions/*` are not flagged by this rule and were left as-is. Nothing suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)