### PR TITLE
fix(ci): grant workflow permissions at the job, not the workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+# Nothing is granted by default; the single job below asks for exactly what it needs. Scoping at
+# the workflow level hands the same token to every job, including any added later. Aikido 215263921.
+permissions: {}
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # creates the release commit, tag and GitHub release
     # Skip if this is a version bump commit from this workflow
     if: "!startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:

--- a/.github/workflows/version-created.yml
+++ b/.github/workflows/version-created.yml
@@ -4,13 +4,15 @@ on:
   release:
     types: [published]
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: read
+# Nothing granted by default -- see create-release.yml. Same shape, not separately flagged.
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## The problem

```yaml
permissions:
  contents: write   # ← workflow level
```

Aikido **215263921**, `AIK_yaml_gh-actions-overly-broad-permissions`, severity **68** — the highest-severity SAST finding in this repo.

A workflow-level grant hands that token to **every job in the workflow**, including any job added later. That last part is what makes it worth fixing rather than a style note: today `create-release.yml` has one job, so the grant is correct; the next job someone adds inherits `contents: write` silently.

## The change

`permissions: {}` at the workflow level, and the grant moved onto the one job that needs it.

**Provably equivalent today.** Both files have exactly one job, so the same grant reaches the same job. Verified by parsing both after the change:

```
create-release.yml    workflow={}  job[create-release]={'contents': 'write'}
version-created.yml   workflow={}  job[publish]={'id-token': 'write', 'contents': 'read'}
```

`version-created.yml` is **not separately flagged** but has the identical shape — workflow-level grant, single job — so it is fixed here rather than left to surface as a twin later. That pattern has already cost two extra MRs elsewhere in this remediation pass.

## Deliberately not: the five workflows with no `permissions:` at all

`auto-assign-ai-actions`, `conventions`, `pr-title`, `pre-release`, `update-algolia` set nothing and inherit the repository default. Adding `permissions: {}` there is a **real tightening**, not a move, and each needs a different scope:

| Workflow | What it actually needs |
| --- | --- |
| `auto-assign-ai-actions` | calls `action-add-assignees` with `GITHUB_TOKEN` → `issues: write` / `pull-requests: write` |
| `pre-release` | pushes with `VERSION_BUMP_TOKEN`, uses `GITHUB_TOKEN` for `setup-node` registry auth |
| `conventions`, `pr-title`, `update-algolia` | checkout only → `contents: read` |

Getting `auto-assign` or `pre-release` wrong breaks assignment or releases, and none of it is testable outside GitHub. That is its own change with its own review — the analysis above is recorded so whoever takes it has a starting point.

## Reachability

Supply chain. The concern is a job with more token scope than it needs — most acutely a future job added to a workflow that already grants `contents: write` at the top. `create-release.yml` runs on every push to `main`.

## Tests, before and after

| | |
| --- | --- |
| Both files parse as valid YAML | **yes** |
| Effective permissions for the existing job | **unchanged** (table above) |
| Aikido scan | control flags at **68**; fixed file returns **no issues** |

GitHub Actions cannot be exercised locally, so the parse plus the equivalence argument is the signal. The change is textual and the semantics of workflow- vs job-level `permissions` are well defined.

## Risk / not covered locally

**Low.**

| Path | If the reasoning is wrong |
| --- | --- |
| `create-release` still creates releases | Same job, same `contents: write`. A missing grant would fail the release step loudly on the next push to `main`, not silently. |
| `version-created` still publishes | Same job, same `id-token: write` + `contents: read` — OIDC publish unaffected. |
| A future job in either workflow | Now inherits nothing and must ask. That is the intended change. |
| The other five workflows | Untouched. |

Not Very Low only because CI cannot be run before merge; the first real exercise is the next push to `main`.

## Scanner outcome

**215263921 clears** — verified as a pair. No suppression.
