### PR TITLE
chore: speed up CI by removing per-file type-checking from Jest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,14 @@ on:
       - "main"
       - "release/*"
 
+# Pushing a new commit supersedes the runs still in flight for the same ref.
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  build:
+    name: build
     permissions:
       packages: write
       contents: read
@@ -28,6 +34,88 @@ jobs:
 
       - name: Compile Typescript
         run: yarn build
-      
+
+      # ts-jest no longer type-checks each test file (see tsconfig.json's
+      # isolatedModules), so the whole program is checked once here instead.
+      # tsconfig.json covers test files; tsconfig.build.json excludes them.
+      - name: Type-check (including tests)
+        run: yarn tsc --noEmit -p tsconfig.json
+
+  test-shard:
+    name: test-shard
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every failing shard, not just the first one.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      # Tests import from source, not dist/, so this does not need `yarn build`.
       - name: Run tests
-        run: yarn test
+        run: yarn test --shard=${{ matrix.shard }}/4
+
+  # Advisory for now: `yarn lint` reports 45 pre-existing errors on `main`, so
+  # this job reports them without blocking and is deliberately NOT wired into the
+  # `test` gate below. Once those are cleared, drop `continue-on-error` and add
+  # `lint` to the gate's `needs`. Runs in parallel, so it costs no wall-clock.
+  lint:
+    name: lint (advisory)
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Lint
+        run: |
+          echo "::notice::Advisory only - lint failures here do not block the PR."
+          yarn lint
+
+  # Single stable check to gate on, so branch protection does not have to name
+  # each shard. Keep this job's name in sync with skills/pr-conventions §0.
+  test:
+    name: test
+    needs: [build, test-shard]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify build and all test shards passed
+        run: |
+          set -euo pipefail
+          echo "build:      ${{ needs.build.result }}"
+          echo "test-shard: ${{ needs.test-shard.result }}"
+          if [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.test-shard.result }}" != "success" ]; then
+            echo "::error::build or one or more test shards did not pass"
+            exit 1
+          fi
+          echo "✅ build and all 4 test shards passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
       packages: write
       contents: read
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -95,17 +94,38 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      # Always exits 0, so this check stays green rather than showing a
+      # permanently red check that everyone learns to ignore. The findings go to
+      # the job summary instead. Make this strict once the backlog is cleared.
       - name: Lint
         run: |
