### PR TITLE
fix(sast): validate extension key before scaffolding paths in generate-extension

### DIFF
--- a/scripts/generate-extension.ts
+++ b/scripts/generate-extension.ts
@@ -5,6 +5,7 @@ import { hideBin } from 'yargs/helpers'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as readline from 'readline'
+import { assertValidExtensionKey } from './lib/extensionKey'
 
 const EXTENSIONS_DIR = path.join(__dirname, '..', 'extensions')
 
@@ -115,7 +116,9 @@ async function gatherConfig(): Promise<ExtensionConfig> {
     // Extension key
     const defaultKey = toCamelCase(name)
     const keyInput = await question(rl, `Extension key [${defaultKey}]: `)
-    const key = keyInput.length > 0 ? keyInput : defaultKey
+    const key = assertValidExtensionKey(
+      keyInput.length > 0 ? keyInput : defaultKey,
+    )
 
     // Description
     const descriptionInput = await question(rl, 'Extension description: ')
@@ -442,7 +445,10 @@ function updateExtensionsIndex(config: ExtensionConfig): void {
 }
 
 async function generateExtension(config: ExtensionConfig): Promise<void> {
-  const extDir = path.join(EXTENSIONS_DIR, config.key)
+  // Validate before joining: path.join normalises '..' away, so a hostile key
+  // cannot be detected afterwards. Covers both the interactive and --key /
+  // --name (toCamelCase) entry points.
+  const extDir = path.join(EXTENSIONS_DIR, assertValidExtensionKey(config.key))
 
   // Check if extension already exists
   if (fs.existsSync(extDir)) {

--- a/scripts/lib/extensionKey.test.ts
+++ b/scripts/lib/extensionKey.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import path from 'path'
+import { assertValidExtensionKey, isValidExtensionKey } from './extensionKey'
+
+describe('extension key validation', () => {
+  test('every existing extension directory is accepted (no regression for real keys)', () => {
+    const dirs = fs
+      .readdirSync(path.join(__dirname, '..', '..', 'extensions'), {
+        withFileTypes: true,
+      })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+    expect(dirs.length).toBeGreaterThan(0)
+    for (const dir of dirs) {
+      expect(isValidExtensionKey(dir)).toBe(true)
+    }
+  })
+
+  test.each(['acmeHealth', 'external-server', 'hello-world', 'a1_b2'])(
+    'accepts %s',
+    (key) => {
+      expect(assertValidExtensionKey(key)).toBe(key)
+    },
+  )
+
+  test.each([
+    '..',
+    '../../etc',
+    '..%2F..',
+    '/tmp/abs',
+    'foo/bar',
+    'foo\\bar',
+    '.hidden',
+    '1starts-with-digit',
+    'has space',
+    '',
+  ])('rejects %p', (key) => {
+    expect(() => assertValidExtensionKey(key)).toThrow(/Invalid extension key/)
+  })
+})

--- a/scripts/lib/extensionKey.ts
+++ b/scripts/lib/extensionKey.ts
@@ -1,0 +1,22 @@
+/**
+ * An extension key names a directory under `extensions/` and is spliced into
+ * generated import paths, so it must be a plain identifier: a letter followed
+ * by letters, digits, `_` or `-`. Every existing extension directory matches
+ * (camelCase like `canvasMedical`, hyphenated like `external-server`).
+ *
+ * Validating here — before the key reaches `path.join` — is what stops a key
+ * like `../../etc` from writing scaffolding outside the repo.
+ */
+export const EXTENSION_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/
+
+export const isValidExtensionKey = (key: string): boolean =>
+  EXTENSION_KEY_PATTERN.test(key)
+
+export const assertValidExtensionKey = (key: string): string => {
+  if (!isValidExtensionKey(key)) {
+    throw new Error(
+      `Invalid extension key "${key}": must start with a letter and contain only letters, digits, "_" or "-" (e.g. "acmeHealth")`,
+    )
+  }
+  return key
+}


### PR DESCRIPTION
Fixes the whole Aikido SAST group [11941507](https://app.aikido.dev/issues/single/131156691?groupId=6344) for `scripts/generate-extension.ts` — `AIK_ts_generic_path_traversal`: 2 **high** (131156691 line 445, 131156696 line 481), 2 medium and 8 low findings, all the same root cause (`config.key` → `path.join(EXTENSIONS_DIR, config.key)` → many `mkdirSync`/`writeFileSync`).

## Reachability
`yarn generate-extension` is a **developer CLI** run from a checkout; the key comes from `--key`, from `toCamelCase(--name)`, or from the interactive prompt. Nothing network-facing calls it. The realistic threat is a copy-pasted or scripted invocation with a bad key, not a remote attacker — but the effect was real: on `origin/main`, `yarn generate-extension --no-interactive --name Evil --key ../../pwned` **created `../../pwned/` two directories above the repo** with generated files inside (reproduced locally, cleaned up). `toCamelCase` does not strip a leading `..` either, so `--name` alone could do it.

Callers audited: `gatherConfig()` (interactive) and `main()` (argv) build the `ExtensionConfig`; `generateExtension()` is the only place the key becomes a path. The guard sits there, so both entry points are covered by one check; the interactive prompt additionally validates early for a faster error.

## Tests — before / after (`yarn test`, jest)
| Run | `scripts/lib/extensionKey.test.ts` | End-to-end |
| --- | --- | --- |
| `origin/main` @ 999516ce | n/a (module is new) | `--key ../../pwned` → **wrote outside the repo** |
| this branch | 15 pass (every existing `extensions/*` dir accepted; `..`, `../../etc`, `/tmp/abs`, `foo/bar`, `.hidden`, `1digit`, `has space`, `''` rejected) | `--key ../../pwned` → `❌ Error: Invalid extension key "../../pwned": …`, nothing written |

The "every existing directory is accepted" test is the regression guard for real keys — 60+ directories including `external-server`, `hello-world`, `text-em-all`, `canvasMedical`.

## Risk analysis
- **Accept path:** any key matching `/^[A-Za-z][A-Za-z0-9_-]*$/` produces the identical `extDir` as before (`assertValidExtensionKey` returns its input). Every existing extension directory passes, so the pattern matches the de-facto convention.
- **New refusals:** keys starting with a digit or `.`/`_`, or containing `/`, `\`, spaces or other punctuation. Those would also have produced invalid TS import paths (`import … from './<key>'`) or broken the `extensions/index.ts` regex edit, so they were never usable keys.
- **Blast radius:** dev script + a new `scripts/lib/` module. `scripts/*.ts` is excluded from `tsconfig.build.json`; the new lib is not shipped. Root `tsconfig.json` type-checks the test.
- **Runtime:** none — not part of the published package.

**Very low** — dev-only tool, pure additive validation, legitimate keys provably unchanged, regression covered by a test over the real directory list.

## Scanner outcome
Expected to **clear** the 12 findings in group 11941507 on merge: the rule tracks `config.key` from argv/readline into `path.join`; routing it through `assertValidExtensionKey()` (a function that throws on anything unsafe) breaks the taint path. If it turns out to be a pure sink detector and still fires on the `path.join`, I will add a `// nosemgrep` with the guard named — not done pre-emptively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
