### PR TITLE
fix(metriport): omit empty contact on create patient; surface Metriport error title and detail

### DIFF
--- a/extensions/metriport/actions/patient/create.test.ts
+++ b/extensions/metriport/actions/patient/create.test.ts
@@ -1,0 +1,50 @@
+import { convertToMetriportPatient } from './create'
+import { patientCreateSchema } from './validation'
+
+const baseFields = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  dob: '1940-08-29',
+  genderAtBirth: 'F',
+  addressLine1: '1 Analytical Engine Way',
+  city: 'San Francisco',
+  state: 'CA',
+  zip: '94105',
+}
+
+const convert = (
+  overrides: Record<string, unknown>,
+): ReturnType<typeof convertToMetriportPatient> =>
+  convertToMetriportPatient(
+    patientCreateSchema.parse({ ...baseFields, ...overrides }),
+  )
+
+describe('convertToMetriportPatient.contact', () => {
+  test('includes phone and email when both are provided', () => {
+    expect(
+      convert({ phone: '+15555550100', email: 'ada@example.com' }).contact,
+    ).toEqual({ phone: '+15555550100', email: 'ada@example.com' })
+  })
+
+  test('includes only the phone when the email is empty', () => {
+    expect(convert({ phone: '+15555550100', email: '' }).contact).toEqual({
+      phone: '+15555550100',
+      email: undefined,
+    })
+  })
+
+  test('includes only the email when the phone is missing', () => {
+    expect(convert({ email: 'ada@example.com' }).contact).toEqual({
+      phone: undefined,
+      email: 'ada@example.com',
+    })
+  })
+
+  test.each([
+    ['both are missing', {}],
+    ['both are empty strings', { phone: '', email: '' }],
+    ['phone is empty and email is missing', { phone: '' }],
+  ])('omits contact when %s', (_label, overrides) => {
+    expect(convert(overrides)).not.toHaveProperty('contact')
+  })
+})

--- a/extensions/metriport/actions/patient/create.ts
+++ b/extensions/metriport/actions/patient/create.ts
@@ -69,10 +69,13 @@ export const convertToMetriportPatient = (
       country: patient.country,
     },
     personalIdentifiers: [],
-    contact: {
-      phone: patient.phone,
-      email: patient.email,
-    },
+  }
+
+  if (patient.phone || patient.email) {
+    patientMetriport.contact = {
+      phone: patient.phone || undefined,
+      email: patient.email || undefined,
+    }
   }
 
   if (

--- a/extensions/metriport/shared/errorHandler.test.ts
+++ b/extensions/metriport/shared/errorHandler.test.ts
@@ -1,5 +1,15 @@
+import { AxiosError, type AxiosResponse } from 'axios'
 import { handleErrorMessage } from './errorHandler'
 import { NameLookupError } from './nameLookup'
+
+const axiosError = (status: number, data: unknown): AxiosError =>
+  new AxiosError(
+    `Request failed with status code ${status}`,
+    'ERR_BAD_REQUEST',
+    undefined,
+    undefined,
+    { status, data } as unknown as AxiosResponse,
+  )
 
 describe('handleErrorMessage', () => {
   test('reports a NameLookupError as WRONG_INPUT, since the care flow supplied a name Metriport does not know', async () => {
@@ -22,4 +32,84 @@ describe('handleErrorMessage', () => {
       ],
     })
   })
+
+  test('reports the Metriport title and detail instead of the opaque Axios message', async () => {
+    const onError = jest.fn()
+
+    // Verbatim Metriport error body for a malformed facilityId.
+    await handleErrorMessage(
+      axiosError(400, {
+        status: 400,
+        title: 'Missing or invalid parameters',
+        detail: 'Invalid uuid, on [facilityId]',
+        name: 'Bad Request',
+      }),
+      onError,
+    )
+
+    const message =
+      '400 Missing or invalid parameters: Invalid uuid, on [facilityId]'
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          text: { en: message },
+          error: { category: 'SERVER_ERROR', message },
+        }),
+      ],
+    })
+  })
+
+  test('reports the detail alone when the body has no title', async () => {
+    const onError = jest.fn()
+
+    await handleErrorMessage(
+      axiosError(404, { status: 404, detail: 'Could not find patient' }),
+      onError,
+    )
+
+    expect(onError).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          text: { en: '404 Error: Could not find patient' },
+        }),
+      ],
+    })
+  })
+
+  test('reports the title alone when the body has no detail', async () => {
+    const onError = jest.fn()
+
+    await handleErrorMessage(
+      axiosError(403, { status: 403, title: 'Forbidden' }),
+      onError,
+    )
+
+    expect(onError).toHaveBeenCalledWith({
+      events: [expect.objectContaining({ text: { en: '403 Forbidden' } })],
+    })
+  })
+
+  test.each([
+    ['no response body', undefined],
+    ['a body without detail', { status: 500, name: 'InternalServerError' }],
+    ['empty title and detail', { title: '', detail: '' }],
+    ['a non-string detail', { detail: { nested: true } }],
+  ])(
+    'falls back to the Axios message when there is %s',
+    async (_label, data) => {
+      const onError = jest.fn()
+
+      await handleErrorMessage(axiosError(500, data), onError)
+
+      const message = '500 Error: Request failed with status code 500'
+      expect(onError).toHaveBeenCalledWith({
+        events: [
+          expect.objectContaining({
+            text: { en: message },
+            error: { category: 'SERVER_ERROR', message },
+          }),
+        ],
+      })
+    },
+  )
 })

