### PR TITLE
feat(metriport): return cohort and facility IDs from Enroll in Monitoring

### DIFF
--- a/extensions/metriport/actions/monitoring/enrollInMonitoring.test.ts
+++ b/extensions/metriport/actions/monitoring/enrollInMonitoring.test.ts
@@ -99,7 +99,11 @@ describe('Metriport - Enroll in Monitoring', () => {
       'facility-1',
     )
     expect(onComplete).toHaveBeenCalledWith({
-      data_points: { patientId: 'patient-1' },
+      data_points: {
+        patientId: 'patient-1',
+        cohortId: 'cohort-1',
+        facilityId: 'facility-1',
+      },
     })
   })
 

--- a/extensions/metriport/actions/monitoring/enrollInMonitoring.ts
+++ b/extensions/metriport/actions/monitoring/enrollInMonitoring.ts
@@ -1,5 +1,8 @@
-import { type Action } from '@awell-health/extensions-core'
-import { Category } from '@awell-health/extensions-core'
+import {
+  type Action,
+  type DataPointDefinition,
+  Category,
+} from '@awell-health/extensions-core'
 import { type settings } from '../../settings'
 import { createMetriportApi } from '../../client'
 import { handleErrorMessage } from '../../shared/errorHandler'
@@ -12,6 +15,18 @@ import { convertToMetriportPatient } from '../patient/create'
 import { patientIdDataPoint } from '../patient/dataPoints'
 import { enrollInMonitoringFields } from './fields'
 import { enrollInMonitoringSchema } from './validation'
+
+const enrollInMonitoringDataPoints = {
+  ...patientIdDataPoint,
+  cohortId: {
+    key: 'cohortId',
+    valueType: 'string',
+  },
+  facilityId: {
+    key: 'facilityId',
+    valueType: 'string',
+  },
+} satisfies Record<string, DataPointDefinition>
 
 /**
  * Joins the messages of every rejected lookup into one error. It stays a
@@ -34,7 +49,7 @@ const combineLookupErrors = (
 export const enrollInMonitoring: Action<
   typeof enrollInMonitoringFields,
   typeof settings,
-  keyof typeof patientIdDataPoint
+  keyof typeof enrollInMonitoringDataPoints
 > = {
   key: 'enrollInMonitoring',
   category: Category.EHR_INTEGRATIONS,
@@ -44,7 +59,7 @@ export const enrollInMonitoring: Action<
   fields: enrollInMonitoringFields,
   previewable: true,
   supports_automated_retries: true,
-  dataPoints: patientIdDataPoint,
+  dataPoints: enrollInMonitoringDataPoints,
   onEvent: async ({ payload, onComplete, onError, helpers }): Promise<void> => {
     helpers.log({ fields: payload.fields }, 'Processing enrollInMonitoring')
 
@@ -78,6 +93,8 @@ export const enrollInMonitoring: Action<
       await onComplete({
         data_points: {
           patientId: String(id),
+          cohortId: cohort.id,
+          facilityId: facility.id,
         },
       })
     } catch (err) {


### PR DESCRIPTION
## Summary
- `enrollInMonitoring` already looks up the Cohort and Facility by name before creating the Patient — this now returns their IDs as data points (`cohortId`, `facilityId`) alongside the existing `patientId`, so downstream care flow steps can use them without a second lookup.

## Testing
- `yarn jest extensions/metriport -w 1` — 181 passed, 17 suites
