### PR TITLE
feat(metriport): add Get Facility by Name action

### DIFF
--- a/extensions/metriport/README.md
+++ b/extensions/metriport/README.md
@@ -69,6 +69,34 @@ Visit [endpoint docs](https://docs.metriport.com/medical-api/api-reference/docum
 
 **NOTE: This endpoint returns a URL which you can use to download the specified Document using the file name provided from the List Documents endpoint.**
 
+## Get Facility by Name
+
+Gets the Facility with the given name, so a care flow can resolve a human-readable Facility name into the `facilityId` that the Patient and Document actions require.
+
+Metriport has no endpoint to filter Facilities by name, so this action lists all Facilities in your Organization and matches in memory. The name is matched case-insensitively and ignoring surrounding whitespace, and must match **exactly one** Facility: the action errors if no Facility matches, and also if several do, rather than guessing which one was meant.
+
+Visit [endpoint docs](https://docs.metriport.com/medical-api/api-reference/facility/list-facilities) for more info.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `facilityName` | string | The name of the Facility to look up. Matched case-insensitively, ignoring surrounding whitespace, and must match exactly one Facility in your Organization. |
+
+The data points mirror the Facility object Metriport returns from [Get Facility](https://docs.metriport.com/medical-api/api-reference/facility/get-facility), one data point per response field:
+
+| Data point | Type | Metriport field | Description |
+| --- | --- | --- | --- |
+| `facilityId` | string | `id` | Metriport's UUID for the Facility. This is the `facilityId` the Patient and Document actions take. |
+| `facilityName` | string | `name` | The Facility name, as stored at Metriport — the canonical casing and spacing, not the name that was searched for. |
+| `npi` | string | `npi` | The Facility's National Provider Identifier. |
+| `tin` | string | `tin` | The Facility's Taxpayer Identification Number. Optional at Metriport; left unset when absent. |
+| `active` | boolean | `active` | Whether the Facility is active. Optional at Metriport; left unset when absent. |
+| `addressLine1` | string | `address.addressLine1` | Street address line 1. |
+| `addressLine2` | string | `address.addressLine2` | Street address line 2. Optional; left unset when absent. |
+| `city` | string | `address.city` | Address city. |
+| `state` | string | `address.state` | Two-letter US state or territory code. |
+| `zip` | string | `address.zip` | Address ZIP code. |
+| `country` | string | `address.country` | Address country — always `USA` at Metriport today. Left unset when absent. |
+
 ## Remove Patient from Cohort
 
 Removes the specified Patient from a cohort.

--- a/extensions/metriport/actions/facility/dataPoints.ts
+++ b/extensions/metriport/actions/facility/dataPoints.ts
@@ -1,0 +1,26 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+import { address } from '../../shared/dataPoints'
+
+export const facilityDataPoints = {
+  facilityId: {
+    key: 'facilityId',
+    valueType: 'string',
+  },
+  facilityName: {
+    key: 'facilityName',
+    valueType: 'string',
+  },
+  npi: {
+    key: 'npi',
+    valueType: 'string',
+  },
+  tin: {
+    key: 'tin',
+    valueType: 'string',
+  },
+  active: {
+    key: 'active',
+    valueType: 'boolean',
+  },
+  ...address,
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/metriport/actions/facility/fields.ts
+++ b/extensions/metriport/actions/facility/fields.ts
@@ -1,0 +1,12 @@
+import { FieldType, type Field } from '@awell-health/extensions-core'
+
+export const getByNameFields = {
+  facilityName: {
+    id: 'facilityName',
+    label: 'Facility Name',
+    description:
+      'The name of the Facility to look up. Matched case-insensitively, ignoring surrounding whitespace, and must match exactly one Facility in your Organization.',
+    type: FieldType.STRING,
+    required: true,
+  },
+} satisfies Record<string, Field>

--- a/extensions/metriport/actions/facility/getFacilityByName.test.ts
+++ b/extensions/metriport/actions/facility/getFacilityByName.test.ts
@@ -1,0 +1,212 @@
+import { generateTestPayload } from '@/tests'
+import { TestHelpers } from '@awell-health/extensions-core'
+import { createMetriportApi } from '../../client'
+import { getFacilityByName } from './getFacilityByName'
+
+jest.mock('../../client')
+
+const mockedCreateMetriportApi = createMetriportApi as jest.MockedFunction<
+  typeof createMetriportApi
+>
+
+const settings = {
+  apiKey: 'test-api-key',
+  baseUrl: '',
+  webhookKey: '',
+  rateLimitDuration: '',
+}
+
+const facility = {
+  id: 'facility-1',
+  name: 'Awell Clinic',
+  npi: '1234567893',
+  tin: '12-3456789',
+  active: true,
+  address: {
+    addressLine1: '2261 Market Street',
+    addressLine2: 'Suite 4818',
+    city: 'San Francisco',
+    state: 'CA',
+    zip: '94114',
+    country: 'USA',
+  },
+}
+
+describe('Metriport - Get Facility by Name', () => {
+  const { onComplete, onError, helpers, clearMocks } =
+    TestHelpers.fromAction(getFacilityByName)
+  const listFacilities = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    clearMocks()
+    mockedCreateMetriportApi.mockReturnValue({
+      listFacilities,
+    } as never)
+  })
+
+  const invoke = async (name: string): Promise<void> => {
+    await getFacilityByName.onEvent!({
+      payload: generateTestPayload({
+        fields: { facilityName: name },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+  }
+
+  test('Should return the facility data points when exactly one facility matches', async () => {
+    listFacilities.mockResolvedValue([
+      { ...facility, id: 'facility-0', name: 'Other Clinic' },
+      facility,
+    ])
+
+    await invoke('Awell Clinic')
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        facilityId: 'facility-1',
+        facilityName: 'Awell Clinic',
+        npi: '1234567893',
+        tin: '12-3456789',
+        active: 'true',
+        addressLine1: '2261 Market Street',
+        addressLine2: 'Suite 4818',
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94114',
+        country: 'USA',
+      },
+    })
+  })
+
+  test('Should match the name case-insensitively and ignore surrounding whitespace', async () => {
+    listFacilities.mockResolvedValue([{ ...facility, name: '  Awell Clinic ' }])
+
+    await invoke('awell clinic')
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data_points: expect.objectContaining({ facilityId: 'facility-1' }),
+      }),
+    )
+  })
+
+  test('Should not match a facility whose name merely contains the given name', async () => {
+    listFacilities.mockResolvedValue([
+      { ...facility, name: 'Awell Clinic North' },
+    ])
+
+    await invoke('Awell Clinic')
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          error: {
+            category: 'WRONG_INPUT',
+            message: 'No Facility found with the name "Awell Clinic"',
+          },
+        }),
+      ],
+    })
+  })
+
+  test('Should call onError when no facility matches', async () => {
+    listFacilities.mockResolvedValue([
+      { ...facility, name: 'Other Clinic' },
+      { ...facility, name: 'Another Clinic' },
+    ])
+
+    await invoke('Awell Clinic')
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          error: {
+            category: 'WRONG_INPUT',
+            message: 'No Facility found with the name "Awell Clinic"',
+          },
+        }),
+      ],
+    })
+  })
+
+  test('Should call onError when more than one facility matches', async () => {
+    listFacilities.mockResolvedValue([
+      facility,
+      { ...facility, id: 'facility-2', name: 'awell clinic' },
+      { ...facility, id: 'facility-3', name: 'AWELL CLINIC' },
+    ])
+
+    await invoke('Awell Clinic')
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          error: {
+            category: 'WRONG_INPUT',
+            message:
+              '3 Facilities found with the name "Awell Clinic". The name must identify exactly one Facility.',
+          },
+        }),
+      ],
+    })
+  })
+
+  test('Should call onError when the name is empty', async () => {
+    await invoke('   ')
+
+    expect(listFacilities).not.toHaveBeenCalled()
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          error: expect.objectContaining({ category: 'WRONG_INPUT' }),
+        }),
+      ],
+    })
+  })
+
+  test('Should omit optional facility values that Metriport does not return', async () => {
+    listFacilities.mockResolvedValue([
+      {
+        id: 'facility-1',
+        name: 'Awell Clinic',
+        npi: '1234567893',
+        address: {
+          addressLine1: '2261 Market Street',
+          city: 'San Francisco',
+          state: 'CA',
+          zip: '94114',
+        },
+      },
+    ])
+
+    await invoke('Awell Clinic')
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith({
+      data_points: {
+        facilityId: 'facility-1',
+        facilityName: 'Awell Clinic',
+        npi: '1234567893',
+        tin: undefined,
+        active: undefined,
+        addressLine1: '2261 Market Street',
+        addressLine2: undefined,
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94114',
+        country: undefined,
+      },
+    })
+  })
+})