-          echo "::notice::Advisory only - lint failures here do not block the PR."
-          yarn lint
+          set -uo pipefail
+          yarn lint 2>&1 | tee lint.txt || true
+          {
+            echo "### Lint (advisory - does not block)"
+            if grep -q "problems" lint.txt; then
+              echo ""
+              echo "\`\`\`"
+              grep -E "problems|potentially fixable" lint.txt || true
+              echo "\`\`\`"
+              echo ""
+              echo "Pre-existing backlog on \`main\`; see the job log for the full list."
+            else
+              echo ""
+              echo "No lint problems reported."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Single stable check to gate on, so branch protection does not have to name
   # each shard. Keep this job's name in sync with skills/pr-conventions §0.
   test:
     name: test
     needs: [build, test-shard]
-    if: always()
+    # Not `always()`: on a cancelled run (e.g. superseded by a newer commit via
+    # the concurrency rule above) `always()` would still run this job and report
+    # a spurious failure. `!cancelled()` skips it then, but still runs it - and
+    # so reports a real failure - when a dependency actually fails.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify build and all test shards passed

--- a/skills/pr-conventions/SKILL.md
+++ b/skills/pr-conventions/SKILL.md
@@ -29,7 +29,7 @@ Derived from analysing the last ~200 PRs and ~50 commits on `main` in this repo.
 - **Do NOT add a `release/*` branch.** Those are owned by the release workflow for beta testing.
 - **Do NOT manually add `Review effort 1/5`–`5/5` labels.** CodiumAI PR-Agent applies them automatically.
 - **No `CONTRIBUTING.md` or `.github/PULL_REQUEST_TEMPLATE.md` exists in-repo.** External contributing guidelines live at https://developers.awellhealth.com/awell-extensions/docs/getting-started/contributing-guidelines — your PR should still follow the de facto structure in §5 below.
-- **Required CI check:** `test` job in `.github/workflows/test.yml` (runs `yarn install`, `yarn build`, `yarn test` on Node 22). Lint is NOT enforced by CI but is requested in the root README — run it locally.
+- **Required CI check:** `test` job in `.github/workflows/test.yml` — an aggregate gate that passes only when the `build` job (`yarn build` + `yarn tsc --noEmit -p tsconfig.json`) and all four sharded `test-shard` jobs (`yarn test --shard=<n>/4`) succeed, on Node 22. Gate on `test`, not on the individual shards. A parallel `lint (advisory)` job runs `yarn lint` but does NOT block (45 pre-existing errors on `main`) — still run lint locally.
 - **No signed-commit requirement.** No GPG signing needed.
 - **Branches are deleted on merge** (repo setting).
 - **Deterministic enforcement in place:** the no-version-bump rule in this section is enforced in CI by `.github/workflows/conventions.yml` (which runs `.github/scripts/check-repo-conventions.sh`). The PR-title rule in §3 is enforced by `.github/workflows/pr-title.yml`. Both block the action — they are not prompt-based. Other rules in this file are prompt-based guidance.

--- a/skills/testing-awell-extensions/SKILL.md
+++ b/skills/testing-awell-extensions/SKILL.md
@@ -97,6 +97,7 @@ yarn test-file sendMessageToChannel        # scope by action/file name (regex, m
 yarn test-file extensions/slack/           # scope to a whole extension
 yarn test                                  # ⚠️ ALL 300+ test files + the global field-validation flood — only for a full run
 yarn test-local                            # include *.local.test.ts (hit real APIs)
+yarn compile                               # type-check — Jest no longer does this for you
 ```
 
 > **Footgun — do not append a path to `yarn test`.** The `test` script ends in `--testPathIgnorePatterns`, a greedy array option. `yarn test extensions/slack/foo.test.ts` makes Jest treat `foo.test.ts` as an *ignore* pattern — so it runs **every other** test (300+ files, thousands of lines, and the noisy global `extensions.test.ts` field check) and skips the one you wanted. Always use `yarn test-file <pattern>` (it pins `--testPathPattern`), and never run bare `yarn test` just to check a single extension.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "paths": {
       "@/tests": ["tests"]
     }


### PR DESCRIPTION
## Context

The `test` job takes **~8m20s**. Per-step timings from run [34512505654](https://github.com/awell-health/awell-extensions/actions/runs/34512505654) show it is almost entirely Jest — the usual CI suspects are already solved:

| Step | Time |
|---|---|
| Checkout | 4s |
| Install Node | 5s |
| `yarn` install | 12s (zero-installs already working) |
| `yarn build` | 24s |
| **`yarn test`** | **7m32s — 90% of the job** |

## Root cause

`jest.config.js` uses the plain `ts-jest` preset, so ts-jest **type-checks each of the 361 test files independently, in every worker**, with a cold TS program each time. Individual files were taking 7–9s.

## Changes

- **`tsconfig.json`: `isolatedModules: true`.** ts-jest reads this from the parsed tsconfig (`config-set.js:229`) and switches to its transpile-only path, so no type-checking happens per file. This is the forward-compatible spelling — the `isolatedModules` *transform* option is deprecated for ts-jest v30, and this route emits no deprecation warning. It needs no new dependency, which matters here: `@swc/jest` would drag in `@swc/core`'s per-platform binaries, and zero-installs would need them all vendored into `.yarn/cache`.
- **`tsc --noEmit -p tsconfig.json` in the `build` job.** One shared program instead of 361 isolated ones. This is a **net increase in coverage**: `yarn build` uses `tsconfig.build.json`, which excludes `**/*.test.ts`, so CI has never type-checked test files at all.
- **Tests sharded across 4 parallel jobs.** The repo is public, so standard runners are free and unmetered; a larger runner is billed per-minute even on public repos. Sharding buys the same parallelism for nothing.
- **`concurrency: cancel-in-progress`.** Run history shows superseded commits burning full runs — `feat(metriport): add the metriportAdt ingestion endpoint` ran **4 times**, the transform PDF fix 3 times.
- **`lint (advisory)` job**, running in parallel — see the note below.

## Results

Full suite, locally, matched worker counts:

| | Full suite | Result |
|---|---|---|
| Before | **195s** | 358 suites, 3757 passed, 72 skipped |
| After | **43s** | 358 suites, 3757 passed, 72 skipped — identical |

`tsc --noEmit` over source *and* tests: **12s, clean**. Sharding verified to partition cleanly (90/92/90/89 = 361 files) and lose nothing — shard test counts sum to exactly 3829 / 3757 passed / 72 skipped, matching the unsharded run.

**Measured on this PR's own CI run** ([34604379012](https://github.com/awell-health/awell-extensions/actions/runs/34604379012)) — **8m21s → 76s, a 6.6x speedup**, everything green:

| Job | Time |
|---|---|
| `build` (install + build + type-check) | 57s |
| `test-shard (1..4)` | 41–55s each, in parallel |
| `lint (advisory)` | 1m12s, in parallel |
| `test` (gate) | 4s |
| **Total wall-clock** | **76s** |

## Nothing here can newly block a PR

- The `lint (advisory)` job is deliberately **not** in the `test` gate's `needs`, and its step always exits 0. `yarn lint` has **45 pre-existing errors on `main`** (byte-identical before and after this change — verified by running lint on a clean `main`), so making it blocking would red the pipeline immediately. The findings go to the job summary; the check stays green. I first wired this as `continue-on-error: true`, but that still surfaced a red `lint` check on the PR, and a permanently red check is noise everyone learns to ignore.
- `build` (incl. the new type-check) and all 4 shards are verified green on this branch.
- The gate uses `if: ${{ !cancelled() }}`, not `always()`. The first CI run on this PR caught this: a merge of `main` superseded the run, the concurrency rule cancelled it, and an `always()` gate still executed and reported a spurious failure on an already-cancelled run.
- `test` is kept as a single aggregate gate job so branch protection does not need to name each shard. There are currently **no required status checks** configured on `main` (only tag rulesets), so check names changing breaks nothing.

## Test plan

- [x] `yarn build` passes (15s)
- [x] `yarn test` passes — 195s → 43s, identical results
- [x] `yarn tsc --noEmit -p tsconfig.json` passes, incl. test files (12s)
- [x] All 4 shards pass individually; test counts sum to the unsharded totals
- [x] `yarn lint` output byte-identical to `main` (45 pre-existing errors, unchanged)
- [x] Confirmed on real CI: 76s wall-clock, all checks green (incl. after merging `main`, which added the mailgun tests — suite now 3765 passed)

## Note / follow-up

- Burn down the 45 lint errors, then drop `continue-on-error` and add `lint` to the gate's `needs`. They cluster in a few rules (14 `strict-boolean-expressions`, 9 `no-unnecessary-type-assertion`, 6 `consistent-type-imports`), and 19 are `--fix`-able. Better still, ratchet lint to PR-changed files only — note that `tsconfig.eslint.json` excludes test/mock files, so a naive changed-files lint trips the "file not included in tsconfig" error.
- Pre-existing and untouched: `jest-haste-map: duplicate manual mock found: index` warns on every run (`extensions/medplum/__mocks__/index.ts` vs `extensions/stripe/__mocks__/index.ts`) and prints ~230 lines of stdout noise.
- The 12 `*RealOpenAI.test.ts` files are `describe.skip`'d, so they cost no time — but nothing exercises those LLM paths in CI.

Local dev trade-off: `yarn test` no longer surfaces type errors. `yarn compile` does, and CI gates on it. Documented in `skills/testing-awell-extensions` and `skills/pr-conventions`.
