### PR TITLE
feat(mailgun): add optional file attachment to Send email

### DIFF
--- a/extensions/mailgun/CHANGELOG.md
+++ b/extensions/mailgun/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Mailgun changelog
+
+## Unreleased
+
+- "Send email": added optional file attachment support via three new fields: attachment content (base64), attachment filename, and attachment content type (defaults to `application/pdf`). Designed to attach the `base64Pdf` output of the Transform "HTML to PDF" action. Existing care flows are unaffected when the new fields are left empty.

--- a/extensions/mailgun/README.md
+++ b/extensions/mailgun/README.md
@@ -21,7 +21,18 @@ In order to set up this extension, you will need to provide a:
 
 ### Send email
 
-Allows for sending a plain email to a recipient.
+Allows for sending a plain email to a recipient, optionally with a single file attachment.
+
+**Inputs:**
+
+- **To** (required): recipient email address(es), comma-separated.
+- **Subject** (required)
+- **Body** (required): HTML content of the email.
+- **Attachment content (base64)** (optional): the base64-encoded file to attach. Typically bound to the `base64Pdf` data point produced by the Transform extension's "HTML to PDF" action.
+- **Attachment filename** (optional, required when attachment content is set): the filename the recipient sees, including extension, e.g. `Health-Snapshot.pdf`.
+- **Attachment content type** (optional): MIME type of the attachment. Defaults to `application/pdf`.
+
+Leave the attachment fields empty to send the email without an attachment. Attachments are limited to 20 MB (decoded) to stay under Mailgun's 25 MB message limit.
 
 ### Send email with a template
 

--- a/extensions/mailgun/v1/actions/sendEmail/config/fields.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/config/fields.ts
@@ -1,6 +1,7 @@
 import { z, type ZodType } from 'zod'
 import { type Field, FieldType } from '@awell-health/extensions-core'
 import { CommaSeparatedEmailsValidationSchema } from '../../../../../../src/lib/awell'