--- a/extensions/metriport/actions/facility/getFacilityByName.ts
+++ b/extensions/metriport/actions/facility/getFacilityByName.ts
@@ -1,0 +1,93 @@
+import { type Action } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { createMetriportApi } from '../../client'
+import { handleErrorMessage } from '../../shared/errorHandler'
+import { getByNameFields } from './fields'
+import { getByNameSchema } from './validation'
+import { facilityDataPoints as dataPoints } from './dataPoints'
+
+/**
+ * Metriport types the optional Facility values as nullable, and `state` as
+ * `unknown`, so they are normalised to a data point value or left unset.
+ */
+const asDataPoint = (value: unknown): string | undefined =>
+  value === undefined || value === null ? undefined : String(value)
+
+export const getFacilityByName: Action<
+  typeof getByNameFields,
+  typeof settings,
+  keyof typeof dataPoints
+> = {
+  key: 'getFacilityByName',
+  category: Category.EHR_INTEGRATIONS,
+  title: 'Get Facility by Name',
+  description:
+    'Gets the Facility with the given name by listing all Facilities in your Organization and matching on the name.',
+  fields: getByNameFields,
+  previewable: true,
+  supports_automated_retries: true,
+  dataPoints,
+  onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
+    helpers.log({ fields: payload.fields }, 'Processing getFacilityByName')
+
+    try {
+      const { facilityName } = getByNameSchema.parse(payload.fields)
+
+      const api = createMetriportApi(payload.settings)
+
+      /**
+       * Metriport has no endpoint to filter Facilities by name, so the full
+       * list is fetched and matched in memory. An Organization holds a handful
+       * of Facilities, so the list is small enough to scan on every activity.
+       */
+      const facilities = await api.listFacilities()
+      const target = facilityName.toLowerCase()
+      const matches = facilities.filter(
+        (facility) => facility.name.trim().toLowerCase() === target,
+      )
+
+      if (matches.length !== 1) {
+        const message =
+          matches.length === 0
+            ? `No Facility found with the name "${facilityName}"`
+            : `${matches.length} Facilities found with the name "${facilityName}". The name must identify exactly one Facility.`
+
+        await onError({
+          events: [
+            {
+              date: new Date().toISOString(),
+              text: { en: message },
+              error: {
+                category: 'WRONG_INPUT',
+                message,
+              },
+            },
+          ],
+        })
+        return
+      }
+
+      const [facility] = matches
+
+      await onComplete({
+        data_points: {
+          facilityId: facility.id,
+          facilityName: facility.name,
+          npi: facility.npi,
+          tin: asDataPoint(facility.tin),
+          active: asDataPoint(facility.active),
+          addressLine1: facility.address.addressLine1,
+          addressLine2: asDataPoint(facility.address.addressLine2),
+          city: facility.address.city,
+          state: asDataPoint(facility.address.state),
+          zip: facility.address.zip,
+          country: asDataPoint(facility.address.country),
+        },
+      })
+    } catch (err) {
+      helpers.log({ err }, 'error', err as Error)
+      await handleErrorMessage(err, onError)
+    }
+  },
+}

