### PR TITLE
fix(secrets): drop the hardcoded Algolia admin-key fallback from upload-to-algolia.mjs

### DIFF
--- a/upload-to-algolia.mjs
+++ b/upload-to-algolia.mjs
@@ -4,9 +4,14 @@ import matter from 'gray-matter';
 import { algoliasearch } from 'algoliasearch';
 import { globSync } from 'glob';
 
-// Read environment variables
-const ALGOLIA_APP_ID = process.env.ALGOLIA_APP_ID || 'O53UAVSSKA';
-const ALGOLIA_ADMIN_KEY = process.env.ALGOLIA_ADMIN_KEY || 'f5f192b7de58b933d0a954cb7ba558b3';
+// Read environment variables. Both come from the workflow's secrets; there is deliberately no
+// fallback: a hardcoded admin key here was a leaked credential, and a missing variable should
+// fail the job rather than silently upload with a baked-in key.
+const { ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY } = process.env;
+if (!ALGOLIA_APP_ID || !ALGOLIA_ADMIN_KEY) {
+  console.error('ALGOLIA_APP_ID and ALGOLIA_ADMIN_KEY must be set in the environment');
+  process.exit(1);
+}
 const INDEX_NAME = 'awell_developers';
 const EXCLUDE_EXTENSIONS = ['wellinks', 'hello-world', 'avaAi'];
 


### PR DESCRIPTION
Part of AWL-4333. Closes Aikido **385950950** (leaked_secret, high 80, "Identified an Algolia API Key") in code — and **this one is a real credential, not a fixture.**

## What

`upload-to-algolia.mjs` read `ALGOLIA_APP_ID` / `ALGOLIA_ADMIN_KEY` from the environment but fell back to literals — including an Algolia **admin** key, committed in `e62c24f7` ("fix(): algoliasearch #4"). The fallbacks are gone; the script now requires both variables and exits 1 with a clear message if either is missing.

## Reachability

An Algolia admin key can read, write and delete the `awell_developers` search index that powers the developer docs search. The key has been in this repository's history since the script was added. The workflow that runs the script (`.github/workflows/update-algolia.yml`) already injects both values from GitHub secrets, so the fallback was never exercised in CI — the exposure is the committed value, not the code path.

## What this PR does and does not do

- **Does:** removes the literal from `main` so the finding closes and no future run can use a baked-in key; fails fast when the environment is incomplete (previously a misconfigured run would have silently used the hardcoded key).
- **Does not:** remove the key from git history, and cannot make the exposed key safe. **The admin key must be rotated in the Algolia dashboard and the `ALGOLIA_ADMIN_KEY` GitHub secret updated.** Until that happens the old key still works for anyone who has read this repo's history.

## Tests

`node --check` passes. Behaviour with the secrets set (the only way CI runs it) is unchanged: same client, same index, same upload. With a variable missing the job now fails at the top instead of uploading with the fallback.

## Risk

**Very low** for the code. The `update-algolia` workflow has the secrets configured, so the next run is identical. The real action item is the rotation above.

## Scanner outcome

Closes on the next scan of `main`. No suppression, no register row. If Aikido also scans history the finding may persist until the key is rotated and the platform marks it resolved.