+import { isEmpty, isNil } from 'lodash'
 
 export const fields = {
   to: {
@@ -29,18 +30,110 @@ export const fields = {
     type: FieldType.HTML,
     required: true,
   },
+  attachmentContent: {
+    id: 'attachmentContent',
+    label: 'Attachment content (base64)',
+    description:
+      'Base64-encoded content of a file to attach, for example the "base64Pdf" data point produced by the Transform "HTML to PDF" action. Leave empty to send the email without an attachment.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  attachmentFilename: {
+    id: 'attachmentFilename',
+    label: 'Attachment filename',
+    description:
+      'The filename the recipient will see, including the extension (e.g. "Health-Snapshot.pdf"). Required when attachment content is provided.',
+    type: FieldType.STRING,
+    required: false,
+  },
+  attachmentContentType: {
+    id: 'attachmentContentType',
+    label: 'Attachment content type',
+    description:
+      'MIME type of the attachment. Defaults to "application/pdf" when left empty.',
+    type: FieldType.STRING,
+    required: false,
+  },
 } satisfies Record<string, Field>
 
-export const FieldsValidationSchema = z.object({
-  to: CommaSeparatedEmailsValidationSchema.refine(
-    (emails) => emails.length > 0,
-    {
-      error: 'At least one email address is required',
-    },
-  ),
-  subject: z.string(),
-  body: z.string(),
-} satisfies Record<keyof typeof fields, ZodType>)
+/**
+ * Mailgun rejects messages above 25 MB in total. Cap the decoded attachment
+ * well below that so the failure surfaces as a clear validation error rather
+ * than an opaque API error.
+ */
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+export const DEFAULT_ATTACHMENT_CONTENT_TYPE = 'application/pdf'
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/
+
+/**
+ * Accepts raw base64 as well as a data URI ("data:application/pdf;base64,....")
+ * and returns the bare base64 payload with all whitespace removed.
+ */
+export const normalizeBase64 = (value: string): string => {
+  const withoutDataUriPrefix = value.replace(/^data:[^;,]*;base64,/i, '')
+  return withoutDataUriPrefix.replace(/\s+/g, '')
+}
+
+export const isValidBase64 = (value: string): boolean =>
+  value.length > 0 && value.length % 4 === 0 && BASE64_PATTERN.test(value)
+
+const optionalTrimmedString = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value) => (isNil(value) || isEmpty(value) ? undefined : value))
+
+export const FieldsValidationSchema = z
+  .object({
+    to: CommaSeparatedEmailsValidationSchema.refine(
+      (emails) => emails.length > 0,
+      {
+        error: 'At least one email address is required',
+      },
+    ),
+    subject: z.string(),
+    body: z.string(),
+    attachmentContent: optionalTrimmedString,
+    attachmentFilename: optionalTrimmedString,
+    attachmentContentType: optionalTrimmedString,
+  } satisfies Record<keyof typeof fields, ZodType>)
+  .superRefine((value, ctx) => {
+    if (isNil(value.attachmentContent)) {
+      return
+    }
+
+    if (isNil(value.attachmentFilename)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['attachmentFilename'],
+        message:
+          'An attachment filename is required when attachment content is provided.',
+      })
+    }
+
+    const base64 = normalizeBase64(value.attachmentContent)
+
+    if (!isValidBase64(base64)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['attachmentContent'],
+        message:
+          'Attachment content is not valid base64. Expected the raw base64 string, e.g. the "base64Pdf" data point from the HTML to PDF action.',
+      })
+      return
+    }
+
+    const decodedBytes = Buffer.from(base64, 'base64').length
+
+    if (decodedBytes > MAX_ATTACHMENT_BYTES) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['attachmentContent'],
+        message: `Attachment is ${decodedBytes} bytes, which exceeds the maximum of ${MAX_ATTACHMENT_BYTES} bytes.`,
+      })
+    }
+  })
 
 export const validateActionFields = (
   fields: unknown,
@@ -48,4 +141,29 @@ export const validateActionFields = (
   const parsedData = FieldsValidationSchema.parse(fields)
 
   return parsedData
+}
+
+export interface MailgunAttachment {
+  filename: string
+  data: Buffer
+  contentType: string
+}
+
+/**
+ * Builds the attachment object expected by mailgun.js `messages.create`
+ * (`{ filename, data, contentType }`), or `undefined` when no attachment
+ * content was provided. Assumes the fields have already been validated.
+ */
+export const buildAttachment = (
+  fields: z.infer<typeof FieldsValidationSchema>,
+): MailgunAttachment | undefined => {
+  if (isNil(fields.attachmentContent) || isNil(fields.attachmentFilename)) {
+    return undefined
+  }
+
+  return {
+    filename: fields.attachmentFilename,
+    data: Buffer.from(normalizeBase64(fields.attachmentContent), 'base64'),
+    contentType: fields.attachmentContentType ?? DEFAULT_ATTACHMENT_CONTENT_TYPE,
+  }
 }

--- a/extensions/mailgun/v1/actions/sendEmail/sendEmail.test.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/sendEmail.test.ts
@@ -1,8 +1,42 @@
 import { sendEmail } from '..'
 import { generateTestPayload } from '@/tests'
 import { TestHelpers } from '@awell-health/extensions-core'
+import mailgunSdk from '../../../common/sdk/mailgunSdk'
 
 jest.mock('../../../common/sdk/mailgunSdk')
+
+const settings = {
+  apiKey: 'an-api-key',
+  domain: 'a-domain',
+  fromName: 'John Doe',
+  fromEmail: 'hello@awellhealth.com',
+  region: 'EU',
+  testMode: 'yes',
+}
+
+const baseFields = {
+  to: 'email@hello.com',
+  subject: 'A subject',
+  body: "<h1>Don't shout!</h1>",
+  attachmentContent: undefined,
+  attachmentFilename: undefined,
+  attachmentContentType: undefined,
+}
+
+/** "%PDF-1.4 hello" as base64 */
+const PDF_BASE64 = Buffer.from('%PDF-1.4 hello').toString('base64')
+
+/**
+ * The SDK mock returns a fresh client per `client()` call; grab the
+ * `messages.create` mock from the most recent client to assert on its params.
+ */
+const getLastCreateCall = (): Record<string, unknown> => {
+  const clientMock = mailgunSdk.client as jest.Mock
+  const client = clientMock.mock.results[clientMock.mock.results.length - 1]
+    .value as { messages: { create: jest.Mock } }
+  const createMock = client.messages.create
+  return createMock.mock.calls[0][1] as Record<string, unknown>
+}
 
 describe('Send email', () => {
   const { onComplete, onError, helpers, clearMocks } =
@@ -10,25 +44,12 @@ describe('Send email', () => {
 
   beforeEach(() => {
     clearMocks()
+    ;(mailgunSdk.client as jest.Mock).mockClear()
   })
 
   test('Should call the onComplete callback', async () => {
     await sendEmail.onEvent!({
-      payload: generateTestPayload({
-        fields: {
-          to: 'email@hello.com',
-          subject: 'A subject',
-          body: "<h1>Don't shout!</h1>",
-        },
-        settings: {
-          apiKey: 'an-api-key',
-          domain: 'a-domain',
-          fromName: 'John Doe',
-          fromEmail: 'hello@awellhealth.com',
-          region: 'EU',
-          testMode: 'yes',
-        },
-      }),
+      payload: generateTestPayload({ fields: baseFields, settings }),
       onComplete,
       onError,
       helpers,
@@ -39,21 +60,149 @@ describe('Send email', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  test('Should call the onError callback when there is a validation error', async () => {
+  test('Should not pass an attachment when no attachment content is provided', async () => {
+    await sendEmail.onEvent!({
+      payload: generateTestPayload({
+        fields: { ...baseFields, attachmentContent: '', attachmentFilename: '' },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(getLastCreateCall()).not.toHaveProperty('attachment')
+  })
+
+  test('Should attach a decoded file when attachment content and filename are provided', async () => {
     await sendEmail.onEvent!({
       payload: generateTestPayload({
         fields: {
-          to: 'email@hello.com',
-          subject: 'A subject',
-          body: "<h1>Don't shout!</h1>",
+          ...baseFields,
+          attachmentContent: PDF_BASE64,
+          attachmentFilename: 'Health-Snapshot.pdf',
         },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalled()
+
+    const params = getLastCreateCall()
+    expect(params).toMatchObject({
+      to: ['email@hello.com'],
+      subject: 'A subject',
+      html: "<h1>Don't shout!</h1>",
+    })
+    const attachment = params.attachment as {
+      filename: string
+      data: Buffer
+      contentType: string
+    }
+    expect(attachment.filename).toBe('Health-Snapshot.pdf')
+    expect(attachment.contentType).toBe('application/pdf')
+    expect(Buffer.isBuffer(attachment.data)).toBe(true)
+    expect(attachment.data.toString('utf-8')).toBe('%PDF-1.4 hello')
+  })
+
+  test('Should honour an explicit content type and accept a data URI prefix', async () => {
+    await sendEmail.onEvent!({
+      payload: generateTestPayload({
+        fields: {
+          ...baseFields,
+          attachmentContent: `data:text/plain;base64,${Buffer.from('hi').toString('base64')}`,
+          attachmentFilename: 'note.txt',
+          attachmentContentType: 'text/plain',
+        },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+    const attachment = getLastCreateCall().attachment as {
+      data: Buffer
+      contentType: string
+    }
+    expect(attachment.contentType).toBe('text/plain')
+    expect(attachment.data.toString('utf-8')).toBe('hi')
+  })
+
+  test('Should call onError when attachment content is provided without a filename', async () => {
+    await sendEmail.onEvent!({
+      payload: generateTestPayload({
+        fields: { ...baseFields, attachmentContent: PDF_BASE64 },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            error: expect.objectContaining({
+              category: 'WRONG_INPUT',
+              message: expect.stringContaining('attachment filename is required'),
+            }),
+          }),
+        ],
+      }),
+    )
+  })
+
+  test('Should call onError when attachment content is not valid base64', async () => {
+    await sendEmail.onEvent!({
+      payload: generateTestPayload({
+        fields: {
+          ...baseFields,
+          attachmentContent: 'this is not base64!!',
+          attachmentFilename: 'file.pdf',
+        },
+        settings,
+      }),
+      onComplete,
+      onError,
+      helpers,
+      attempt: 1,
+    })
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            error: expect.objectContaining({
+              category: 'WRONG_INPUT',
+              message: expect.stringContaining('not valid base64'),
+            }),
+          }),
+        ],
+      }),
+    )
+  })
+
+  test('Should call the onError callback when there is a validation error', async () => {
+    await sendEmail.onEvent!({
+      payload: generateTestPayload({
+        fields: baseFields,
         settings: {
-          apiKey: 'an-api-key',
-          domain: 'a-domain',
-          fromName: 'John Doe',
-          fromEmail: 'hello@awellhealth.com',
+          ...settings,
           region: 'not-a-valid-region', // Should be "EU" or "US"
-          testMode: 'yes',
         },
       }),
       onComplete,

--- a/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
+++ b/extensions/mailgun/v1/actions/sendEmail/sendEmail.ts
@@ -4,25 +4,45 @@ import { Category } from '@awell-health/extensions-core'
 import { validateSettings, type settings } from '../../../settings'
 import mailgunSdk from '../../../common/sdk/mailgunSdk'
 import { getApiUrl } from '../../../common/utils'
-import { validateActionFields } from './config/fields'
+import { buildAttachment, validateActionFields } from './config/fields'
 import { fromZodError } from 'zod-validation-error'
 import { ZodError } from 'zod'
+import { isNil } from 'lodash'
 import { addActivityEventLog } from '../../../../../src/lib/awell/addEventLog'
 
 export const sendEmail: Action<typeof fields, typeof settings> = {
   key: 'sendEmail',
   title: 'Send email',
-  description: 'Send an email to a recipient of your choice.',
+  description:
+    'Send an email to a recipient of your choice, optionally with a file attachment.',
   category: Category.COMMUNICATION,
   fields,
   previewable: false,
   onEvent: async ({ payload, onComplete, onError, helpers }) => {
-    helpers.log({ fields: payload.fields }, 'Processing sendEmail')
+    /**
+     * The attachment content can be a large base64 string; log its size
+     * rather than the content itself.
+     */
+    const { attachmentContent, ...loggableFields } = payload.fields
+    helpers.log(
+      {
+        fields: {
+          ...loggableFields,
+          attachmentContentLength: isNil(attachmentContent)
+            ? 0
+            : String(attachmentContent).length,
+        },
+      },
+      'Processing sendEmail',
+    )
 
     try {
-      const { to, subject, body } = validateActionFields(payload.fields)
+      const validatedFields = validateActionFields(payload.fields)
+      const { to, subject, body } = validatedFields
       const { apiKey, domain, region, fromName, fromEmail, testMode } =
         validateSettings(payload.settings)
+
+      const attachment = buildAttachment(validatedFields)
 
       const mg = mailgunSdk.client({
         username: 'api',
@@ -36,14 +56,20 @@ export const sendEmail: Action<typeof fields, typeof settings> = {
         subject,
         html: body,
         'o:testmode': testMode,
+        ...(attachment !== undefined && { attachment }),
       })
+
+      const attachmentSummary =
+        attachment === undefined
+          ? ''
+          : `, with attachment "${attachment.filename}" (${attachment.data.length} bytes, ${attachment.contentType})`
 
       await onComplete({
         events: [
           addActivityEventLog({
             message: `Mailgun accepted the request, message ID: ${String(
               res?.id,
-            )}`,
+            )}${attachmentSummary}`,
           }),
         ],
       })


### PR DESCRIPTION
## Context

The Transform extension's "HTML to PDF" action produces a PDF as a base64 string data point (`base64Pdf`). Until now no marketplace email action could deliver that file to a patient: both the Mailgun and SendGrid "Send email" actions accept only `to`, `subject` and `body`. First concrete need is a customer (Luxmed, EU) who wants a generated Health Snapshot PDF emailed to the patient.

## Summary

- Adds three **optional** fields to Mailgun "Send email":
  - `attachmentContent` — base64 file content (typically bound to the `base64Pdf` data point)
  - `attachmentFilename` — filename the recipient sees, e.g. `Health-Snapshot.pdf`; required when content is provided
  - `attachmentContentType` — MIME type, defaults to `application/pdf`
- Validation (Zod `superRefine`): content without filename fails; content that is not valid base64 fails; decoded size above 20 MB fails (Mailgun's message limit is 25 MB). All surface as `WRONG_INPUT` with a clear message. A `data:...;base64,` prefix is tolerated and stripped.
- The attachment is decoded to a `Buffer` and passed to `mailgun.js` as `{ filename, data, contentType }`, which is the shape the SDK's form-data builder expects (verified in `mailgun.js@8.2.2` bundle: `addFilesToFD` reads `.data`, `getAttachmentOptions` reads `filename` / `contentType`). The SDK handles the multipart encoding.
- The processing log now reports the attachment content **length** instead of the content itself, so a large base64 string does not land in logs.
- The completion event log mentions the attachment filename, size and type when present.
- **No behaviour change** for existing care flows: when the new fields are empty, `messages.create` is called with exactly the same parameters as before (covered by a test).

## Not in scope

- SendGrid "Send email" — same change would apply; left for a separate PR if needed.
- Mailgun "Send email with a template" — unchanged.
- Multiple attachments — kept to a single attachment with flat fields so builders configure it in Studio without hand-writing JSON. A JSON list can be added later without breaking these fields.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test extensions/mailgun` passes (8 tests). New tests cover: no attachment leaves the SDK call unchanged; attachment is decoded and passed with filename and default content type; explicit content type and data-URI prefix; content without filename → `WRONG_INPUT`; invalid base64 → `WRONG_INPUT`
- [x] `yarn jest src/__tests__/extensions.test.ts` passes (field id / README / CHANGELOG conventions, 1301 tests)
- [x] `yarn lint extensions/mailgun` clean; `tsc --noEmit` clean
- [x] `.github/scripts/check-repo-conventions.sh origin/main...HEAD` passes
- [ ] Manual, Luxmed Sandbox: care flow "Patient Health Report Mock-up (demo)" (`VmRDL8mvL91D`). Bind `attachmentContent` to the HTML to PDF `base64Pdf` data point, set `attachmentFilename` to `Health-Snapshot.pdf`, run with Mailgun **test mode** on, then off to a test inbox; confirm the PDF opens.

## Note / follow-up

- Mailgun's own limit is 25 MB per message; the 20 MB cap leaves headroom for the body and multipart overhead. A one-page generated PDF is ~15 KB, so this is far from the limit in practice.
- Awell data points holding a large base64 string are the more likely practical limit; not a concern for single-page PDFs, worth knowing for multi-page reports with embedded images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)