--- a/extensions/metriport/actions/facility/validation.ts
+++ b/extensions/metriport/actions/facility/validation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const getByNameSchema = z.object({
+  facilityName: z.coerce
+    .string({ error: 'Requires a Facility name' })
+    .trim()
+    .min(1, 'Requires a Facility name'),
+})

--- a/extensions/metriport/actions/index.ts
+++ b/extensions/metriport/actions/index.ts
@@ -10,6 +10,7 @@ import { startConsolidatedQuery } from './consolidated/startConsolidatedQuery'
 import { getConsolidatedQueryStatus } from './consolidated/getConsolidatedQueryStatus'
 import { getWebhookBundle } from './webhookBundle/getWebhookBundle'
 import { removePatientFromCohort } from './cohort/removePatientFromCohort'
+import { getFacilityByName } from './facility/getFacilityByName'
 
 export const actions = {
   getPatient,
@@ -24,4 +25,5 @@ export const actions = {
   getConsolidatedQueryStatus,
   getWebhookBundle,
   removePatientFromCohort,
+  getFacilityByName,
 }


### PR DESCRIPTION
## Summary

Adds a new action to resolve human-readable facility names to facilityIds, so care flows can work with facility names instead of UUIDs.

The action lists all facilities in your organization and matches by name (case-insensitive), erroring if zero or multiple facilities match.

## Testing

- [x] Unit tests for exact match, case-insensitive match, no match, and multiple match scenarios
- [x] README documentation updated with data points and field specifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)