--- a/extensions/metriport/shared/errorHandler.ts
+++ b/extensions/metriport/shared/errorHandler.ts
@@ -36,18 +36,15 @@ export const handleErrorMessage = async (
       ],
     })
   } else if (err instanceof AxiosError) {
+    const message = formatAxiosError(err)
     await onError({
       events: [
         {
           date: new Date().toISOString(),
-          text: {
-            en: `${err.status ?? '(no status code)'} Error: ${err.message}`,
-          },
+          text: { en: message },
           error: {
             category: 'SERVER_ERROR',
-            message: `${err.status ?? '(no status code)'} Error: ${
-              err.message
-            }`,
+            message,
           },
         },
       ],
@@ -67,4 +64,34 @@ export const handleErrorMessage = async (
       ],
     })
   }
+}
+
+/**
+ * Metriport error bodies follow RFC 7807: `title` names the problem
+ * ("Missing or invalid parameters") and `detail` explains it
+ * ("Invalid uuid, on [facilityId]"). The Axios message only says
+ * "Request failed with status code 400", so prefer the body and fall back
+ * to the Axios message only when the body carries neither field.
+ */
+const formatAxiosError = (err: AxiosError): string => {
+  const status = err.status ?? '(no status code)'
+  const title = getBodyString(err, 'title')
+  const detail = getBodyString(err, 'detail')
+
+  if (title !== undefined && detail !== undefined) {
+    return `${status} ${title}: ${detail}`
+  }
+  if (title !== undefined) {
+    return `${status} ${title}`
+  }
+  return `${status} Error: ${detail ?? err.message}`
+}
+
+const getBodyString = (err: AxiosError, key: string): string | undefined => {
+  const data: unknown = err.response?.data
+  if (typeof data !== 'object' || data === null || !(key in data)) {
+    return undefined
+  }
+  const value = (data as Record<string, unknown>)[key]
+  return typeof value === 'string' && value !== '' ? value : undefined
 }


### PR DESCRIPTION
## Summary

Closes [AWL-4808](https://linear.app/awell/issue/AWL-4808/metriport-create-patient-sends-an-empty-contact-object-and-reports)

Two fixes to the Metriport extension.

**Create Patient: omit `contact` when there is no phone or email.** `convertToMetriportPatient` always sent `contact: { phone: undefined, email: undefined }` when the care flow supplied neither. The block is now only included when at least one of them is a non-empty string. Empty strings are treated as absent, since the email schema lets `''` through.

**Error reporting: use Metriport's `title` and `detail` instead of the Axios message.** Failures were surfaced as `400 Error: Request failed with status code 400`, which hides the reason. The shared error handler now reads Metriport's RFC 7807 body:

| Body has | Reported message |
|---|---|
| `title` + `detail` | `400 Missing or invalid parameters: Invalid uuid, on [facilityId]` |
| `detail` only | `404 Error: Could not find patient` |
| `title` only | `403 Forbidden` |
| neither / no body | `400 Error: Request failed with status code 400` (unchanged) |

Empty or non-string values are treated as absent so a malformed body can never blank the message. This applies to every Metriport action since they all route through `handleErrorMessage`.

Not in scope: the `helpers.log` calls in each action still log the raw `AxiosError`. Only the `onError` text shown in the activity feed changes here.

## Testing

- New `actions/patient/create.test.ts` pins both-present, phone-only, email-only, and three omit cases (both missing, both empty, phone empty + email missing). The omit cases failed before the change.
- `shared/errorHandler.test.ts` gains the verbatim Metriport 400 body above, detail-only, title-only, and four fallback cases. The title+detail case failed before the change.
- `yarn jest extensions/metriport -w 1`: 18 suites, 194 tests passing.
- `tsc --noEmit`, eslint, and prettier clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
